### PR TITLE
Update region as optional variable

### DIFF
--- a/modules/terraform/aws/eks/variables.tf
+++ b/modules/terraform/aws/eks/variables.tf
@@ -17,6 +17,7 @@ variable "vpc_id" {
 variable "region" {
   description = "value of the region"
   type        = string
+  default     = "us-east-2"
 }
 
 variable "eks_config" {


### PR DESCRIPTION
This pull request includes a small change to the `modules/terraform/aws/eks/variables.tf` file. The change sets a default value for the `region` variable.

* [`modules/terraform/aws/eks/variables.tf`](diffhunk://#diff-8abbc84758137371997b88238369c9fd9f08384fc96dc0932a3841a66cdf83abR20): Added a default value of `"us-east-2"` to the `region` variable.