### PR TITLE
add sku tier as input variable

### DIFF
--- a/modules/terraform/azure/README.md
+++ b/modules/terraform/azure/README.md
@@ -19,7 +19,8 @@ SCENARIO_TYPE=perf-eval
 SCENARIO_NAME=nap-c4n10p100
 RUN_ID=$(date +%s)
 CLOUD=azure
-REGION="eastus2"
+REGION=eastus2
+SKU_TIER=free
 TERRAFORM_MODULES_DIR=modules/terraform/$CLOUD
 TERRAFORM_INPUT_FILE=$(pwd)/scenarios/$SCENARIO_TYPE/$SCENARIO_NAME/terraform-inputs/${CLOUD}.tfvars
 SYSTEM_NODE_POOL=${SYSTEM_NODE_POOL:-null}
@@ -57,11 +58,13 @@ Set `INPUT_JSON` variable. This variable is not exhaustive and may vary dependin
   INPUT_JSON=$(jq -n \
   --arg run_id $RUN_ID \
   --arg region $REGION \
+  --arg aks_cli_sku_tier $SKU_TIER \
   --argjson aks_cli_system_node_pool "$SYSTEM_NODE_POOL" \
   --argjson aks_cli_user_node_pool "$USER_NODE_POOL" \
   '{
     run_id: $run_id,
     region: $region,
+    aks_cli_sku_tier: $aks_cli_sku_tier,
     aks_cli_system_node_pool: $aks_cli_system_node_pool,
     aks_cli_user_node_pool: $aks_cli_user_node_pool
   }' | jq 'with_entries(select(.value != null and .value != ""))')
@@ -73,14 +76,14 @@ Set `INPUT_JSON` variable. This variable is not exhaustive and may vary dependin
 ```bash
 pushd $TERRAFORM_MODULES_DIR
 terraform init
-terraform plan  -var json_input=$(echo $INPUT_JSON | jq -c .) -var-file $TERRAFORM_INPUT_FILE 
+terraform plan  -var json_input=$(echo $INPUT_JSON | jq -c .) -var-file $TERRAFORM_INPUT_FILE
 terraform apply -var json_input=$(echo $INPUT_JSON | jq -c .) -var-file $TERRAFORM_INPUT_FILE
 popd
 ```
 
 ### Cleanup Resources
 Cleanup test resources using terraform
-```bash 
+```bash
 pushd $TERRAFORM_MODULES_DIR
 terraform destroy -var json_input=$(echo $INPUT_JSON | jq -c .) -var-file $TERRAFORM_INPUT_FILE
 popd

