### PR TITLE
Make sure we don't leave dangling NICs

### DIFF
--- a/modules/bash/vm/utils.sh
+++ b/modules/bash/vm/utils.sh
@@ -19,7 +19,80 @@ get_vm_name() {
     vm_name="${vm_name:0:15}"
     vm_name="${vm_name%-}"
 
-    echo $vm_name
+    echo "$vm_name"
+}
+
+# Description:
+#   This function is used to pre-create a NIC if needed
+#
+# Parameters:
+#   - $1: The cloud provider (e.g. azure, aws, gcp)
+#   - $2: The name of the VM (e.g. vm-1-1233213123)
+#   - $3: The run id
+#   - $4: The region where the VM will be created (e.g. us-east1)
+#   - $5: The security group (e.g. my-security-group)
+#   - $6: The subnet (e.g. my-subnet)
+#   - $7: The tags to use (e.g. "owner=azure_devops,creation_time=2024-03-11T19:12:01Z")
+#   - $8: Whether to pre-create the NIC or let it be part of the VM creation/deletion measurement (e.g. true)
+#
+# Notes:
+#   - the NIC name is returned if no errors occurred
+#
+# Usage: precreate_nic_if_needed <cloud> <vm_name> <run_id> <region> <security_group> <subnet> <tags> <precreate_nic>
+precreate_nic_if_needed()
+{
+    local cloud=$1
+    local vm_name=$2
+    local run_id=$3
+    local region=$4
+    local security_group=$5
+    local subnet=$6
+    local tags=$7
+    local precreate_nic=$8
+
+    local nic=""
+    if [[ "$precreate_nic" == "true" ]]; then
+        # we will use defaults here to not clobber the method signature, but we may want to parameterize these in the future
+        local nic_name="nic_$vm_name"
+
+        case $cloud in
+            azure)
+                local vnet="create-delete-vm-vnet"
+                subnet="create-delete-vm-subnet"
+                local accelerated_networking=true
+                nic=$(create_nic "$nic_name" "$run_id" "$vnet" "$subnet" "$accelerated_networking" "$tags")
+            ;;
+            aws)
+                local nic_tags="${tags/ResourceType=instance/ResourceType=network-interface}"
+                nic=$(create_nic "$nic_name" "$subnet" "$security_group" "$nic_tags")
+            ;;
+            gcp)
+                nic=$(create_nic_instance_template "it_$nic_name" "$region" "$subnet" "$tags")
+            ;;
+            *)
+                exit 1 # cloud provider unknown
+            ;;
+        esac
+    fi
+
+    echo "$nic"
+}
+
+# Description:
+#   This function is used to delete a NIC if needed
+#
+# Parameters:
+#   - $1: The cloud provider (e.g. azure, aws, gcp)
+#   - $2: The NIC name
+#
+# Usage: delete_nic_if_needed <cloud> <nic_name>
+delete_nic_if_needed() {
+    local cloud=$1
+    local nic_name=$2
+
+    if [[ -n "$nic_name" ]] && [[ "$cloud" == "aws" ]]; then
+        delete_nic "$nic_name"
+    fi
 }
 
 # Description:
@@ -81,12 +154,16 @@ measure_create_delete_vm() {
 - Security type: $security_type
 - Storage type: $storage_type
 - Tags: $tags"
+
+    nic=$(precreate_nic_if_needed "$cloud" "$vm_name" "$run_id" "$region" "$security_group" "$subnet" "$tags" "$precreate_nic")
     
-    vm_id=$(measure_create_vm "$cloud" "$vm_name" "$vm_size" "$vm_os" "$region" "$precreate_nic" "$run_id" "$security_group" "$subnet" "$accelerator" "$security_type" "$storage_type" "$result_dir" "$test_details" "$tags")
+    vm_id=$(measure_create_vm "$cloud" "$vm_name" "$vm_size" "$vm_os" "$region" "$nic" "$run_id" "$security_group" "$subnet" "$accelerator" "$security_type" "$storage_type" "$result_dir" "$test_details" "$tags")
 
     if [ -n "$vm_id" ] && [[ "$vm_id" != Error* ]]; then
-        vm_id=$(measure_delete_vm "$cloud" "$vm_id" "$region" "$precreate_nic" "$run_id" "$result_dir" "$test_details")
+        vm_id=$(measure_delete_vm "$cloud" "$vm_id" "$region" "$run_id" "$result_dir" "$test_details")
     fi
+
+    delete_nic=$(delete_nic_if_needed "$cloud" "$nic")
 }
 
 # Description:
