### PR TITLE
Add support for creating/deleting VMs

### DIFF
--- a/modules/bash/vm/aws.sh
+++ b/modules/bash/vm/aws.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Description:
+#   This function is used to create an EC2 instance in AWS.
+#
+# Parameters:
+#   - $1: The name of the EC2 instance (e.g. my-vm)
+#   - $2: The size of the EC2 instance (e.g. t2.micro)
+#   - $3: The OS the EC2 instance will use (e.g. ami-0d5d9d301c853a04a)
+#   - $4: The region where the EC2 instance will be created (e.g. us-east-1)
+#   - $5: [optional] The id of the security group to add the EC2 instance to (e.g. security-group-0d5d9d301c853a04a)
+#   - $6: [optional] The id of the subnet the EC2 instance uses (e.g. subnet-0d5d9d301c853a04a)
+#   - $7: [optional] The tags to use (e.g. "ResourceType=instance,Tags=[{Key=owner,Value=azure_devops},{Key=creation_time,Value=2024-03-11T19:12:01Z}]", default value is "ResourceType=instance,Tags=[{Key=owner,Value=azure_devops}]")
+#
+# Notes:
+#   - this commands waits for the EC2 instance's state to be running before returning the instance id
+#   - the instance id is returned if no errors occurred
+#   - you cannot create an EC2 instance by providing both security group and subnet id - if the method is called with both, the security group will take precedence
+#
+# Usage: create_ec2 <name> <size> <os> <region> <security_group> <subnet> [tag_specifications]
+create_ec2() {
+    local instance_name=$1
+    local instance_size=$2
+    local instance_os=$3
+    local region=$4
+    local security_group="${5:-""}"
+    local subnet="${6:-""}"
+    local tag_specifications="${7:-"ResourceType=instance,Tags=[{Key=owner,Value=azure_devops}]"}"
+
+    if [[ -n "$security_group" ]]; then
+        instance_id=$(aws ec2 run-instances --region "$region" --image-id "$instance_os" --instance-type "$instance_size" --security-groups "$security_group" --tag-specifications "$tag_specifications" --output json | jq -r '.Instances[0].InstanceId')
+    elif [[ -n "$subnet" ]]; then
+        instance_id=$(aws ec2 run-instances --region "$region" --image-id "$instance_os" --instance-type "$instance_size" --subnet-id "$subnet" --tag-specifications "$tag_specifications" --output json | jq -r '.Instances[0].InstanceId')
+    fi
+
+    if [[ -n "$instance_id" ]]; then
+        if aws ec2 wait instance-running --region "$region" --instance-ids "$instance_id"; then
+            echo "$instance_id"
+        fi
+    fi
+}
+
+# Description:
+#   This function is used to delete an EC2 instance in AWS.
+#
+# Parameters:
+#   - $1: The id of the EC2 instance (e.g. i-0d5d9d301c853a04a)
+#   - $2: The region where the EC2 instance was created (e.g. us-east-1)
+#
+# Notes:
+#   - this commands waits for the EC2 instance's state to be terminated before returning the instance id
+#   - the instance id is returned if no errors occurred
+#
+# Usage: delete_ec2 <instance_id> <region>
+delete_ec2() {
+    local instance_id=$1
+    local region=$2
+
+    if aws ec2 terminate-instances --region "$region" --instance-ids "$instance_id"; then
+        if aws ec2 wait instance-terminated --region "$region" --instance-ids "$instance_id"; then
+            echo "$instance_id"
+        fi
+    fi
+}
+
+# Description:
+#   This function is used to retrieve a security group by tags
+#
+# Parameters:
+#   - $1: The region where the security group is located (e.g. us-east-1)
+#   - $2: The tags filters to use (e.g. "Name=tag:name,Values=create-delete-vm-sg")
+#
+# Usage: get_security_group_by_tags <region> <tags>
+get_security_group_by_tags() {
+    local region=$1
+    local tags=$2
+
+    aws ec2 describe-security-groups --region "$region" --filters "$tags" --output json | jq -r '.SecurityGroups[0].GroupId'
+}
+
+# Description:
+#   This function is used to retrieve a subnet by tags
+#
+# Parameters:
+#   - $1: The region where the subnet is located (e.g. us-east-1)
+#   - $2: The tags filters to use (e.g. "Name=tag:name,Values=create-delete-vm-subnet")
+#
+# Usage: get_subnet_by_tags <region> <tags>
+get_subnet_by_tags() {
+    local region=$1
+    local tags=$2
+
+    aws ec2 describe-subnets --region "$region" --filters "$tags" --output json | jq -r '.Subnets[0].SubnetId'
+}

