### PR TITLE
VPC-CNI: set additional ENI tags flag

### DIFF
--- a/modules/terraform/aws/eks/addon/main.tf
+++ b/modules/terraform/aws/eks/addon/main.tf
@@ -67,6 +67,7 @@ resource "aws_eks_addon" "addon" {
   addon_name               = each.value.name
   addon_version            = each.value.version
   service_account_role_arn = aws_iam_role.addon_role.arn
+  configuration_values     = each.value.configuration_values
 
 
   tags = merge(var.tags, {

--- a/modules/terraform/aws/eks/addon/variables.tf
+++ b/modules/terraform/aws/eks/addon/variables.tf
@@ -17,9 +17,10 @@ variable "tags" {
 variable "eks_addon_config_map" {
   description = "A map of EKS addons to deploy"
   type = map(object({
-    name            = string
-    version         = optional(string)
-    service_account = optional(string)
-    policy_arns     = optional(list(string), [])
+    name                 = string
+    version              = optional(string)
+    service_account      = optional(string)
+    policy_arns          = optional(list(string), [])
+    configuration_values = optional(string)
   }))
 }

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -9,8 +9,6 @@ locals {
         policy_arns = ["AmazonEKS_CNI_Policy"],
         configuration_values = jsonencode({
           env = {
-            ENABLE_PREFIX_DELEGATION = "true"
-            WARM_PREFIX_TARGET       = "1"
             ADDITIONAL_ENI_TAGS      = jsonencode(var.tags)
           }
         })

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -2,7 +2,6 @@ locals {
   role               = var.eks_config.role
   eks_cluster_name   = "${var.eks_config.eks_name}-${var.run_id}"
   eks_node_group_map = { for node_group in var.eks_config.eks_managed_node_groups : node_group.name => node_group }
-  tags_json          = jsonencode(var.tags)
   karpenter_addons_map = {
     for addon in [
       { name        = "vpc-cni",

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -9,7 +9,7 @@ locals {
         policy_arns = ["AmazonEKS_CNI_Policy"],
         configuration_values = jsonencode({
           env = {
-            ADDITIONAL_ENI_TAGS      = jsonencode(var.tags)
+            ADDITIONAL_ENI_TAGS = jsonencode(var.tags)
           }
         })
       },
@@ -22,11 +22,11 @@ locals {
       service_account      = lookup(addon, "service_account", null)
       policy_arns          = lookup(addon, "policy_arns", []),
       configuration_values = lookup(addon, "configuration_values", null)
-    }
+    } if var.eks_config.enable_karpenter
   }
 
   eks_addons_map         = { for addon in var.eks_config.eks_addons : addon.name => addon }
-  updated_eks_addons_map = var.eks_config.enable_karpenter ? merge(local.karpenter_addons_map, local.eks_addons_map) : local.eks_addons_map
+  updated_eks_addons_map = merge(local.karpenter_addons_map, local.eks_addons_map)
   policy_arns            = var.eks_config.policy_arns
 }
 

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -2,13 +2,28 @@ locals {
   role               = var.eks_config.role
   eks_cluster_name   = "${var.eks_config.eks_name}-${var.run_id}"
   eks_node_group_map = { for node_group in var.eks_config.eks_managed_node_groups : node_group.name => node_group }
+  tags_json          = jsonencode(var.tags)
   karpenter_addons_map = {
-    for addon in [{ name = "vpc-cni", policy_arns = ["AmazonEKS_CNI_Policy"] }, { name = "kube-proxy" }, { name = "coredns" }] : addon.name =>
+    for addon in [
+      { name        = "vpc-cni",
+        policy_arns = ["AmazonEKS_CNI_Policy"],
+        configuration_values = jsonencode({
+          env = {
+            ENABLE_PREFIX_DELEGATION = "true"
+            WARM_PREFIX_TARGET       = "1"
+            ADDITIONAL_ENI_TAGS      = jsonencode(var.tags)
+          }
+        })
+      },
+      { name = "kube-proxy" },
+      { name = "coredns" }
+    ] : addon.name =>
     {
-      name            = addon.name
-      version         = lookup(addon, "version", null)
-      service_account = lookup(addon, "service_account", null)
-      policy_arns     = lookup(addon, "policy_arns", [])
+      name                 = addon.name
+      version              = lookup(addon, "version", null)
+      service_account      = lookup(addon, "service_account", null)
+      policy_arns          = lookup(addon, "policy_arns", []),
+      configuration_values = lookup(addon, "configuration_values", null)
     }
   }
 


### PR DESCRIPTION
Pass the default tags to the VPC-CNI configuration (ADDITIONAL_ENI_TAGS) to add the tags to all created ENIs.


<img width="691" alt="Screenshot 2024-10-18 at 16 13 12" src="https://github.com/user-attachments/assets/8ec11b9f-33ef-4ffc-8757-901811a5bfa7">
