### PR TITLE
add stage for L4 vs. L7 proxy API server benchmark

### DIFF
--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -45,12 +45,12 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
   - stage: azure_eastus2_l4
-    subscription: b8ceb4e5-f05b-4562-a9f5-14acb1f24219
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:
           cloud: azure
+          subscription: b8ceb4e5-f05b-4562-a9f5-14acb1f24219
           regions:
             - eastus2
           engine: kperf
@@ -77,12 +77,12 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
   - stage: azure_eastus2_l7
-    subscription: c0d4b923-b5ea-4f8f-9b56-5390a9bf2248
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:
           cloud: azure
+          subscription: c0d4b923-b5ea-4f8f-9b56-5390a9bf2248
           regions:
             - eastus2
           engine: kperf

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -44,7 +44,40 @@ stages:
           timeout_in_minutes: 760
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2
+  - stage: azure_eastus2_l4
+    subscription: b8ceb4e5-f05b-4562-a9f5-14acb1f24219
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            podsize-10k:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=6114"
+            podsize-10k-exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=6114"
+            podsize-20k:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+            podsize-20k-exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+          engine_input:
+            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            benchmark_subcmd: node100_pod10k
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+          max_parallel: 2
+          timeout_in_minutes: 760
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: azure_eastus2_l7
+    subscription: c0d4b923-b5ea-4f8f-9b56-5390a9bf2248
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml


### PR DESCRIPTION
This pull request modifies the `pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml` file to add new stages and configurations for performance evaluation. The changes primarily focus on adding new stages (`azure_eastus2_l4` and `azure_eastus2_l7`) with specific parameters for benchmarking.

New stages and configurations:

* Added `azure_eastus2_l4` stage with specific subscription and job parameters, including cloud, regions, engine, topology, matrix configurations, and engine input.
* Added `azure_eastus2_l7` stage with a different subscription and job parameters similar to `azure_eastus2_l4`.