### PR TITLE
AWS clean up: Delete any available (not in use) elastic network inter…

### DIFF
--- a/steps/engine/clusterloader2/autoscale/cleanup-aws.yml
+++ b/steps/engine/clusterloader2/autoscale/cleanup-aws.yml
@@ -19,6 +19,18 @@ steps:
 
     sleep 120
 
+    # Delete any available (not in use) elastic network interface (ENI) attached to the VPC
+    # Get VPC Id
+    vpc_id=$(aws ec2 describe-vpcs --query "Vpcs[?Tags[?Key=='run_id' && Value=='$RUN_ID']].VpcId" --output text)
+    # Get all available ENIs attached to the VPC
+    network_interface_ids=$(aws ec2 describe-network-interfaces --filters 'Name=vpc-id,Values=$vpc_id' 'Name=status,Values=available' --query "NetworkInterfaces[].NetworkInterfaceId" --output text)
+    for network_interface in $network_interface_ids; do
+      echo "Deleting available Network Interface: $network_interface attached to VPC: $vpc_id"
+      if ! aws ec2 delete-network-interface --network-interface-id $network_interface; then
+        echo "##[warning] Failed to delete Network Interface: $network_interface"
+      fi
+    done
+
     subnet_ids=$(aws ec2 describe-subnets --query "Subnets[?Tags[?Key=='run_id' && Value=='$RUN_ID']].SubnetId" --output text)
     for subnet_id in $subnet_ids; do
       echo "Detaching Subnet: $subnet_id Network Interfaces"


### PR DESCRIPTION
Delete any available (not in use) elastic network interface (ENI) attached to the VPC

Candidate fix for the ENIs leak issue, which unused ENIs were blocking terraform to destroy the subnets in the Pipeline [node-auto-provisioning-benchmark-nodes10-pods100](pipelines/perf-eval/node-auto-provisioning-benchmark-nodes10-pods100.ymlc) 