### PR TITLE
Add fio metadata tests for fileshares on multiple pods 

### DIFF
--- a/modules/bash/aws.sh
+++ b/modules/bash/aws.sh
@@ -191,3 +191,28 @@ aws_eks_deploy_fio()
   kubectl apply -f "${file_source}/pvc.yml"
   kubectl apply -f "${file_source}/fio.yml"
 }
+
+aws_eks_deploy_fio_fileshare()
+{
+  local region=$1
+  local eksName=$2
+  local scenario_type=$3
+  local scenario_name=$4
+  local fileSystemId=$5
+  local replica_count=$6
+
+  aws eks update-kubeconfig --region $region --name $eksName
+  local file_source=./scenarios/${scenario_type}/${scenario_name}/yml-files/aws
+
+  delete_time=$(date -ud '+2 hour' +'%FT%TZ')
+  deletion_tag="deletion_due_time=${delete_time}"
+
+  sed -i "s/\(fileSystemId: \).*/\1$fileSystemId/" "${file_source}/storage-class.yml"
+  sed -i "s/\(tagSpecification_1: \).*/\1\"$deletion_tag\"/" "${file_source}/storage-class.yml"
+  kubectl apply -f "${file_source}/storage-class.yml"
+
+  sed -i "s/\(replicas: \).*/\1$replica_count/" "${file_source}/fio.yml"
+  
+  kubectl apply -f "${file_source}/pvc.yml"
+  kubectl apply -f "${file_source}/fio.yml"
+}

--- a/modules/bash/storage/fileshare.sh
+++ b/modules/bash/storage/fileshare.sh
@@ -148,6 +148,14 @@ aws_get_1st_subnet_id_by_tag() {
   echo $subnet_id
 }
 
