### PR TITLE
fix aws_mount_efs_on_remote_vm

### DIFF
--- a/modules/bash/storage/fileshare.sh
+++ b/modules/bash/storage/fileshare.sh
@@ -207,6 +207,6 @@ aws_mount_efs_on_remote_vm() {
 
   for cmd in "${cmds[@]}"; do
     echo "Running: $cmd"
-    run_ssh $privatekey_path ubuntu $egress_ip_address "$cmd"
+    run_ssh $privatekey_path ubuntu $egress_ip_address 2222 "$cmd"
   done
 }


### PR DESCRIPTION
[it](https://github.com/Azure/telescope/commit/054ad493f011643e05ca22a9aee0585b22939dab#diff-94ee01d95c0db99890ac4e950b8ae930a49749b3f492110d1a593fc8f1a258c3) introduced 1 additional param for `run_ssh`, we need to fix `aws_mount_efs_on_remote_vm` to accommodate that change.