--- a/modules/bash/vm/azure.sh
+++ b/modules/bash/vm/azure.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Description:
+#   This function is used to create a VM in Azure.
+#
+# Parameters:
+#   - $1: The name of the VM (e.g. my-vm)
+#   - $2: The size of the VM (e.g. Standard_D2ds_v5)
+#   - $3: The full URN of the OS image the VM will use (e.g. canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest)
+#   - $4: The region where the VM will be created (e.g. us-east-1)
+#   - $5: The resource group to use (e.g. rg-my-vm)
+#   - $6: [optional] The security type to use (e.g. Standard, default value is TrustedLaunch)
+#   - $7: [optional] The storage type to use (e.g. Premium_LRS, default value is Standard_LRS)
+#   - $8: [optional] The tags to use (e.g. "'owner=azure_devops' 'creation_time=2024-03-11T19:12:01Z'", default value is empty)
+#   - $9: [optional] The admin username to use (e.g. my_username, default value is azureuser)
+#   - $10: [optional] The admin password to use (e.g. my_password, default value is Azur3User!FTW)
+#
+# Notes:
+#   - the VM name is returned if no errors occurred
+#
+# Usage: create_vm <vm_name> <vm_size> <vm_os> <region> <resource_group> [security_type] [storage_type] [tags] [admin_username] [admin_password]
+create_vm() {
+    local vm_name=$1
+    local vm_size=$2
+    local vm_os=$3
+    local region=$4
+    local resource_group=$5
+    local security_type="${6:-"TrustedLaunch"}"
+    local storage_type="${7:-"Standard_LRS"}"
+    local tags="${8:-"''"}"
+    local admin_username="${9:-"azureuser"}"
+    local admin_password="${10:-"Azur3User!FTW"}"
+
+    if az vm create --resource-group "$resource_group" --name "$vm_name" --size "$vm_size" --image "$vm_os" --location "$region" --admin-username "$admin_username" --admin-password "$admin_password" --security-type "$security_type" --storage-sku "$storage_type" --output none --tags $tags; then
+        echo "$vm_name"
+    fi
+}
+
+# Description:
+#   This function is used to delete a VM in Azure.
+#
+# Parameters:
+#   - $1: The name of the VM (e.g. my-vm)
+#   - $2: The resource group under which the VM was created (e.g. rg-my-vm)
+#
+# Notes:
+#   - the VM name is returned if no errors occurred
+#
+# Usage: delete_vm <vm_name> <resource_group>
+delete_vm() {
+    local vm_name=$1
+    local resource_group=$2
+
+    if az vm delete --resource-group "$resource_group" --name "$vm_name" --yes --output none; then
+        echo "$vm_name"
+    fi
+}

