### PR TITLE
use kperf github package

### DIFF
--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes10-pods100.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes10-pods100.yml
@@ -33,7 +33,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:0.1.5
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2
@@ -58,7 +58,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:0.1.5
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -37,7 +37,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:0.1.5
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -68,7 +68,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:0.1.5
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -31,7 +31,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:0.1.5
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2
@@ -56,7 +56,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:0.1.5
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2


### PR DESCRIPTION
This pull request updates the runner image version across multiple benchmark configuration files to ensure consistency and use the latest available version.

Updates to runner image versions:

* [`pipelines/perf-eval/apiserver-benchmark-virtualnodes10-pods100.yml`](diffhunk://#diff-0637ac88f0b2ccd044978f0c20e4c0946867cc47061de1d3febc543e3ae026d3L36-R36): Updated `runner_image` from `telescope.azurecr.io/oss/kperf:v0.1.3` to `ghcr.io/azure/kperf:0.1.4` [[1]](diffhunk://#diff-0637ac88f0b2ccd044978f0c20e4c0946867cc47061de1d3febc543e3ae026d3L36-R36) [[2]](diffhunk://#diff-0637ac88f0b2ccd044978f0c20e4c0946867cc47061de1d3febc543e3ae026d3L60-R60).
* [`pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml`](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454L40-R40): Updated `runner_image` from `telescope.azurecr.io/oss/kperf:v0.1.2` to `ghcr.io/azure/kperf:0.1.4` [[1]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454L40-R40) [[2]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454L70-R70).
* [`pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods3k.yml`](diffhunk://#diff-1ee4395f8f4876bd595e62a1eb480d49a94f70fa4114d59803a0a9811b91dd6aL34-R34): Updated `runner_image` from `telescope.azurecr.io/oss/kperf:v0.0.8` to `ghcr.io/azure/kperf:0.1.4` [[1]](diffhunk://#diff-1ee4395f8f4876bd595e62a1eb480d49a94f70fa4114d59803a0a9811b91dd6aL34-R34) [[2]](diffhunk://#diff-1ee4395f8f4876bd595e62a1eb480d49a94f70fa4114d59803a0a9811b91dd6aL58-R58).