### PR TITLE
Make ssh key optional

### DIFF
--- a/jobs/competitive-test.yml
+++ b/jobs/competitive-test.yml
@@ -48,6 +48,9 @@ parameters:
 - name: subscription
   type: string
   default: ''
+- name: ssh_key_enabled
+  type: boolean
+  default: true
 
 jobs:
 - job: ${{ parameters.cloud }}
@@ -66,6 +69,7 @@ jobs:
       retry_attempt_count: ${{ parameters.retry_attempt_count }}
       credential_type: ${{ parameters.credential_type }}
       subscription: ${{ parameters.subscription }}
+      ssh_key_enabled: ${{ parameters.ssh_key_enabled }}
   - template: /steps/provision-resources.yml
     parameters:
       cloud: ${{ parameters.cloud }}

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes10-pods100.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes10-pods100.yml
@@ -39,6 +39,7 @@ stages:
           max_parallel: 2
           timeout_in_minutes: 360
           credential_type: service_connection
+          ssh_key_enabled: false
   - stage: azure_eastus2
     dependsOn: []
     jobs:
@@ -63,3 +64,4 @@ stages:
           max_parallel: 2
           timeout_in_minutes: 360
           credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -43,6 +43,7 @@ stages:
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
+          ssh_key_enabled: false
   - stage: azure_eastus2
     dependsOn: []
     jobs:
@@ -73,3 +74,4 @@ stages:
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -37,6 +37,7 @@ stages:
           max_parallel: 2
           timeout_in_minutes: 360
           credential_type: service_connection
+          ssh_key_enabled: false
   - stage: azure_eastus2
     dependsOn: []
     jobs:
@@ -61,3 +62,4 @@ stages:
           max_parallel: 2
           timeout_in_minutes: 360
           credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/perf-eval/node-auto-provisioning-benchmark-nodes10-pods100.yml
+++ b/pipelines/perf-eval/node-auto-provisioning-benchmark-nodes10-pods100.yml
@@ -37,6 +37,7 @@ stages:
           max_parallel: 1
           timeout_in_minutes: 360
           credential_type: service_connection
+          ssh_key_enabled: false
   - stage: azure_eastus2
     dependsOn: []
     jobs:
@@ -60,3 +61,4 @@ stages:
           max_parallel: 1
           timeout_in_minutes: 360
           credential_type: service_connection
+          ssh_key_enabled: false

--- a/steps/provision-resources.yml
+++ b/steps/provision-resources.yml
@@ -30,10 +30,6 @@ steps:
     cloud: ${{ parameters.cloud }}
     modules_dir: ${{ parameters.terraform_modules_dir }}
 
-- template: /steps/ssh/setup-key.yml
-  parameters:
-    cloud: ${{ parameters.cloud }}
-
 - template: /steps/terraform/set-input-file.yml
   parameters:
     cloud: ${{ parameters.cloud }}

--- a/steps/setup-tests.yml
+++ b/steps/setup-tests.yml
@@ -16,7 +16,9 @@ parameters:
   type: string
 - name: subscription
   type: string
-  default: ''
+- name: ssh_key_enabled
+  type: boolean
+  default: true
 
 steps:
 - script: |
@@ -82,3 +84,8 @@ steps:
   displayName: 'Set Script Module Directory'
   env:
     TEST_MODULES_DIR: ${{ parameters.test_modules_dir }}
+
+- template: /steps/ssh/setup-key.yml
+  ${{ if eq(parameters.ssh_key_enabled, true) }}:
+    parameters:
+      cloud: ${{ parameters.cloud }}

--- a/steps/setup-tests.yml
+++ b/steps/setup-tests.yml
@@ -16,6 +16,7 @@ parameters:
   type: string
 - name: subscription
   type: string
+  default: ''
 - name: ssh_key_enabled
   type: boolean
 

--- a/steps/setup-tests.yml
+++ b/steps/setup-tests.yml
@@ -87,4 +87,4 @@ steps:
 - ${{ if eq(parameters.ssh_key_enabled, true) }}:
   - template: /steps/ssh/setup-key.yml
     parameters:
-       cloud: ${{ parameters.cloud }}
+      cloud: ${{ parameters.cloud }}

--- a/steps/setup-tests.yml
+++ b/steps/setup-tests.yml
@@ -18,7 +18,6 @@ parameters:
   type: string
 - name: ssh_key_enabled
   type: boolean