--- a/modules/bash/vm/gcp.sh
+++ b/modules/bash/vm/gcp.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Description:
+#   This function is used to create a VM in GCP.
+#
+# Parameters:
+#   - $1: The name of the VM (e.g. my-vm)
+#   - $2: The size of the VM (e.g. c3-highcpu-4)
+#   - $3: The OS identifier the VM will use (e.g. projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20240229)
+#   - $4: The region where the VM will be created (e.g. us-east1)
+#   - $5: [optional] The accelerator to use (e.g. count=8,type=nvidia-h100-80gb, default value is empty)
+#   - $6: [optional] The labels to use (e.g. "owner=azure_devops,creation_time=2024-03-11T19:12:01Z", default value is empty)
+#
+# Notes:
+#   - the VM name is returned if no errors occurred
+#
+# Usage: create_vm <vm_name> <vm_size> <vm_os> <region> [accelerator] [labels]
+create_vm() {
+    local vm_name=$1
+    local vm_size=$2
+    local vm_os=$3
+    local region=$4
+    local accelerator="${5:-""}"
+    local labels="${6:-""}"
+
+    if gcloud compute instances create "$vm_name" --zone "$region" --machine-type "$vm_size" --image "$vm_os" --accelerator "$accelerator" --labels=$labels --quiet; then
+        echo "$vm_name"
+    fi
+}
+
+# Description:
+#   This function is used to delete a VM in GCP.
+#
+# Parameters:
+#   - $1: The name of the VM (e.g. c3-highcpu-4)
+#   - $2: The region under which the VM was created (e.g. us-east1)
+#
+# Notes:
+#   - the VM name is returned if no errors occurred
+#
+# Usage: delete_vm <vm_name> <region>
+delete_vm() {
+    local vm_name=$1
+    local region=$2
+
+    if gcloud compute instances delete "$vm_name" --zone "$region" --quiet; then
+        echo "$vm_name"
+    fi
+}

