### PR TITLE
Add VPC-CNI addon as default to EKS

### DIFF
--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -4,35 +4,35 @@ locals {
   eks_node_group_map = { for node_group in var.eks_config.eks_managed_node_groups : node_group.name => node_group }
   karpenter_addons_map = {
     for addon in [
-      { name        = "vpc-cni",
-        policy_arns = ["AmazonEKS_CNI_Policy"],
-        configuration_values = jsonencode({
-          env = {
-            # Enable IPv4 prefix delegation to increase the number of available IP addresses on the provisioned EC2 nodes.
-            # This significantly increases number of pods that can be run per node. (see: https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/)
-            # Note: we've seen that it also prevents ENIs leak caused the issue: https://github.com/aws/amazon-vpc-cni-k8s/issues/608
-            ENABLE_PREFIX_DELEGATION = "true"
-            WARM_PREFIX_TARGET       = "1"
-
-            ADDITIONAL_ENI_TAGS = jsonencode(var.tags)
-          }
-        })
-      },
       { name = "kube-proxy" },
       { name = "coredns" }
-    ] : addon.name =>
-    {
-      name                 = addon.name
-      version              = lookup(addon, "version", null)
-      service_account      = lookup(addon, "service_account", null)
-      policy_arns          = lookup(addon, "policy_arns", []),
-      configuration_values = lookup(addon, "configuration_values", null)
-    } if var.eks_config.enable_karpenter
+    ] : addon.name => addon
+    if var.eks_config.enable_karpenter
   }
 
-  eks_addons_map         = { for addon in var.eks_config.eks_addons : addon.name => addon }
-  updated_eks_addons_map = merge(local.karpenter_addons_map, local.eks_addons_map)
-  policy_arns            = var.eks_config.policy_arns
+  vpc_cni_addon_map = {
+    "vpc-cni" = {
+      name        = "vpc-cni",
+      policy_arns = ["AmazonEKS_CNI_Policy"],
+      configuration_values = jsonencode({
+        env = {
+          # Enable IPv4 prefix delegation to increase the number of available IP addresses on the provisioned EC2 nodes.
+          # This significantly increases number of pods that can be run per node. (see: https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/)
+          # Note: we've seen that it also prevents ENIs leak caused the issue: https://github.com/aws/amazon-vpc-cni-k8s/issues/608
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
+
+          ADDITIONAL_ENI_TAGS = jsonencode(var.tags)
+        }
+      })
+    }
+  }
+
+  eks_config_addons_map = { for addon in var.eks_config.eks_addons : addon.name => addon }
+  # Add vpc-cni as default
+  eks_addons_map = merge(local.karpenter_addons_map, local.eks_config_addons_map, local.vpc_cni_addon_map) # note: the order matters (the later takes precedence)
+
+  policy_arns = var.eks_config.policy_arns
 }
 
 data "aws_subnets" "subnets" {
@@ -141,9 +141,9 @@ resource "aws_eks_node_group" "eks_managed_node_groups" {
 module "eks_addon" {
   source = "./addon"
 
-  count = length(local.updated_eks_addons_map) != 0 ? 1 : 0
+  count = length(local.eks_addons_map) != 0 ? 1 : 0
 
-  eks_addon_config_map      = local.updated_eks_addons_map
+  eks_addon_config_map      = local.eks_addons_map
   cluster_name              = aws_eks_cluster.eks.name
   cluster_oidc_provider_url = aws_eks_cluster.eks.identity[0].oidc[0].issuer
   tags                      = var.tags

--- a/scenarios/perf-eval/slo-n100p5000/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/slo-n100p5000/terraform-inputs/aws.tfvars
@@ -100,7 +100,6 @@ eks_config_list = [{
   ]
 
   eks_addons = [
-    { name = "vpc-cni", version = "v1.18.3-eksbuild.2", policy_arns = ["AmazonEKS_CNI_Policy"] },
     { name = "kube-proxy" },
     { name = "coredns" }
   ]


### PR DESCRIPTION
Use default settings for VPC-CNI add-on in all EKS scenarios to avoid ENI leaks