-  default: true
 
 steps:
 - script: |
@@ -85,7 +84,7 @@ steps:
   env:
     TEST_MODULES_DIR: ${{ parameters.test_modules_dir }}
 
-- template: /steps/ssh/setup-key.yml
-  ${{ if eq(parameters.ssh_key_enabled, true) }}:
+- ${{ if eq(parameters.ssh_key_enabled, true) }}:
+  - template: /steps/ssh/setup-key.yml
     parameters:
-      cloud: ${{ parameters.cloud }}
+       cloud: ${{ parameters.cloud }}


### PR DESCRIPTION
This pull request introduces a new `ssh_key_enabled` parameter across various YAML configuration files to control whether SSH keys are set up during different stages and steps. The most important changes include updates to the `jobs/competitive-test.yml`, `pipelines/perf-eval` files, and the `steps/provision-resources.yml` and `steps/setup-tests.yml` files.

### Parameter Addition:

* [`jobs/competitive-test.yml`](diffhunk://#diff-2f9729eea91e9c4269be4d0b0777b4a427c14c6fdf8ab18f804e1789ab6d0056R51-R53): Added `ssh_key_enabled` parameter with a default value of `true` and updated job parameters to include it. [[1]](diffhunk://#diff-2f9729eea91e9c4269be4d0b0777b4a427c14c6fdf8ab18f804e1789ab6d0056R51-R53) [[2]](diffhunk://#diff-2f9729eea91e9c4269be4d0b0777b4a427c14c6fdf8ab18f804e1789ab6d0056R72)
* [`steps/setup-tests.yml`](diffhunk://#diff-2fb7bd760bef4b06cd3b760b759031d9f1608c6da4c53080ea2d714cfcec512cL19-R20): Added `ssh_key_enabled` parameter and conditional step to set up SSH keys if the parameter is `true`. [[1]](diffhunk://#diff-2fb7bd760bef4b06cd3b760b759031d9f1608c6da4c53080ea2d714cfcec512cL19-R20) [[2]](diffhunk://#diff-2fb7bd760bef4b06cd3b760b759031d9f1608c6da4c53080ea2d714cfcec512cR86-R90)

### Pipeline Configuration:

* [`pipelines/perf-eval/apiserver-benchmark-virtualnodes10-pods100.yml`](diffhunk://#diff-0637ac88f0b2ccd044978f0c20e4c0946867cc47061de1d3febc543e3ae026d3R42): Added `ssh_key_enabled: false` to stages. [[1]](diffhunk://#diff-0637ac88f0b2ccd044978f0c20e4c0946867cc47061de1d3febc543e3ae026d3R42) [[2]](diffhunk://#diff-0637ac88f0b2ccd044978f0c20e4c0946867cc47061de1d3febc543e3ae026d3R67)
* [`pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml`](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454R46): Added `ssh_key_enabled: false` to stages. [[1]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454R46) [[2]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454R77)
* [`pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods3k.yml`](diffhunk://#diff-1ee4395f8f4876bd595e62a1eb480d49a94f70fa4114d59803a0a9811b91dd6aR40): Added `ssh_key_enabled: false` to stages. [[1]](diffhunk://#diff-1ee4395f8f4876bd595e62a1eb480d49a94f70fa4114d59803a0a9811b91dd6aR40) [[2]](diffhunk://#diff-1ee4395f8f4876bd595e62a1eb480d49a94f70fa4114d59803a0a9811b91dd6aR65)
* [`pipelines/perf-eval/node-auto-provisioning-benchmark-nodes10-pods100.yml`](diffhunk://#diff-93c53c7e3dbc36d13a2a95925d3a35704a79e63416fb6c1e6adb79b83251fa27R40): Added `ssh_key_enabled: false` to stages. [[1]](diffhunk://#diff-93c53c7e3dbc36d13a2a95925d3a35704a79e63416fb6c1e6adb79b83251fa27R40) [[2]](diffhunk://#diff-93c53c7e3dbc36d13a2a95925d3a35704a79e63416fb6c1e6adb79b83251fa27R64)

### Step Removal:

* [`steps/provision-resources.yml`](diffhunk://#diff-bb57749fbaaea2fbff3adb99cba62fb712d6502e1e7fd2f985fa7581fa0a513bL33-L36): Removed the setup of SSH keys step, which is now conditionally handled in `steps/setup-tests.yml`.