--- a/modules/bash/vm/utils.sh
+++ b/modules/bash/vm/utils.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+
+# Description:
+#   This function is used to generate a VM name
+#
+# Parameters:
+#   - $1: The index of the VM
+#   - $2: The run id
+#
+# Notes:
+#   - the VM name is truncated to 15 characters due to Windows limitations
+#
+# Usage: get_vm_name <index> <run_id>
+get_vm_name() {
+    local i=$1
+    local run_id=$2
+
+    local vm_name="vm-$i-$run_id"
+    vm_name="${vm_name:0:15}"
+    vm_name="${vm_name%-}"
+
+    echo $vm_name
+}
+
+# Description:
+#   This function is used to to measure the time it takes to create and delete a VM and save results in JSON format
+#
+# Parameters:
+#   - $1: The cloud provider (e.g. azure, aws, gcp)
+#   - $2: The name of the VM (e.g. vm-1-1233213123)
+#   - $3: The size of the VM (e.g. c3-highcpu-4)
+#   - $4: The OS identifier the VM will use (e.g. projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20240229)
+#   - $5: The region where the VM will be created (e.g. us-east1)
+#   - $6: The resource group (e.g. my-resource-group)
+#   - $7: The security group (e.g. my-security-group)
+#   - $8: The subnet (e.g. my-subnet)
+#   - $9: [optional] The accelerator to use (e.g. count=8,type=nvidia-h100-80gb, default value is empty)
+#   - $10: The security type (e.g. TrustedLaunch)
+#   - $11: The storage type (e.g. Premium_LRS)
+#   - $12: The result directory where to place the results in JSON format
+#   - $13: The tags to use (e.g. "owner=azure_devops,creation_time=2024-03-11T19:12:01Z")
+#
+# Usage: measure_create_delete_vm <cloud> <vm_name> <vm_size> <vm_os> <region> <resource_group> <security_group> <subnet> <accelerator> <security_type> <storage_type> <result_dir> <tags>
+measure_create_delete_vm() {
+    local cloud=$1
+    local vm_name=$2
+    local vm_size=$3
+    local vm_os=$4
+    local region=$5
+    local resource_group=$6
+    local security_group=$7
+    local subnet=$8
+    local accelerator=$9
+    local security_type=${10}
+    local storage_type=${11}
+    local result_dir=${12}
+    local tags=${13}
+
+    local test_details="{ \
+        \"cloud\": \"$cloud\", \
+        \"name\": \"$vm_name\", \
+        \"size\": \"$vm_size\", \
+        \"os\": \"$vm_os\", \
+        \"region\": \"$region\", \
+        \"accelerator\": \"$accelerator\", \
+        \"security_type\": \"$security_type\", \
+        \"storage_type\": \"$storage_type\""
+    
+    echo "Measuring $cloud VM creation/deletion for with the following details: 
+- VM name: $vm_name
+- VM size: $vm_size
+- VM OS: $vm_os
+- Region: $region
+- Resource group: $resource_group
+- Security group: $security_group
+- Subnet: $subnet
+- Accelerator: $accelerator
+- Security type: $security_type
+- Storage type: $storage_type
+- Tags: $tags"
+    
+    instance_id=$(measure_create_vm "$cloud" "$vm_name" "$vm_size" "$vm_os" "$region" "$resource_group" "$security_group" "$subnet" "$accelerator" "$security_type" "$storage_type" "$result_dir" "$test_details" "$tags")
+
+    if [ -n "$instance_id" ] && [[ "$instance_id" != Error* ]]; then
+        instance_id=$(measure_delete_vm "$cloud" "$instance_id" "$region" "$resource_group" "$result_dir" "$test_details")
+    fi
+}
+
+# Description:
+#   This function is used to to measure the time it takes to create a VM and save results in JSON format
+#
+# Parameters:
+#   - $1: The cloud provider (e.g. azure, aws, gcp)
+#   - $2: The name of the VM (e.g. vm-1-1233213123)
+#   - $3: The size of the VM (e.g. c3-highcpu-4)
+#   - $4: The OS identifier the VM will use (e.g. projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20240229)
+#   - $5: The region where the VM will be created (e.g. us-east1)
+#   - $6: The resource group (e.g. my-resource-group)
+#   - $7: The security group (e.g. my-security-group)
+#   - $8: The subnet (e.g. my-subnet)
+#   - $9: [optional] The accelerator to use (e.g. count=8,type=nvidia-h100-80gb, default value is empty)
+#   - $10: The security type (e.g. TrustedLaunch)
+#   - $11: The storage type (e.g. Premium_LRS)
+#   - $12: The result directory where to place the results in JSON format
+#   - $13: The test details in JSON format
+#   - $14: The tags to use (e.g. "owner=azure_devops,creation_time=2024-03-11T19:12:01Z")
+#
+# Notes:
+#   - the Instance ID is returned if no errors occurred
+#
+# Usage: measure_create_vm <cloud> <vm_name> <vm_size> <vm_os> <region> <resource_group> <security_group> <subnet> <accelerator> <security_type> <storage_type> <result_dir> <test_details>
+measure_create_vm() {
+    local cloud=$1
+    local vm_name=$2
+    local vm_size=$3
+    local vm_os=$4
+    local region=$5
+    local resource_group=$6
+    local security_group=$7
+    local subnet=$8
+    local accelerator=$9
+    local security_type=${10}
+    local storage_type=${11}
+    local result_dir=${12}
+    local test_details=${13}
+    local tags=${14}
+
+    {
+        local start_time=$(date +%s)
+        case $cloud in
+            azure)
+            instance_id=$(create_vm "$vm_name" "$vm_size" "$vm_os" "$region" "$resource_group" "$security_type" "$storage_type" "$tags")
+            ;;
+            aws)
+            instance_id=$(create_ec2 "$vm_name" "$vm_size" "$vm_os" "$region" "$security_group" "$subnet" "$tags")
+            ;;
+            gcp)
+            instance_id=$(create_vm "$vm_name" "$vm_size" "$vm_os" "$region" "$accelerator" "$tags")
+            ;;
+            *)
+            exit 1 # cloud provider unknown
+            ;;
+        esac
+        
+        if [ -n "$instance_id" ] && [[ "$instance_id" != Error* ]]; then
+            wait
+            end_time=$(date +%s)
+            creation_time=$((end_time - start_time))
+            creation_succeeded=true
+        else
+            instance_id=$vm_name
+            creation_time=-1
+            creation_succeeded=false
+        fi
+    } || {
+        instance_id=$vm_name
+        creation_time=-2
+        creation_succeeded=false
+    }
+
+    result="$test_details, \
+        \"vm_id\": \"$instance_id\", \
+        \"operation\": \"create_vm\", \
+        \"time\": \"$creation_time\", \
+        \"succeeded\": \"$creation_succeeded\" \
+    }"
+
+    mkdir -p $result_dir
+    echo $result > "$result_dir/creation-$cloud-$vm_name-$vm_size-$(date +%s).json"
+
+    if [[ "$creation_succeeded" == "true" ]]; then
+        echo "$instance_id"
+    fi
+}
+
+# Description:
+#   This function is used to to measure the time it takes to delete a VM and save results in JSON format
+#
+# Parameters:
+#   - $1: The cloud provider (e.g. azure, aws, gcp)
+#   - $2: The name of the VM (e.g. vm-1-1233213123)
+#   - $3: The region where the VM will be created (e.g. us-east1)
+#   - $4: The resource group (e.g. my-resource-group)
+#   - $5: The result directory where to place the results in JSON format
+#   - $6: The test details in JSON format
+#
+# Notes:
+#   - the Instance ID is returned if no errors occurred
+#
+# Usage: measure_delete_vm <cloud> <vm_name> <region> <resource_group> <result_dir> <test_details>
+measure_delete_vm() {
+    local cloud=$1
+    local vm_name=$2
+    local region=$3
+    local resource_group=$4
+    local result_dir=$5
+    local test_details=$6
+
+    {
+        local start_time=$(date +%s)
+        case $cloud in
+            azure)
+            vm=$(delete_vm "$vm_name" "$resource_group")
+            ;;
+            aws)
+            vm=$(delete_ec2 "$vm_name" "$region")
+            ;;
+            gcp)
+            vm=$(delete_vm "$vm_name" "$region")
+            ;;
+            *)
+            exit 1 # cloud provider unknown
+            ;;
+        esac
+        
+        if [ -n "$vm" ] && [[ "$vm" != *Error* ]]; then
+            wait
+            end_time=$(date +%s)
+            deletion_time=$((end_time - start_time))
+            deletion_succeeded=true
+        else
+            deletion_time=-1
+            deletion_succeeded=false
+        fi
+    } || {
+        deletion_time=-2
+        deletion_succeeded=false
+    }
+
+    result="$test_details, \
+        \"vm_id\": \"$instance_id\", \
+        \"operation\": \"delete_vm\", \
+        \"time\": \"$deletion_time\", \
+        \"succeeded\": \"$deletion_succeeded\" \
+    }"
+
+    mkdir -p $result_dir
+    echo $result > "$result_dir/deletion-$cloud-$vm_name-$vm_size-$(date +%s).json"
+
+    if [[ "$deletion_succeeded" == "true" ]]; then
+        echo "$vm_name"
+    fi
+}

