### PR TITLE
perf-eval: add apiserver-vn100pod3k-28days

### DIFF
--- a/scenarios/perf-eval/apiserver-vn100pod3k-28days/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod3k-28days/terraform-inputs/aws.tfvars
@@ -1,0 +1,101 @@
+scenario_type  = "perf-eval"
+scenario_name  = "apiserver-vn100pod3k-28days"
+deletion_delay = "720h"
+
+network_config_list = [
+  {
+    role           = "client"
+    vpc_name       = "client-vpc"
+    vpc_cidr_block = "10.0.0.0/16"
+    subnet = [
+      {
+        name                    = "client-subnet"
+        cidr_block              = "10.0.0.0/24"
+        zone_suffix             = "a"
+        map_public_ip_on_launch = true
+      },
+      {
+        name                    = "client-subnet-2"
+        cidr_block              = "10.0.1.0/24"
+        zone_suffix             = "b"
+        map_public_ip_on_launch = true
+      }
+    ]
+    security_group_name = "client-sg"
+    route_tables = [
+      {
+        name       = "internet-rt"
+        cidr_block = "0.0.0.0/0"
+      }
+    ],
+    route_table_associations = [
+      {
+        name             = "client-subnet-rt-assoc"
+        subnet_name      = "client-subnet"
+        route_table_name = "internet-rt"
+      },
+      {
+        name             = "client-subnet-rt-assoc-2"
+        subnet_name      = "client-subnet-2"
+        route_table_name = "internet-rt"
+      }
+    ]
+    sg_rules = {
+      ingress = []
+      egress = [
+        {
+          from_port  = 0
+          to_port    = 0
+          protocol   = "-1"
+          cidr_block = "0.0.0.0/0"
+        }
+      ]
+    }
+  }
+]
+
+eks_config_list = [{
+  role        = "client"
+  eks_name    = "apiserver-vn100pod3k-28days"
+  vpc_name    = "client-vpc"
+  policy_arns = ["AmazonEKSClusterPolicy", "AmazonEKSVPCResourceController", "AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly"]
+  eks_managed_node_groups = [
+    {
+      name           = "idle"
+      ami_type       = "AL2_x86_64"
+      instance_types = ["m4.large"]
+      min_size       = 1
+      max_size       = 1
+      desired_size   = 1
+      capacity_type  = "ON_DEMAND"
+      labels         = { terraform = "true", k8s = "true", role = "apiserver-eval" } # Optional input
+    },
+    {
+      name           = "virtualnodes"
+      ami_type       = "AL2_x86_64"
+      instance_types = ["m4.2xlarge"]
+      min_size       = 5
+      max_size       = 5
+      desired_size   = 5
+      capacity_type  = "ON_DEMAND"
+      labels         = { terraform = "true", k8s = "true", role = "apiserver-eval" } # Optional input
+    },
+    {
+      name           = "runner"
+      ami_type       = "AL2_x86_64"
+      instance_types = ["m4.4xlarge"]
+      min_size       = 3
+      max_size       = 3
+      desired_size   = 3
+      capacity_type  = "ON_DEMAND"
+      labels         = { terraform = "true", k8s = "true", role = "apiserver-eval" } # Optional input
+    }
+  ]
+
+  eks_addons = [
+    {
+      name = "coredns"
+    }
+  ]
+}]
+

--- a/scenarios/perf-eval/apiserver-vn100pod3k-28days/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod3k-28days/terraform-inputs/azure.tfvars
@@ -1,0 +1,36 @@
+scenario_type  = "perf-eval"
+scenario_name  = "apiserver-vn100pod3k-28days"
+deletion_delay = "720h"
+aks_config_list = [
+  {
+    role        = "client"
+    aks_name    = "apiservervn100pod3k28day"
+    dns_prefix  = "kperf"
+    subnet_name = "aks-network"
+    sku_tier    = "Standard"
+    network_profile = {
+      network_plugin      = "azure"
+      network_plugin_mode = "overlay"
+    }
+    default_node_pool = {
+      name                         = "default"
+      node_count                   = 2
+      vm_size                      = "Standard_D2s_v3"
+      os_disk_type                 = "Managed"
+      only_critical_addons_enabled = true
+      temporary_name_for_rotation  = "defaulttmp"
+    }
+    extra_node_pool = [
+      {
+        name       = "virtualnodes"
+        node_count = 5
+        vm_size    = "Standard_D8s_v3"
+      },
+      {
+        name       = "runner"
+        node_count = 3
+        vm_size    = "Standard_D16s_v3"
+      }
+    ]
+  }
+]

--- a/scenarios/perf-eval/apiserver-vn100pod3k-28days/terraform-test-inputs/aws.json
+++ b/scenarios/perf-eval/apiserver-vn100pod3k-28days/terraform-test-inputs/aws.json
@@ -1,0 +1,5 @@
+{
+    "owner"                            : "terraform_unit_tests",
+    "run_id"                           : "123456789",
+    "region"                           : "us-east-1"
+}

--- a/scenarios/perf-eval/apiserver-vn100pod3k-28days/terraform-test-inputs/azure.json
+++ b/scenarios/perf-eval/apiserver-vn100pod3k-28days/terraform-test-inputs/azure.json
@@ -1,0 +1,5 @@
+{
+    "owner"                            : "terraform_unit_tests",
+    "run_id"                           : "123456789",
+    "region"                           : "eastus"
+}


### PR DESCRIPTION
Allow to run perf test on the same cluster for 28 days