### PR TITLE
Aposea/disk attach detach no polling

### DIFF
--- a/modules/bash/disk-attach-detach/azure.sh
+++ b/modules/bash/disk-attach-detach/azure.sh
@@ -82,7 +82,6 @@ attach_or_detach_disk() {
 
     pipe_filename="/tmp/pipe-$(date +%s)" # Used to store the output of the background process
     local external_polling_output_message="ERROR : Telescope polling timed out"
-    local external_polling_start_time=$(date +%s)
 
     (
         local internal_polling_start_time=$(date +%s)


### PR DESCRIPTION
The scenario now measures the times it take for the CLI command to complete and the time it takes for the disk to actually become attached.
Pipeline run: https://msazure.visualstudio.com/CloudNativeCompute/_build/results?buildId=96239817&view=logs&j=87165fe2-6498-5efc-f67a-d1b789fda623&t=780859d8-1287-5c14-ce83-4f63dfb72720