@@ -98,7 +175,7 @@ measure_create_delete_vm() {
 #   - $3: The size of the VM (e.g. c3-highcpu-4)
 #   - $4: The OS identifier the VM will use (e.g. projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20240229)
 #   - $5: The region where the VM will be created (e.g. us-east1)
-#   - $6: Whether to pre-create the NIC or let it be part of the VM creation/deletion measurement (e.g. true)
+#   - $6: Optional NIC to be used for VM creation/deletion measurement
 #   - $7: The run id
 #   - $8: The security group (e.g. my-security-group)
 #   - $9: The subnet (e.g. my-subnet)
@@ -112,14 +189,14 @@ measure_create_delete_vm() {
 # Notes:
 #   - the VM ID is returned if no errors occurred
 #
-# Usage: measure_create_vm <cloud> <vm_name> <vm_size> <vm_os> <region> <precreate_nic> <run_id> <security_group> <subnet> <accelerator> <security_type> <storage_type> <result_dir> <test_details> <tags>
+# Usage: measure_create_vm <cloud> <vm_name> <vm_size> <vm_os> <region> <nic> <run_id> <security_group> <subnet> <accelerator> <security_type> <storage_type> <result_dir> <test_details> <tags>
 measure_create_vm() {
     local cloud=$1
     local vm_name=$2
     local vm_size=$3
     local vm_os=$4
     local region=$5
-    local precreate_nic=$6
+    local nic=$6
     local run_id=$7
     local security_group=$8
     local subnet=$9
@@ -134,30 +211,6 @@ measure_create_vm() {
     local creation_time=-1
     local vm_id="$vm_name"
     local output_vm_data="{ \"vm_data\": {}}"
-
-    local nic=""
-    if [[ "$precreate_nic" == "true" ]]; then
-        # we will use defaults here to not clobber the method signature, but we may want to parameterize these in the future
-        local nic_name="nic_$vm_name"
-        case $cloud in
-            azure)
-                local vnet="create-delete-vm-vnet"
-                subnet="create-delete-vm-subnet"
-                local accelerated_networking=true
-                nic=$(create_nic "$nic_name" "$run_id" "$vnet" "$subnet" "$accelerated_networking" "$tags")
-            ;;
-            aws)
-                local nic_tags="${tags/ResourceType=instance/ResourceType=network-interface}"
-                nic=$(create_nic "$nic_name" "$subnet" "$security_group" "$nic_tags")
-            ;;
-            gcp)
-                nic=$(create_nic_instance_template "it_$nic_name" "$region" "$subnet" "$tags")
-            ;;
-            *)
-                exit 1 # cloud provider unknown
-            ;;
-        esac
-    fi
 
     local start_time=$(date +%s)
     case $cloud in
@@ -218,31 +271,25 @@ measure_create_vm() {
 #   - $1: The cloud provider (e.g. azure, aws, gcp)
 #   - $2: The name of the VM (e.g. vm-1-1233213123)
 #   - $3: The region where the VM will be created (e.g. us-east1)
-#   - $4: Whether there was a pre-created NIC that needs to be removed or let it be part of the VM creation/deletion measurement (e.g. true)
-#   - $5: The run id
-#   - $6: The result directory where to place the results in JSON format
-#   - $7: The test details in JSON format
+#   - $4: The run id
+#   - $5: The result directory where to place the results in JSON format
+#   - $6: The test details in JSON format
 #
 # Notes:
 #   - the VM ID is returned if no errors occurred
 #
-# Usage: measure_delete_vm <cloud> <vm_name> <region> <precreate_nic> <run_id> <result_dir> <test_details>
+# Usage: measure_delete_vm <cloud> <vm_name> <region> <run_id> <result_dir> <test_details>
 measure_delete_vm() {
     local cloud=$1
     local vm_name=$2
     local region=$3
-    local precreate_nic=$4
-    local run_id=$5
-    local result_dir=$6
-    local test_details=$7
+    local run_id=$4
+    local result_dir=$5
+    local test_details=$6
     
     local deletion_succeeded=false
     local deletion_time=-1
     local output_vm_data="{ \"vm_data\": {}}"
-
-    if [[ "$precreate_nic" == "true" ]] && [[ "$cloud" == "aws" ]]; then
-        nic=$(aws ec2 describe-instances --instance-ids "$vm_name" --output text --query 'Reservations[0].Instances[0].NetworkInterfaces[0].NetworkInterfaceId')
-    fi
 
     local start_time=$(date +%s)
     case $cloud in
@@ -275,10 +322,6 @@ measure_delete_vm() {
                 output_vm_data=$temporary_vm_data
             fi
         fi
-    fi
-    
-    if [[ "$precreate_nic" == "true" ]] && [[ "$cloud" == "aws" ]]; then
-        deleted_nic=$(delete_nic "$nic")
     fi
 
     result="$test_details, \


### PR DESCRIPTION
For the case of precreating NICs, we would leave orphaned NICs if an error occurred in the VM creation process, because we would never call the VM routine. This commit addresses that by moving the NIC precreation and deletion outside of the create/delete routine.

Run with precreate: https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=90402219
Run without precreate: https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=90403678

Previous run: https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=90398007 (notice the AWS terraform destroy step)