### PR TITLE
Create/delete NIC as part of the create/delete VM scenario

### DIFF
--- a/modules/bash/vm/aws.sh
+++ b/modules/bash/vm/aws.sh
@@ -9,28 +9,28 @@
 #   - $3: The OS the EC2 instance will use (e.g. ami-0d5d9d301c853a04a)
 #   - $4: The region where the EC2 instance will be created (e.g. us-east-1)
 #   - $5: [optional] The id of the security group to add the EC2 instance to (e.g. security-group-0d5d9d301c853a04a)
-#   - $6: [optional] The id of the subnet the EC2 instance uses (e.g. subnet-0d5d9d301c853a04a)
-#   - $7: [optional] The tags to use (e.g. "ResourceType=instance,Tags=[{Key=owner,Value=azure_devops},{Key=creation_time,Value=2024-03-11T19:12:01Z}]", default value is "ResourceType=instance,Tags=[{Key=owner,Value=azure_devops}]")
+#   - $6: [optional] The id of the NIC the EC2 instance uses (e.g. eni-0d5d9d301c853a04a)
+#   - $7: [optional] The id of the subnet the EC2 instance uses (e.g. subnet-0d5d9d301c853a04a)
+#   - $8: [optional] The tags to use (e.g. "ResourceType=instance,Tags=[{Key=owner,Value=azure_devops},{Key=creation_time,Value=2024-03-11T19:12:01Z}]", default value is "ResourceType=instance,Tags=[{Key=owner,Value=azure_devops}]")
 #
 # Notes:
 #   - this commands waits for the EC2 instance's state to be running before returning the instance id
 #   - the instance id is returned if no errors occurred
-#   - you cannot create an EC2 instance by providing both security group and subnet id - if the method is called with both, the security group will take precedence
 #
