### PR TITLE
Allow customization of AWS AMI

### DIFF
--- a/modules/terraform/aws/variables.tf
+++ b/modules/terraform/aws/variables.tf
@@ -115,6 +115,14 @@ variable "vm_config_list" {
     subnet_name                 = string
     security_group_name         = string
     associate_public_ip_address = bool
+
+    ami_config = optional(object({
+      most_recent         = bool
+      name                = string
+      virtualization_type = string
+      architecture        = string
+      owners              = list(string)
+    }))
   }))
   default = []
 }

--- a/modules/terraform/aws/virtual-machine/main.tf
+++ b/modules/terraform/aws/virtual-machine/main.tf
@@ -1,17 +1,22 @@
 data "aws_ami" "ubuntu" {
-  most_recent = true
+  most_recent = var.vm_config.ami_config.most_recent
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["${var.vm_config.ami_config.name}"]
   }
 
   filter {
     name   = "virtualization-type"
-    values = ["hvm"]
+    values = ["${var.vm_config.ami_config.virtualization_type}"]
   }
 
-  owners = ["099720109477"] # Canonical
+  filter {
+    name   = "architecture"
+    values = ["${var.vm_config.ami_config.architecture}"]
+  }
+
+  owners = var.vm_config.ami_config.owners
 }
 
 data "aws_security_group" "security_group" {

--- a/modules/terraform/aws/virtual-machine/variables.tf
+++ b/modules/terraform/aws/virtual-machine/variables.tf
@@ -14,6 +14,20 @@ variable "vm_config" {
       data_disk_iops_read_write = optional(number)
       data_disk_mbps_read_write = optional(number)
     }))
+
+    ami_config = optional(object({
+      most_recent         = bool
+      name                = string
+      virtualization_type = string
+      architecture        = string
+      owners              = list(string)
+      }), {
+      most_recent         = true
+      name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
+      virtualization_type = "hvm"
+      architecture        = "x86_64"
+      owners              = ["099720109477"]
+    })
   })
 }
 


### PR DESCRIPTION
Right now, VM created in AWS always use ubuntu 20.04 so add variable to allow customization of AWS AMI
Example usage:
```
vm_config_list = [{
  vm_name                     = "client-vm"
  role                        = "client"
  subnet_name                 = "client-subnet"
  security_group_name         = "client-sg"
  associate_public_ip_address = true
  zone_suffix                 = "a"
  ami_config = {
    most_recent         = true
    name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
    virtualization_type = "hvm"
    architecture        = "x86_64"
    owners              = ["099720109477"]
  }
}]
```

Manual test: 
- [Ubuntu 22.04](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=87892619&view=logs&j=2a2dba69-e6ae-5482-9462-abd7ab462f0d&t=be57e4db-794e-5fdc-8d7d-1598fb90cbd5)
- [Ubuntu Minimal ARM64](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=87893962&view=logs&j=7b633933-6294-54c6-4d23-6614ccc690c6&t=046531ca-bd2b-522d-b6ee-11245836ba61)
- [Windows Server 2019](https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=87894335&view=logs&j=ed5bb8b1-d67c-5f01-96f7-5350a254f106&t=7b4df893-00ff-5e6a-c9c7-8f597bd7bff8)