### PR TITLE
Add run url for iperf3 and sockperf

### DIFF
--- a/modules/bash/iperf.sh
+++ b/modules/bash/iperf.sh
@@ -152,6 +152,7 @@ collect_result_iperf3() {
     --arg egress_ip "$egress_ip_address" \
     --arg ingress_ip "$ingress_ip_address" \
     --arg run_id "$run_id" \
+    --arg run_url "$run_url" \
     '{timestamp: $timestamp, metric: $metric, target_bandwidth: $target_bw, unit: $unit, iperf_info: $iperf_info, cloud_info: $cloud_info, egress_ip: $egress_ip, ingress_ip: $ingress_ip, run_id: $run_id, run_url: $run_url}')
 
   echo $data >> $result_dir/results.json

--- a/modules/bash/sockperf.sh
+++ b/modules/bash/sockperf.sh
@@ -48,6 +48,7 @@ collect_result_sockperf() {
     --arg egress_ip "$egress_ip_address" \
     --arg ingress_ip "$ingress_ip_address" \
     --arg run_id "$run_id" \
+    --arg run_url "$run_url" \
     '{timestamp: $timestamp, metric: $metric, unit: $unit, sockperf_info: $sockperf_info, cloud_info: $cloud_info, egress_ip: $egress_ip, ingress_ip: $ingress_ip, run_id: $run_id, run_url: $run_url}')
 
   echo $data >> $result_dir/results.json


### PR DESCRIPTION
Output and upload the RUN_URL for iperf3 and sockperf 1a cases.

sockperf Test run:
https://dev.azure.com/msazure/CloudNativeCompute/_build/results?buildId=97784561&view=logs&j=7480d892-a74e-5989-b90b-466441c49e5f&t=65f01609-46ff-559f-bc9a-1e11c35ecf61

iperf3 Test run:
https://dev.azure.com/msazure/CloudNativeCompute/_build/results?buildId=97849542&view=results