### PR TITLE
Dependabot for terraform provider updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+
+  # Manage dependencies for Terraform
+  - package-ecosystem: "terraform"
+    directory: "/modules/terraform/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - sumanthreddy29
+    reviewers:
+      - sumanthreddy29
+      - alyssa1303
+      - anson627
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-
-  # Maintain dependencies for Terraform
-  - package-ecosystem: "terraform"
-    directory: "/modules/terraform"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  # Maintain dependencies for Terraform
+  - package-ecosystem: "terraform"
+    directory: "/modules/terraform"
+    schedule:
+      interval: "daily"

--- a/modules/terraform/aws/main.tf
+++ b/modules/terraform/aws/main.tf
@@ -15,16 +15,6 @@ locals {
   all_vpcs           = { for network in var.network_config_list : network.vpc_name => module.virtual_network[network.role].vpc }
 }
 
-terraform {
-  required_version = ">=1.5.6"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "<= 5.38"
-    }
-  }
-}
-
 provider "aws" {
   region = local.region
 }

--- a/modules/terraform/aws/versions.tf
+++ b/modules/terraform/aws/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">=1.5.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "<= 5.38"
+    }
+  }
+}

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -34,16 +34,6 @@ locals {
   aks_cli_config_map = length(local.updated_aks_cli_config_list) == 0 ? { for aks in var.aks_cli_config_list : aks.role => aks } : { for aks in local.updated_aks_cli_config_list : aks.role => aks }
 }
 
-terraform {
-  required_version = ">=1.5.6"
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "<= 3.93.0"
-    }
-  }
-}
-
 provider "azurerm" {
   features {}
 }

--- a/modules/terraform/azure/versions.tf
+++ b/modules/terraform/azure/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">=1.5.6"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<= 3.93.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request includes several changes to the Terraform configuration and Dependabot settings. The most important changes involve managing dependencies for Terraform and restructuring the Terraform configuration files.

### Dependabot Configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R15): Added a new configuration to manage dependencies for Terraform, specifying the directory, schedule, assignees, reviewers, and open pull request limit.

### Terraform Configuration:

* [`modules/terraform/aws/main.tf`](diffhunk://#diff-4fa7e1512b9b19b6cf0ec7166bff84df309a63560e72e26b07a28e5f3fc0a086L18-L27): Removed the Terraform block that specifies the required version and providers.
* [`modules/terraform/aws/versions.tf`](diffhunk://#diff-9c29578937d87994f79600b40d6b6a0219023626d9f4b1f4a045091a2d60b278R1-R9): Added a new file to specify the Terraform required version and providers for AWS.
* [`modules/terraform/azure/main.tf`](diffhunk://#diff-0f7f598ee8901914ae02cf0a5c9c9c1237e1bbe208688856f72a3af4e1cc12bbL37-L46): Removed the Terraform block that specifies the required version and providers.
* [`modules/terraform/azure/versions.tf`](diffhunk://#diff-db80da69c1925b208c7e0de8f495645e88cce4aee7e92412bc60cd5aec7c4a06R1-R9): Added a new file to specify the Terraform required version and providers for Azure.