### PR TITLE
Add index to name methods

### DIFF
--- a/modules/bash/vmss-flex-scale/aws.sh
+++ b/modules/bash/vmss-flex-scale/aws.sh
@@ -4,13 +4,15 @@
 #   This function is used to generate a launch template name
 #
 # Parameters:
-#   - $1: The run id
+#   - $1: The index of the lt
+#   - $2: The run id
 #
-# Usage: get_lt_name <run_id>
+# Usage: get_lt_name <index> <run_id>
 get_lt_name() {
-    local run_id=$1
+    local index=$1
+    local run_id=$2
 
-    local lt_name="lt-$run_id"
+    local lt_name="lt-$index-$run_id"
 
     echo "$lt_name"
 }

--- a/modules/bash/vmss-flex-scale/utils.sh
+++ b/modules/bash/vmss-flex-scale/utils.sh
@@ -4,16 +4,18 @@
 #   This function is used to generate a VMSS name
 #
 # Parameters:
-#   - $1: The run id
+#   - $1: The index of the VMSS
+#   - $2: The run id
 #
 # Notes:
 #   - the VMSS name is truncated to 64 characters due to naming limitations
 #
-# Usage: get_vmss_name <run_id>
+# Usage: get_vmss_name <index> <run_id>
 get_vmss_name() {
-    local run_id=$1
+    local index=$1
+    local run_id=$2
 
-    local vmss_name="vmss-$run_id"
+    local vmss_name="vmss-$index-$run_id"
     vmss_name="${vmss_name:0:64}"
     vmss_name="${vmss_name%-}"
 


### PR DESCRIPTION
I added an index parameter to naming methods for creating more VMSS(s) within the same run with different vmss/asg/lt names.