--- a/modules/terraform/azure/README.md
+++ b/modules/terraform/azure/README.md
@@ -58,7 +58,7 @@ Set `INPUT_JSON` variable. This variable is not exhaustive and may vary dependin
   INPUT_JSON=$(jq -n \
   --arg run_id $RUN_ID \
   --arg region $REGION \
-  --arg aks_cli_sku_tier $SKU_TIER \
+  --arg aks_cli_sku_tier "$SKU_TIER" \
   --argjson aks_cli_system_node_pool "$SYSTEM_NODE_POOL" \
   --argjson aks_cli_user_node_pool "$USER_NODE_POOL" \
   '{

--- a/modules/terraform/azure/azure_input_schema.json
+++ b/modules/terraform/azure/azure_input_schema.json
@@ -7,6 +7,9 @@
     "region": {
       "type": "string"
     },
+    "aks_cli_sku_tier": {
+      "type": "string"
+    },
     "aks_cli_system_node_pool": {
       "type": "object"
     },

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -1,6 +1,7 @@
 locals {
   region                   = lookup(var.json_input, "region", "East US")
   run_id                   = lookup(var.json_input, "run_id", "123456")
+  aks_cli_sku_tier         = lookup(var.json_input, "aks_cli_sku_tier", "standard")
   aks_cli_system_node_pool = lookup(var.json_input, "aks_cli_system_node_pool", null)
   aks_cli_user_node_pool   = lookup(var.json_input, "aks_cli_user_node_pool", null)
   aks_custom_headers       = lookup(var.json_input, "aks_custom_headers", [])
@@ -15,12 +16,12 @@ locals {
 
   aks_config_map = { for aks in var.aks_config_list : aks.role => aks }
 
-  updated_aks_cli_config_list = (length(var.aks_cli_config_list) == 1 && (local.aks_cli_system_node_pool != null || local.aks_cli_user_node_pool != null)) ? flatten([
+  updated_aks_cli_config_list = (length(var.aks_cli_config_list) == 1) ? flatten([
     for aks in var.aks_cli_config_list : [
       {
         role                          = aks.role
         aks_name                      = aks.aks_name
-        sku_tier                      = aks.sku_tier
+        sku_tier                      = length(local.aks_cli_sku_tier) > 0 ? local.aks_cli_sku_tier : aks.sku_tier
         aks_custom_headers            = length(local.aks_custom_headers) > 0 ? local.aks_custom_headers : aks.aks_custom_headers
         use_aks_preview_cli_extension = aks.use_aks_preview_cli_extension
         default_node_pool             = local.aks_cli_system_node_pool != null ? local.aks_cli_system_node_pool : aks.default_node_pool
@@ -28,6 +29,7 @@ locals {
       }
     ]
   ]) : []
+
   aks_cli_config_map = length(local.updated_aks_cli_config_list) == 0 ? { for aks in var.aks_cli_config_list : aks.role => aks } : { for aks in local.updated_aks_cli_config_list : aks.role => aks }
 }
 

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -26,6 +26,7 @@ locals {
         use_aks_preview_cli_extension = aks.use_aks_preview_cli_extension
         default_node_pool             = local.aks_cli_system_node_pool != null ? local.aks_cli_system_node_pool : aks.default_node_pool
         extra_node_pool               = local.aks_cli_user_node_pool != null ? local.aks_cli_user_node_pool : aks.extra_node_pool
+        optional_parameters           = aks.optional_parameters
       }
     ]
   ]) : []

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -3,6 +3,7 @@ variable "json_input" {
   type = object({
     run_id             = string
     region             = string
+    aks_cli_sku_tier   = optional(string, "standard")
     aks_custom_headers = optional(list(string), [])
     aks_cli_system_node_pool = optional(object({
       name        = string


### PR DESCRIPTION
This pull request introduces a new `SKU_TIER` variable to the Azure Terraform module, making it configurable for different deployment scenarios. The most important changes include updates to the `README.md`, JSON schema, and Terraform files to incorporate this new variable.

Configuration Updates:

* [`modules/terraform/azure/README.md`](diffhunk://#diff-6408a79a9cdb905ab9327763a955f3f5cd4d0af74ddb77f688f08a7f82e27ed0L22-R23): Added `SKU_TIER` variable to the example configuration and the `INPUT_JSON` setup. [[1]](diffhunk://#diff-6408a79a9cdb905ab9327763a955f3f5cd4d0af74ddb77f688f08a7f82e27ed0L22-R23) [[2]](diffhunk://#diff-6408a79a9cdb905ab9327763a955f3f5cd4d0af74ddb77f688f08a7f82e27ed0R61-R67)
* [`modules/terraform/azure/azure_input_schema.json`](diffhunk://#diff-4f17a00034a463e9bcadcda2dcc8f0e03cd95603ec9329474618c9f7aad5deaeR10-R12): Introduced a new `aks_cli_sku_tier` field in the JSON schema.

Terraform Logic Enhancements:

* [`modules/terraform/azure/main.tf`](diffhunk://#diff-0f7f598ee8901914ae02cf0a5c9c9c1237e1bbe208688856f72a3af4e1cc12bbR4): Added `aks_cli_sku_tier` to the local variables and updated the logic to use this new variable in the AKS CLI configuration. [[1]](diffhunk://#diff-0f7f598ee8901914ae02cf0a5c9c9c1237e1bbe208688856f72a3af4e1cc12bbR4) [[2]](diffhunk://#diff-0f7f598ee8901914ae02cf0a5c9c9c1237e1bbe208688856f72a3af4e1cc12bbL18-R32)