### PR TITLE
fix: improve node auto-provisioning reliability

### DIFF
--- a/modules/python/clusterloader2/autoscale/autoscale.py
+++ b/modules/python/clusterloader2/autoscale/autoscale.py
@@ -7,8 +7,8 @@ from datetime import datetime, timezone
 from utils import parse_xml_to_json, run_cl2_command
 
 def override_config_clusterloader2(cpu_per_node, node_count, pod_count, scale_up_timeout, scale_down_timeout, loop_count, override_file):
-    # assuming 90% of the CPU cores can be used by test pods
-    cpu_request = (cpu_per_node * 1000 * 0.9) * node_count // pod_count
+    # assuming 85% of the CPU cores can be used by test pods
+    cpu_request = (cpu_per_node * 1000 * 0.85) * node_count // pod_count
 
     print(f"Total number of nodes: {node_count}, total number of pods: {pod_count}")
     print(f"CPU request for each pod: {cpu_request}m")

--- a/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
@@ -17,10 +17,10 @@ spec:
       nodeClassRef:
         name: default
       startupTaints:
-      # https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
-      - key: node.cilium.io/agent-not-ready
-        effect: NoExecute
-        value: "true"
+        # https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
+        - key: node.cilium.io/agent-not-ready
+          effect: NoExecute
+          value: "true"
       requirements:
         - key: kubernetes.io/arch
           operator: In

--- a/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       labels:
+        # required for Karpenter to predict overhead from cilium DaemonSet
         kubernetes.azure.com/ebpf-dataplane: cilium
     spec:
       nodeClassRef:

--- a/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
@@ -9,9 +9,17 @@ spec:
     budgets:
       - nodes: "100%"
   template:
+    metadata:
+      labels:
+        kubernetes.azure.com/ebpf-dataplane: cilium
     spec:
       nodeClassRef:
         name: default
+      startupTaints:
+      # https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
+      - key: node.cilium.io/agent-not-ready
+        effect: NoExecute
+        value: "true"
       requirements:
         - key: kubernetes.io/arch
           operator: In


### PR DESCRIPTION
* Reduced expected allocatable from 90% to 85%. (Note that this affects all tests! May need to be revisited if per-provider/scenario setting would be a better fit)
* NodePool: adds cilium startup taint (https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint)
* NodePool: add cillium ebpf-dataplaine label, so that Karpenter can take the corresponding DaemonSet into account when computing the expected overhead