### PR TITLE
*: introduce aks-cli terraform module

### DIFF
--- a/modules/terraform/azure/aks-cli/README.md
+++ b/modules/terraform/azure/aks-cli/README.md
@@ -1,0 +1,85 @@
+# Azure Kubernetes Service (AKS) CLI Module
+
+This module provisions an Azure Kubernetes Service (AKS) cluster by command
+line. It can be considered when `azurerm_kubernetes_cluster` doesn't support
+configuration, like `--aks-custom-headers" flags.
+
+## Input Variables
+
+### `resource_group_name`
+
+- **Description:** Name of the resource group where the AKS cluster will be created.
+- **Type:** String
+- **Default:** "rg"
+
+### `location`
+
+- **Description:** Azure region where the AKS cluster will be deployed.
+- **Type:** String
+- **Default:** "East US"
+
+### `tags`
+
+- **Description:** Tags to apply to the AKS resources.
+- **Type:** Map of strings
+- **Default:** None
+
+### `aks_cli_config`
+
+- **Description:** Configuration for the AKS cluster.
+- **Type:** Object
+  - `role`: Role of the AKS cluster
+  - `aks_name`: Name of the AKS cluster
+  - `sku_tier`: The type of pricing tiers
+  - `aks_custom_headers`: Custom headers for AKS.
+  - `default_node_pool`: Configuration for the default node pool
+  - `extra_node_pool`: Additional node pools for the AKS cluster
+    - `name`: Name of the node pool
+    - `node_count`: Number of nodes in the node pool
+    - `vm_size`: Size of Virtual Machines to create as Kubernetes nodes.
+
+## Usage Example
+
+```hcl
+module "aks" {
+  source = "./aks-cli"
+
+  resource_group_name = "my-rg"
+
+  location            = "West Europe"
+
+  tags = {
+    environment = "production"
+    project     = "example"
+  }
+
+  aks_cli_config = {
+    role     = "dev"
+    aks_name = "my-aks-cluster"
+    sku_tier = "standard"
+
+    aks_custom_headers = [
+      "WindowsContainerRuntime=containerd",
+      "AKSHTTPCustomFeatures=Microsoft.ContainerService/CustomNodeConfigPreview",
+    ]
+
+    default_node_pool = {
+      name       = "default-pool"
+      vm_size    = "Standard_D2s_v3"
+      node_count = 3
+    }
+    extra_node_pool = [
+      {
+        name       = "pool-1"
+        node_count = 2
+        vm_size    = "Standard_D2s_v3"
+      },
+      {
+        name       = "pool-2"
+        node_count = 2
+        vm_size    = "Standard_D2s_v3"
+      }
+    ]
+  }
+}
+```

--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -1,0 +1,81 @@
+locals {
+  tags_list = [
+    for key, value in merge(var.tags, { "role" = var.aks_cli_config.role }) :
+    format("%s=%s", key, value)
+  ]
+
+  extra_pool_map = {
+    for pool in var.aks_cli_config.extra_node_pool :
+    pool.name => pool
+  }
+
+  aks_custom_headers_flags = (
+    length(var.aks_cli_config.aks_custom_headers) == 0 ?
+    "" :
+    format(
+      "%s %s",
+      "--aks-custom-headers",
+      join(",", var.aks_cli_config.aks_custom_headers),
+    )
+  )
+}
+
+resource "terraform_data" "aks_cli" {
+  input = {
+    group_name = var.resource_group_name,
+    name       = var.aks_cli_config.aks_name
+  }
+
+  provisioner "local-exec" {
+    command = join(" ", [
+      "az",
+      "aks",
+      "create",
+      "-g", self.input.group_name,
+      "-n", self.input.name,
+      "--location", var.location,
+      "--tier", var.aks_cli_config.sku_tier,
+      "--tags", join(" ", local.tags_list),
+      local.aks_custom_headers_flags,
+      "--no-ssh-key",
+      "--enable-managed-identity",
+      "--nodepool-name", var.aks_cli_config.default_node_pool.name,
+      "--node-count", var.aks_cli_config.default_node_pool.node_count,
+      "--node-vm-size", var.aks_cli_config.default_node_pool.vm_size,
+    ])
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+    command = join(" ", [
+      "az",
+      "aks",
+      "delete",
+      "-g", self.input.group_name,
+      "-n", self.input.name,
+      "--yes",
+    ])
+  }
+}
+
+resource "terraform_data" "aks_nodepool_cli" {
+  depends_on = [
+    terraform_data.aks_cli
+  ]
+
+  for_each = local.extra_pool_map
+
+  provisioner "local-exec" {
+    command = join(" ", [
+      "az",
+      "aks",
+      "nodepool",
+      "add",
+      "-g", var.resource_group_name,
+      "--cluster-name", var.aks_cli_config.aks_name,
+      "--nodepool-name", each.value.name,
+      "--node-count", each.value.node_count,
+      "--node-vm-size", each.value.vm_size,
+    ])
+  }
+}

--- a/modules/terraform/azure/aks-cli/variables.tf
+++ b/modules/terraform/azure/aks-cli/variables.tf
@@ -1,0 +1,39 @@
+variable "resource_group_name" {
+  description = "Value of the resource group name"
+  type        = string
+  default     = "rg"
+}
+
+variable "location" {
+  description = "Value of the location"
+  type        = string
+  default     = "East US"
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+  }
+}
+
+variable "aks_cli_config" {
+  type = object({
+    role               = string
+    aks_name           = string
+    sku_tier           = string
+    aks_custom_headers = optional(list(string), [])
+    default_node_pool = object({
+      name       = string
+      node_count = number
+      vm_size    = string
+    })
+    extra_node_pool = optional(
+      list(object({
+        name       = string
+        node_count = number
+        vm_size    = string
+      })),
+      []
+    )
+  })
+}

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -202,6 +202,30 @@ variable "aks_config_list" {
   default = []
 }
 
+variable "aks_cli_config_list" {
+  type = list(object({
+    role     = string
+    aks_name = string
+    sku_tier = string
+
+    aks_custom_headers = optional(list(string))
+
+    default_node_pool = object({
+      name       = string
+      node_count = number
+      vm_size    = string
+    })
+    extra_node_pool = optional(
+      list(object({
+        name       = string
+        node_count = number
+        vm_size    = string
+      }))
+    )
+  }))
+  default = []
+}
+
 variable "loadbalancer_config_list" {
   description = "List of Loadbalancer configurations"
   type = list(object({

--- a/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/azure.tfvars
@@ -1,24 +1,20 @@
 scenario_type  = "perf-eval"
 scenario_name  = "apiserver-vn100pod10k"
 deletion_delay = "20h"
-aks_config_list = [
+aks_cli_config_list = [
   {
-    role        = "client"
-    aks_name    = "virtualnodes100-pods10k"
-    dns_prefix  = "kperf"
-    subnet_name = "aks-network"
-    sku_tier    = "Standard"
-    network_profile = {
-      network_plugin      = "azure"
-      network_plugin_mode = "overlay"
-    }
+    role     = "client"
+    aks_name = "virtualnodes100-pods10k"
+    sku_tier = "standard"
+
+    aks_custom_headers = [
+      "ControlPlaneUnderlay=hcp-underlay-eastus2-cx-382"
+    ]
+
     default_node_pool = {
-      name                         = "default"
-      node_count                   = 2
-      vm_size                      = "Standard_D2s_v3"
-      os_disk_type                 = "Managed"
-      only_critical_addons_enabled = true
-      temporary_name_for_rotation  = "defaulttmp"
+      name       = "default"
+      node_count = 2
+      vm_size    = "Standard_D2s_v3"
     }
     extra_node_pool = [
       {


### PR DESCRIPTION
Current azurerm doesn't support `aks-custom-headers` flag. This patch is to introduce aks-cli terraform module using `az aks` to provision resource.