### PR TITLE
Use apt-get instead of apt for more stability

### DIFF
--- a/scenarios/issue-repro/appgateway-lb-aks-https-502/bash-scripts/client-userdata.sh
+++ b/scenarios/issue-repro/appgateway-lb-aks-https-502/bash-scripts/client-userdata.sh
@@ -2,8 +2,8 @@ sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
 # install java
-sudo apt update
-sudo sudo apt install default-jre -y
+sudo apt-get update
+sudo apt-get install default-jre -y
 java -version
 
 # install jmeter

--- a/scenarios/perf-eval/lb-iperf/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/lb-iperf/bash-scripts/client-userdata.sh
@@ -3,4 +3,4 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y

--- a/scenarios/perf-eval/lb-iperf/bash-scripts/server-userdata.sh
+++ b/scenarios/perf-eval/lb-iperf/bash-scripts/server-userdata.sh
@@ -3,7 +3,7 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y
 
 for i in {0..1}
 do

--- a/scenarios/perf-eval/lb-jmeter/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/lb-jmeter/bash-scripts/client-userdata.sh
@@ -5,8 +5,8 @@ sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
 # install java
-sudo apt update
-sudo sudo apt install default-jre -y
+sudo apt-get update
+sudo apt-get install default-jre -y
 java -version
 
 # install jmeter

--- a/scenarios/perf-eval/lb-jmeter/bash-scripts/server-userdata.sh
+++ b/scenarios/perf-eval/lb-jmeter/bash-scripts/server-userdata.sh
@@ -89,7 +89,7 @@ sudo chmod 644 /etc/ssl/certs/jmeter/*.crt
 sudo chmod 600 /etc/ssl/certs/jmeter/*.key
 
 # install nginx
-sudo apt update && sudo apt install nginx -y
+sudo apt-get update && sudo apt-get install nginx -y
 nginx -v
 
 cat <<EOF > /etc/nginx/sites-available/default

--- a/scenarios/perf-eval/pls-iperf/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/pls-iperf/bash-scripts/client-userdata.sh
@@ -3,4 +3,4 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y

--- a/scenarios/perf-eval/pls-iperf/bash-scripts/server-userdata.sh
+++ b/scenarios/perf-eval/pls-iperf/bash-scripts/server-userdata.sh
@@ -3,7 +3,7 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y
 
 for i in {0..1}
 do

--- a/scenarios/perf-eval/storage-blob/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/storage-blob/bash-scripts/client-userdata.sh
@@ -5,7 +5,7 @@ sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
 # Install fio
-sudo apt-get update && sudo apt install fio -y
+sudo apt-get update && sudo apt-get install fio -y
 fio --version
 
 # install blobfuse2

--- a/scenarios/perf-eval/storage-disk/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/storage-disk/bash-scripts/client-userdata.sh
@@ -5,5 +5,5 @@ sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
 # Install fio
-sudo apt-get update && sudo apt install fio -y
+sudo apt-get update && sudo apt-get install fio -y
 fio --version

--- a/scenarios/perf-eval/storage-fileshare/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/storage-fileshare/bash-scripts/client-userdata.sh
@@ -5,7 +5,7 @@ sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
 # Install fio
-sudo apt-get update && sudo apt install fio -y
+sudo apt-get update && sudo apt-get install fio -y
 fio --version
 
 # install cifs and nfs

--- a/scenarios/perf-eval/vm-diff-zone-iperf/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/vm-diff-zone-iperf/bash-scripts/client-userdata.sh
@@ -3,4 +3,4 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y

--- a/scenarios/perf-eval/vm-diff-zone-iperf/bash-scripts/server-userdata.sh
+++ b/scenarios/perf-eval/vm-diff-zone-iperf/bash-scripts/server-userdata.sh
@@ -3,7 +3,7 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y
 
 nohup iperf --server --port 20001 &> /dev/null &
 nohup iperf --server --udp --port 20002 &> /dev/null &

--- a/scenarios/perf-eval/vm-iperf/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/vm-iperf/bash-scripts/client-userdata.sh
@@ -3,4 +3,4 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y

--- a/scenarios/perf-eval/vm-iperf/bash-scripts/server-userdata.sh
+++ b/scenarios/perf-eval/vm-iperf/bash-scripts/server-userdata.sh
@@ -3,7 +3,7 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y
 
 nohup iperf --server --port 20001 &> /dev/null &
 nohup iperf --server --udp --port 20002 &> /dev/null &

--- a/scenarios/perf-eval/vm-same-zone-iperf/bash-scripts/client-userdata.sh
+++ b/scenarios/perf-eval/vm-same-zone-iperf/bash-scripts/client-userdata.sh
@@ -3,4 +3,4 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y

--- a/scenarios/perf-eval/vm-same-zone-iperf/bash-scripts/server-userdata.sh
+++ b/scenarios/perf-eval/vm-same-zone-iperf/bash-scripts/server-userdata.sh
@@ -3,7 +3,7 @@
 sudo perl -pi -e 's/^#?Port 22$/Port 2222/' /etc/ssh/sshd_config
 sudo service ssh restart
 
-sudo apt-get update && sudo apt install iperf -y
+sudo apt-get update && sudo apt-get install iperf -y
 
 nohup iperf --server --port 20001 &> /dev/null &
 nohup iperf --server --udp --port 20002 &> /dev/null &


### PR DESCRIPTION
The command `apt` is more suitable for daily usage while `apt-get` is better for scripting. Reference [here](https://www.howtogeek.com/791055/apt-vs-apt-get-whats-the-difference-on-linux/#should-i-use-apt-or-apt-get)