--- a/modules/terraform/aws/variables.tf
+++ b/modules/terraform/aws/variables.tf
@@ -4,8 +4,8 @@ variable "json_input" {
     owner                     = string
     run_id                    = string
     region                    = string
-    machine_type              = string
     public_key_path           = string
+    machine_type              = optional(string)
     user_data_path            = optional(string)
     data_disk_volume_type     = optional(string)
     data_disk_size_gb         = optional(number)

--- a/modules/terraform/aws/virtual-network/main.tf
+++ b/modules/terraform/aws/virtual-network/main.tf
@@ -1,10 +1,10 @@
 locals {
-  ingress_sg_rules_map         = { for idx, rule in var.network_config.sg_rules.ingress : idx => rule }
-  egress_sg_rules_map          = { for idx, rule in var.network_config.sg_rules.egress : idx => rule }
+  ingress_sg_rules_map         = var.network_config.sg_rules == null ? {} : { for idx, rule in var.network_config.sg_rules.ingress : idx => rule }
+  egress_sg_rules_map          = var.network_config.sg_rules == null ? {} : { for idx, rule in var.network_config.sg_rules.egress : idx => rule }
   vpc_name                     = var.network_config.vpc_name
   subnet_map                   = { for subnet in var.network_config.subnet : subnet.name => subnet }
-  route_tables_map             = { for rt in var.network_config.route_tables : rt.name => rt }
-  route_table_associations_map = { for rta in var.network_config.route_table_associations : rta.name => rta }
+  route_tables_map             = var.network_config.route_tables == null ? {} : { for rt in var.network_config.route_tables : rt.name => rt }
+  route_table_associations_map = var.network_config.route_table_associations == null ? {} : { for rta in var.network_config.route_table_associations : rta.name => rta }
 
   security_group_name = var.network_config.security_group_name
   tags                = merge(var.tags, { "role" = var.network_config.role })

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -4,8 +4,8 @@ variable "json_input" {
     owner                            = string
     run_id                           = string
     region                           = string
-    machine_type                     = string
     public_key_path                  = string
+    machine_type                     = optional(string)
     aks_machine_type                 = optional(string)
     accelerated_networking           = optional(bool)
     user_data_path                   = optional(string)

--- a/scenarios/perf-eval/create-delete-vm/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/create-delete-vm/terraform-inputs/aws.tfvars
@@ -1,0 +1,22 @@
+scenario_type  = "perf-eval"
+scenario_name  = "create-delete-vm"
+deletion_delay = "2h"
+network_config_list = [
+  {
+    role                = "network"
+    vpc_name            = "create-delete-vm-vpc"
+    vpc_cidr_block      = "10.2.0.0/16"
+    security_group_name = "create-delete-vm-sg"
+    subnet = [{
+      name        = "create-delete-vm-subnet"
+      cidr_block  = "10.2.1.0/24"
+      zone_suffix = "a"
+    }]
+    route_tables             = []
+    route_table_associations = []
+    sg_rules = {
+      ingress = []
+      egress  = []
+    }
+  }
+]

--- a/scenarios/perf-eval/create-delete-vm/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/create-delete-vm/terraform-inputs/azure.tfvars
@@ -1,0 +1,14 @@
+scenario_type  = "perf-eval"
+scenario_name  = "create-delete-vm"
+deletion_delay = "2h"
+network_config_list = [
+  {
+    role                        = "network"
+    vnet_name                   = "create-delete-vm-vnet"
+    vnet_address_space          = "10.2.0.0/16"
+    network_security_group_name = "create-delete-vm-nsg"
+    subnet                      = []
+    nic_public_ip_associations  = []
+    nsr_rules                   = []
+  }
+]

--- a/scenarios/perf-eval/create-delete-vm/terraform-test-inputs/aws.json
+++ b/scenarios/perf-eval/create-delete-vm/terraform-test-inputs/aws.json
@@ -1,0 +1,6 @@
+{
+  "owner"                            : "terraform_unit_tests",
+  "run_id"                           : "123456789",
+  "region"                           : "us-east-1",
+  "zone"                             : "us-east-1a"
+}

--- a/scenarios/perf-eval/create-delete-vm/terraform-test-inputs/azure.json
+++ b/scenarios/perf-eval/create-delete-vm/terraform-test-inputs/azure.json
@@ -1,0 +1,5 @@
+{
+  "owner"                            : "terraform_unit_tests",
+  "run_id"                           : "123456789",
+  "region"                           : "eastus"
+}


### PR DESCRIPTION
Changes include:
- adding basic commands for create/delete VMs for each of the cloud providers (Azure, AWS and GCP - even if not fully supported); the commands have basic parameters available and can be extended to include more as needed;
- add script with helper functions for measuring the time it takes to create and delete a VM
- update AWS terraform setup to include a default security and VPC