-# Usage: create_ec2 <name> <size> <os> <region> <security_group> <subnet> [tag_specifications]
+# Usage: create_ec2 <name> <size> <os> <region> <subnet> [tag_specifications]
 create_ec2() {
     local instance_name=$1
     local instance_size=$2
     local instance_os=$3
     local region=$4
-    local security_group="${5:-""}"
+    local nic="${5:-""}"
     local subnet="${6:-""}"
     local tag_specifications="${7:-"ResourceType=instance,Tags=[{Key=owner,Value=azure_devops}]"}"
 
-    if [[ -n "$security_group" ]]; then
-        instance_id=$(aws ec2 run-instances --region "$region" --image-id "$instance_os" --instance-type "$instance_size" --security-groups "$security_group" --tag-specifications "$tag_specifications" --output json | jq -r '.Instances[0].InstanceId')
-    elif [[ -n "$subnet" ]]; then
-        instance_id=$(aws ec2 run-instances --region "$region" --image-id "$instance_os" --instance-type "$instance_size" --subnet-id "$subnet" --tag-specifications "$tag_specifications" --output json | jq -r '.Instances[0].InstanceId')
+    if [[ -n "$nic" ]]; then
+        instance_id=$(aws ec2 run-instances --region "$region" --image-id "$instance_os" --instance-type "$instance_size" --network-interfaces "[{\"NetworkInterfaceId\": \"$nic\", \"DeviceIndex\": 0}]" --tag-specifications "$tag_specifications" --output text --query 'Instances[0].InstanceId')
+    else
+        instance_id=$(aws ec2 run-instances --region "$region" --image-id "$instance_os" --instance-type "$instance_size" --subnet-id "$subnet" --tag-specifications "$tag_specifications" --output text --query 'Instances[0].InstanceId')
     fi
 
     if [[ -n "$instance_id" ]]; then
@@ -64,31 +64,90 @@ delete_ec2() {
 }
 
 # Description:
-#   This function is used to retrieve a security group by tags
+#   This function is used to create a NIC in AWS.
 #
 # Parameters:
-#   - $1: The region where the security group is located (e.g. us-east-1)
-#   - $2: The tags filters to use (e.g. "Name=tag:name,Values=create-delete-vm-sg")
+#   - $1: The name of the NIC (e.g. nic_my-vm)
+#   - $2: The id of the subnet the network interface uses (e.g. subnet-0d5d9d301c853a04a)
+#   - $3: The id of the security group to add the network interface to (e.g. security-group-0d5d9d301c853a04a)
+#   - $4: [optional] The tags to use (e.g. "ResourceType=network-interface,Tags=[{Key=owner,Value=azure_devops},{Key=creation_time,Value=2024-03-11T19:12:01Z}]", default value is "ResourceType=instance,Tags=[{Key=owner,Value=azure_devops}]")
 #
-# Usage: get_security_group_by_tags <region> <tags>
-get_security_group_by_tags() {
-    local region=$1
-    local tags=$2
+# Notes:
+#   - the NIC id is returned if no errors occurred
+#
+# Usage: create_nic <nic_name> <subnet> <security_group> [tag_specifications]
+create_nic() {
+    local nic_name=$1
+    local subnet=$2
+    local security_group=$3
+    local tag_specifications="${4:-"ResourceType=network-interface,Tags=[{Key=owner,Value=azure_devops}]"}"
 
-    aws ec2 describe-security-groups --region "$region" --filters "$tags" --output json | jq -r '.SecurityGroups[0].GroupId'
+    nic_id=$(aws ec2 create-network-interface --description "$nic_name" --subnet-id "$subnet" --groups "$security_group" --tag-specifications "$tag_specifications" --output text --query 'NetworkInterface.NetworkInterfaceId')
+
+    if [[ -n "$nic_id" ]]; then
+        echo "$nic_id"
+    fi
 }
 
 # Description:
-#   This function is used to retrieve a subnet by tags
+#   This function is used to delete a NIC in AWS.
+#
+# Parameters:
+#   - $1: The id of the NIC (e.g. eni-0d5d9d301c853a04a)
+#
+# Notes:
+#   - the NIC id is returned if no errors occurred
+#
+# Usage: delete_nic <nic_id>
+delete_nic() {
+    local nic_id=$1
+
+    if aws ec2 delete-network-interface --network-interface-id "$nic_id"; then
+        echo "$nic_id"
+    fi
+}
+
+# Description:
+#   This function is used to retrieve a security group by filters
+#
+# Parameters:
+#   - $1: The region where the security group is located (e.g. us-east-1)
+#   - $2: The filters to use (e.g. "Name=tag:name,Values=create-delete-vm-sg")
+#
+# Usage: get_security_group_by_filters <region> <filters>
+get_security_group_by_filters() {
+    local region=$1
+    local filters=$2
+
+    aws ec2 describe-security-groups --region "$region" --filters $filters --output text --query 'SecurityGroups[0].GroupId'
+}
+
+# Description:
+#   This function is used to retrieve a subnet by filters
 #
 # Parameters:
 #   - $1: The region where the subnet is located (e.g. us-east-1)
-#   - $2: The tags filters to use (e.g. "Name=tag:name,Values=create-delete-vm-subnet")
+#   - $2: The filters to use (e.g. "Name=tag:name,Values=create-delete-vm-subnet")
 #
-# Usage: get_subnet_by_tags <region> <tags>
-get_subnet_by_tags() {
+# Usage: get_subnet_by_filters <region> <filters>
+get_subnet_by_filters() {
     local region=$1
-    local tags=$2
+    local filters=$2
 
-    aws ec2 describe-subnets --region "$region" --filters "$tags" --output json | jq -r '.Subnets[0].SubnetId'
+    aws ec2 describe-subnets --region "$region" --filters $filters --output text --query 'Subnets[0].SubnetId'
+}
+
+# Description:
+#   This function is used to retrieve a network interface by filters
+#
+# Parameters:
+#   - $1: The region where the network interface is located (e.g. us-east-1)
+#   - $2: The filters to use (e.g. "Name=tag:name,Values=create-delete-vm-network-interface")
+#
+# Usage: get_nic_by_filters <region> <filters>
+get_nic_by_filters() {
+    local region=$1
+    local filters=$2
+
+    aws ec2 describe-network-interfaces --region "$region" --filters $filters --output text --query 'NetworkInterfaces[0].NetworkInterfaceId'
 }

--- a/modules/bash/vm/azure.sh
+++ b/modules/bash/vm/azure.sh
@@ -9,30 +9,38 @@
 #   - $3: The full URN of the OS image the VM will use (e.g. canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest)
 #   - $4: The region where the VM will be created (e.g. us-east-1)
 #   - $5: The resource group to use (e.g. rg-my-vm)
-#   - $6: [optional] The security type to use (e.g. Standard, default value is TrustedLaunch)
-#   - $7: [optional] The storage type to use (e.g. Premium_LRS, default value is Standard_LRS)
-#   - $8: [optional] The tags to use (e.g. "'owner=azure_devops' 'creation_time=2024-03-11T19:12:01Z'", default value is empty)
-#   - $9: [optional] The admin username to use (e.g. my_username, default value is azureuser)
-#   - $10: [optional] The admin password to use (e.g. my_password, default value is Azur3User!FTW)
+#   - $6: The NIC(s) to use (e.g. my-nic)
+#   - $7: [optional] The security type to use (e.g. Standard, default value is TrustedLaunch)
+#   - $8: [optional] The storage type to use (e.g. Premium_LRS, default value is Standard_LRS)
+#   - $9: [optional] The tags to use (e.g. "'owner=azure_devops' 'creation_time=2024-03-11T19:12:01Z'", default value is empty)
+#   - $10: [optional] The admin username to use (e.g. my_username, default value is azureuser)
+#   - $11: [optional] The admin password to use (e.g. my_password, default value is Azur3User!FTW)
 #
 # Notes:
 #   - the VM name is returned if no errors occurred
 #
-# Usage: create_vm <vm_name> <vm_size> <vm_os> <region> <resource_group> [security_type] [storage_type] [tags] [admin_username] [admin_password]
+# Usage: create_vm <vm_name> <vm_size> <vm_os> <region> <resource_group> <nics> [security_type] [storage_type] [tags] [admin_username] [admin_password]
 create_vm() {
     local vm_name=$1
     local vm_size=$2
     local vm_os=$3
     local region=$4
     local resource_group=$5
-    local security_type="${6:-"TrustedLaunch"}"
-    local storage_type="${7:-"Standard_LRS"}"
-    local tags="${8:-"''"}"
-    local admin_username="${9:-"azureuser"}"
-    local admin_password="${10:-"Azur3User!FTW"}"
+    local nics=$6
+    local security_type="${7:-"TrustedLaunch"}"
+    local storage_type="${8:-"Standard_LRS"}"
+    local tags="${9:-"''"}"
+    local admin_username="${10:-"azureuser"}"
+    local admin_password="${11:-"Azur3User!FTW"}"
 
-    if az vm create --resource-group "$resource_group" --name "$vm_name" --size "$vm_size" --image "$vm_os" --location "$region" --admin-username "$admin_username" --admin-password "$admin_password" --security-type "$security_type" --storage-sku "$storage_type" --output none --tags $tags; then
-        echo "$vm_name"
+    if [[ -n "$nic" ]]; then
+        if az vm create --resource-group "$resource_group" --name "$vm_name" --size "$vm_size" --image "$vm_os" --nics "$nics" --location "$region" --admin-username "$admin_username" --admin-password "$admin_password" --security-type "$security_type" --storage-sku "$storage_type" --nic-delete-option delete --os-disk-delete-option delete --output none --tags $tags; then
+            echo "$vm_name"
+        fi
+    else
+        if az vm create --resource-group "$resource_group" --name "$vm_name" --size "$vm_size" --image "$vm_os" --location "$region" --admin-username "$admin_username" --admin-password "$admin_password" --security-type "$security_type" --storage-sku "$storage_type" --nic-delete-option delete --os-disk-delete-option delete --output none --tags $tags; then
+            echo "$vm_name"
+        fi
     fi
 }
 
@@ -51,7 +59,55 @@ delete_vm() {
     local vm_name=$1
     local resource_group=$2
 
-    if az vm delete --resource-group "$resource_group" --name "$vm_name" --yes --output none; then
+    if az vm delete --resource-group "$resource_group" --name "$vm_name" --force-deletion true --yes --output none; then
         echo "$vm_name"
+    fi
+}
+
+# Description:
+#   This function is used to create a NIC in Azure.
+#
+# Parameters:
+#   - $1: The name of the NIC (e.g. nic_my-vm)
+#   - $2: The resource group under which the VM was created (e.g. rg-my-vm)
+#   - $3: [optional] The name of the VNet to use (e.g. my-vnet, default value is vnet_<nic_name>)
+#   - $4: [optional] The name of the subnet to use (e.g. my-subnet, default value is subnet_<nic_name>)
+#   - $5: [optional] Whether to use accelerated networking (e.g. true, default value is true)
+#   - $6: [optional] The tags to use (e.g. "'owner=azure_devops' 'creation_time=2024-03-11T19:12:01Z'", default value is empty)
+#
+# Notes:
+#   - the NIC name is returned if no errors occurred
+#
+# Usage: create_nic <nic_name> <resource_group> [vnet] [subnet] [accelerated_networking] [tags]
+create_nic() {
+    local nic_name=$1
+    local resource_group=$2
+    local vnet="${3:-"vnet_$nic_name"}"
+    local subnet="${4:-"subnet_$nic_name"}"
+    local accelerated_networking="${5:-"true"}"
+    local tags="${6:-"''"}"
+
+    if az network nic create --resource-group "$resource_group" --name "$nic_name" --vnet-name "$vnet" --subnet "$subnet" --accelerated-networking "$accelerated_networking" --tags $tags --output none; then
+        echo "$nic_name"
+    fi
+}
+
+# Description:
+#   This function is used to delete a NIC in Azure.
+#
+# Parameters:
+#   - $1: The name of the NIC (e.g. nic_my-vm)
+#   - $2: The resource group under which the VM was created (e.g. rg-my-vm)
+#
+# Notes:
+#   - the NIC name is returned if no errors occurred
+#
+# Usage: delete_nic <nic_name> <resource_group>
+delete_nic() {
+    local nic_name=$1
+    local resource_group=$2
+
+    if az network nic delete --resource-group "$resource_group" --name "$nic_name" --output none; then
+        echo "$nic_name"
     fi
 }

--- a/modules/bash/vm/gcp.sh
+++ b/modules/bash/vm/gcp.sh
@@ -8,8 +8,9 @@
 #   - $2: The size of the VM (e.g. c3-highcpu-4)
 #   - $3: The OS identifier the VM will use (e.g. projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20240229)
 #   - $4: The region where the VM will be created (e.g. us-east1)
-#   - $5: [optional] The accelerator to use (e.g. count=8,type=nvidia-h100-80gb, default value is empty)
-#   - $6: [optional] The labels to use (e.g. "owner=azure_devops,creation_time=2024-03-11T19:12:01Z", default value is empty)
+#   - $5: The instance template to be used (e.g. my-instance-template)
+#   - $6: [optional] The accelerator to use (e.g. count=8,type=nvidia-h100-80gb, default value is empty)
+#   - $7: [optional] The labels to use (e.g. "owner=azure_devops,creation_time=2024-03-11T19:12:01Z", default value is empty)
 #
 # Notes:
 #   - the VM name is returned if no errors occurred
@@ -20,10 +21,11 @@ create_vm() {
     local vm_size=$2
     local vm_os=$3
     local region=$4
-    local accelerator="${5:-""}"
-    local labels="${6:-""}"
+    local instance_template=$5}
+    local accelerator="${6:-""}"
+    local labels="${7:-""}"
 
-    if gcloud compute instances create "$vm_name" --zone "$region" --machine-type "$vm_size" --image "$vm_os" --accelerator "$accelerator" --labels=$labels --quiet; then
+    if gcloud compute instances create "$vm_name" --zone "$region" --machine-type "$vm_size" --image "$vm_os" --source-instance-template "$instance_template" --accelerator "$accelerator" --labels=$labels --quiet; then
         echo "$vm_name"
     fi
 }
@@ -47,3 +49,48 @@ delete_vm() {
         echo "$vm_name"
     fi
 }
+
+# Description:
+#   This function is used to create an instance template with a NIC in GCP.
+#
+# Parameters:
+#   - $1: The name of the template (e.g. my-instance-template)
+#   - $2: The region where the instance template will be created (e.g. us-east1)
+#   - $3: [optional] The name of the subnet to use (e.g. my-subnet, default value is subnet_<nic_name>)
+#   - $6: [optional] The labels to use (e.g. "owner=azure_devops,creation_time=2024-03-11T19:12:01Z", default value is empty)
+#
+# Notes:
+#   - the instance template name is returned if no errors occurred
+#
+# Usage: create_nic_instance_template <template_name> <region> [subnet] [labels]
+create_nic_instance_template() {
+    local template_name=$1
+    local region=$2
+    local subnet="${3:-"subnet_$template_name"}"
+    local labels="${4:-""}"
+
+    if gcloud compute instance-templates create "$template_name" --network-interface "subnet=$subnet" --instance-template-region "$region" --labels=$labels --quiet; then
+        echo "$template_name"
+    fi
+}
+
+# Description:
+#   This function is used to delete an instance template with a NIC in GCP.
+#
+# Parameters:
+#   - $1: The name of the template (e.g. my-instance-template)
+#   - $2: The region under which the instance template was created (e.g. us-east1)
+#
+# Notes:
+#   - the instance template name is returned if no errors occurred
+#
+# Usage: delete_nic_instance_template <template_name> <region>
+delete_nic_instance_template() {
+    local template_name=$1
+    local region=$2
+
+    if gcloud compute instance-templates delete "$template_name" --region "$region" --quiet; then
+        echo "$template_name"
+    fi
+}
+

--- a/scenarios/perf-eval/create-delete-vm/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/create-delete-vm/terraform-inputs/azure.tfvars
@@ -7,8 +7,11 @@ network_config_list = [
     vnet_name                   = "create-delete-vm-vnet"
     vnet_address_space          = "10.2.0.0/16"
     network_security_group_name = "create-delete-vm-nsg"
-    subnet                      = []
-    nic_public_ip_associations  = []
-    nsr_rules                   = []
+    subnet = [{
+      name           = "create-delete-vm-subnet"
+      address_prefix = "10.2.1.0/24"
+    }]
+    nic_public_ip_associations = []
+    nsr_rules                  = []
   }
 ]


### PR DESCRIPTION
Since we have a dynamic number of VMs that we create and delete in a scenario, we are doing the NIC creation and deletion as part of the bash scripts. We may want to update the interface in the future to support this from terraform.

The commit adds function to create and delete a NIC, updates the measure VM creation/deletion utils to handle NIC creation/deletion as well and updates the terraform template.