+aws_get_subnet_ids_by_tag() {
+  local tag_key=$1
+  local tag_value=$2
+
+  subnet_ids=$(aws ec2 describe-subnets --query "Subnets[?Tags[?Key=='$tag_key' && Value=='$tag_value']].SubnetId" --output text)
+  echo $subnet_ids
+}
+
 aws_get_1st_security_group_id_by_tag() {
   local tag_key=$1
   local tag_value=$2

--- a/scenarios/perf-eval/k8s-fileshare/docker/Dockerfile
+++ b/scenarios/perf-eval/k8s-fileshare/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y libaio1
+
+WORKDIR /app
+
+COPY fio /app
+ENV PATH="/app:${PATH}"

--- a/scenarios/perf-eval/k8s-fileshare/docker/README.md
+++ b/scenarios/perf-eval/k8s-fileshare/docker/README.md
@@ -1,0 +1,25 @@
+# Creating and publishing FIO image
+
+## Building the package
+The fio package used uses the source code which is a private fork from the public repository which can be found [here](https://msazure.visualstudio.com/One/_git/Storage-storagetests-OSS-fio). This also has a nuget package published to the feed [here](https://msazure.visualstudio.com/One/_artifacts/feed/Storage-XPerfInfra/NuGet/Fio_Linux/overview/3.18.0.19). To build the docker image, we need to download the nuget package and copy the binary to the docker image.
+
+To download the nuget package, the directory contains the `nuget.config` and `packages.config` file.
+Run:
+```
+nuget restore ./packages.config
+```
+
+Make sure the dockerfile points to the correct path of the fio executable in the COPY command.
+Build the docker image by running:
+```
+docker buildx build -t telescope.azurecr.io/perf-eval/fio:1.0.0 .
+```
+
+## Publishing the package
+
+Use docker push command to push to the telescope container registry:
+```
+docker push telescope.azurecr.io/perf-eval/fio:<version>
+```
+
+Once pushed, update the version to be used in the deployment files (fio.yml)

--- a/scenarios/perf-eval/k8s-fileshare/docker/nuget.config
+++ b/scenarios/perf-eval/k8s-fileshare/docker/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Storage-XPerfInfra" value="https://msazure.pkgs.visualstudio.com/One/_packaging/Storage-XPerfInfra/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/scenarios/perf-eval/k8s-fileshare/docker/packages.config
+++ b/scenarios/perf-eval/k8s-fileshare/docker/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Fio_Linux" version="3.18.0.19" />
+</packages>

--- a/scenarios/perf-eval/k8s-fileshare/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/k8s-fileshare/terraform-inputs/aws.tfvars
@@ -1,0 +1,107 @@
+scenario_type   = "perf-eval"
+scenario_name   = "k8s-fileshare"
+deletion_delay  = "2h"
+efs_name_prefix = "k8s-efs"
+network_config_list = [
+  {
+    role           = "client"
+    vpc_name       = "client-vpc"
+    vpc_cidr_block = "10.0.0.0/16"
+    subnet = [
+      {
+        name                    = "client-subnet"
+        cidr_block              = "10.0.0.0/24"
+        zone_suffix             = "a"
+        map_public_ip_on_launch = true
+      },
+      {
+        name                    = "client-subnet-2"
+        cidr_block              = "10.0.1.0/24"
+        zone_suffix             = "b"
+        map_public_ip_on_launch = true
+      }
+    ]
+    security_group_name = "client-sg"
+    route_tables = [
+      {
+        name       = "internet-rt"
+        cidr_block = "0.0.0.0/0"
+      }
+    ],
+    route_table_associations = [
+      {
+        name             = "client-subnet-rt-assoc"
+        subnet_name      = "client-subnet"
+        route_table_name = "internet-rt"
+      },
+      {
+        name             = "client-subnet-rt-assoc-2"
+        subnet_name      = "client-subnet-2"
+        route_table_name = "internet-rt"
+      }
+    ]
+    sg_rules = {
+      ingress = [
+        {
+          from_port  = 2049
+          to_port    = 2049
+          protocol   = "tcp"
+          cidr_block = "0.0.0.0/0"
+        }
+      ]
+      egress = [
+        {
+          from_port  = 0
+          to_port    = 0
+          protocol   = "-1"
+          cidr_block = "0.0.0.0/0"
+        }
+      ]
+    }
+  }
+]
+
+vm_config_list           = []
+loadbalancer_config_list = []
+
+eks_config_list = [{
+  role        = "client"
+  eks_name    = "files-eks"
+  vpc_name    = "client-vpc"
+  policy_arns = ["AmazonEKSClusterPolicy", "AmazonEKSVPCResourceController", "AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly"]
+  eks_managed_node_groups = [
+    {
+      name           = "node-group-1"
+      ami_type       = "AL2_x86_64"
+      instance_types = ["m5.4xlarge"]
+      min_size       = 2
+      max_size       = 2
+      desired_size   = 2
+      labels         = { terraform = "true", k8s = "true", role = "perf-eval", nodepool = "system" }
+      taints         = []
+    },
+    {
+      name           = "node-group-2"
+      ami_type       = "AL2_x86_64"
+      instance_types = ["m5.4xlarge"]
+      min_size       = 3
+      max_size       = 3
+      desired_size   = 3
+      labels         = { terraform = "true", k8s = "true", role = "perf-eval", nodepool = "user" }
+      taints = [
+        {
+          key    = "fio-dedicated"
+          value  = "true"
+          effect = "NO_EXECUTE"
+        }
+      ]
+    }
+  ]
+
+  eks_addons = [{
+    name            = "aws-efs-csi-driver"
+    service_account = "efs-csi-*"
+    policy_arns     = ["service-role/AmazonEFSCSIDriverPolicy"]
+    }
+  ]
+}]

--- a/scenarios/perf-eval/k8s-fileshare/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-fileshare/terraform-inputs/azure.tfvars
@@ -1,0 +1,28 @@
+scenario_name  = "k8s-fileshare"
+scenario_type  = "perf-eval"
+deletion_delay = "20h"
+aks_config_list = [
+  {
+    role           = "client"
+    aks_name       = "files-aks"
+    dns_prefix     = "files"
+    subnet_name    = "aks-network"
+    network_plugin = "azure"
+    sku_tier       = "Free"
+    default_node_pool = {
+      name                         = "default"
+      node_count                   = 2
+      vm_size                      = "Standard_D16s_v4"
+      os_disk_type                 = "Managed"
+      only_critical_addons_enabled = true
+      temporary_name_for_rotation  = "defaulttmp"
+    }
+    extra_node_pool = [
+      {
+        name       = "user"
+        node_count = 3
+        vm_size    = "Standard_D16s_v4"
+      }
+    ]
+  }
+]

--- a/scenarios/perf-eval/k8s-fileshare/terraform-test-inputs/aws.json
+++ b/scenarios/perf-eval/k8s-fileshare/terraform-test-inputs/aws.json
@@ -1,0 +1,8 @@
+{
+    "owner"                                 : "terraform_unit_tests",
+    "run_id"                                : "123456789",
+    "region"                                : "us-east-2",
+    "efs_performance_mode"                  : "generalPurpose",
+    "efs_throughput_mode"                   : "provisioned",
+    "efs_provisioned_throughput_in_mibps"   : "1024"
+}

--- a/scenarios/perf-eval/k8s-fileshare/terraform-test-inputs/azure.json
+++ b/scenarios/perf-eval/k8s-fileshare/terraform-test-inputs/azure.json
@@ -1,0 +1,6 @@
+{
+    "owner"                            : "terraform_unit_tests",
+    "run_id"                           : "123456789",
+    "region"                           : "eastus",
+    "accelerated_networking"           : true
+}

--- a/scenarios/perf-eval/k8s-fileshare/yml-files/aws/fio.yml
+++ b/scenarios/perf-eval/k8s-fileshare/yml-files/aws/fio.yml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fio
+  labels:
+    test: fio
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      test: fio
+  template:
+    metadata:
+      labels:
+        test: fio
+    spec:
+      nodeSelector:
+        nodepool: user
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            test: fio
+      tolerations:
+      - key: "fio-dedicated"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"
+      containers:
+      - name: fio
+        image: telescope.azurecr.io/perf-eval/fio:1.0.0
+        command: ["/bin/sh"]
+        args: ["-c", "sleep infinity"]
+        volumeMounts:
+        - name: aws
+          mountPath: /mnt/aws
+      volumes:
+      - name: aws
+        persistentVolumeClaim:
+          claimName: efs-pvc

--- a/scenarios/perf-eval/k8s-fileshare/yml-files/aws/pvc.yml
+++ b/scenarios/perf-eval/k8s-fileshare/yml-files/aws/pvc.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: efs-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: 1024Gi

--- a/scenarios/perf-eval/k8s-fileshare/yml-files/aws/storage-class.yml
+++ b/scenarios/perf-eval/k8s-fileshare/yml-files/aws/storage-class.yml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: efs-sc
+provisioner: efs.csi.aws.com
+parameters:
+  fileSystemId: fs-0d30519695e723fa6
+  provisioningMode: efs-ap
+  directoryPerms: "700"
+  tagSpecification_1: ""

--- a/scenarios/perf-eval/k8s-fileshare/yml-files/azure/fio.yml
+++ b/scenarios/perf-eval/k8s-fileshare/yml-files/azure/fio.yml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fio
+  labels:
+    test: fio
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      test: fio
+  template:
+    metadata:
+      labels:
+        test: fio
+    spec:
+      nodeSelector:
+        agentpool: user
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            test: fio
+      containers:
+      - name: fio
+        image: telescope.azurecr.io/perf-eval/fio:1.0.0
+        command: ["/bin/sh"]
+        args: ["-c", "sleep infinity"]
+        volumeMounts:
+        - name: azure
+          mountPath: /mnt/azure
+      volumes:
+      - name: azure
+        persistentVolumeClaim:
+          claimName: files-pvc

--- a/scenarios/perf-eval/k8s-fileshare/yml-files/azure/pvc.yml
+++ b/scenarios/perf-eval/k8s-fileshare/yml-files/azure/pvc.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: files-pvc
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: azfile-sc
+  resources:
+    requests:
+      storage: 1024Gi

--- a/scenarios/perf-eval/k8s-fileshare/yml-files/azure/storage-class-nfs.yml
+++ b/scenarios/perf-eval/k8s-fileshare/yml-files/azure/storage-class-nfs.yml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: azfile-sc
+parameters:
+   skuName: Premium_LRS
+   protocol: nfs
+mountOptions:
+ - nconnect=4
+ - sec=sys
+ - actimeo=30
+provisioner: file.csi.azure.com
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer

--- a/scenarios/perf-eval/k8s-fileshare/yml-files/azure/storage-class-smb.yml
+++ b/scenarios/perf-eval/k8s-fileshare/yml-files/azure/storage-class-smb.yml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: azfile-sc
+parameters:
+   skuName: Premium_LRS
+   protocol: smb
+mountOptions:
+ - dir_mode=0777
+ - file_mode=0777
+ - nosharesock
+ - serverino
+ - mfsymlinks
+ - actimeo=30
+provisioner: file.csi.azure.com
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
- Add support for running on fileshares on multiple pods for EKS and AKS
- Use custom fio image which has the metadata operations implemented