### PR TITLE
Remove Git Version checkout step

### DIFF
--- a/steps/setup-tests.yml
+++ b/steps/setup-tests.yml
@@ -22,9 +22,6 @@ parameters:
 
 steps:
 - script: |
-    git checkout $(SCENARIO_VERSION)
-  displayName: "Checkout Scenario Version"
-- script: |
     if [ -n "$RUN_ID" ]; then
       run_id=$RUN_ID
     else


### PR DESCRIPTION
This pull request includes a change to the `steps/setup-tests.yml` file to remove checkout step and streamline the setup process.

Codebase simplification:

* [`steps/setup-tests.yml`](diffhunk://#diff-2fb7bd760bef4b06cd3b760b759031d9f1608c6da4c53080ea2d714cfcec512cL24-L26): Removed the step to check out the scenario version, which is no longer needed.