### PR TITLE
Tag EKS cluster security Group

### DIFF
--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -100,6 +100,13 @@ resource "aws_eks_cluster" "eks" {
   )
 }
 
+resource "aws_ec2_tag" "cluster_security_group" {
+  for_each    = var.tags
+  resource_id = aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id
+  key         = each.key
+  value       = each.value
+}
+
 resource "aws_eks_node_group" "eks_managed_node_groups" {
 
   for_each = local.eks_node_group_map


### PR DESCRIPTION
This pull request introduces a new resource to tag the security group of an EKS cluster in the Terraform configuration. The most important change is the addition of the `aws_ec2_tag` resource to manage tags for the EKS cluster's security group.

New resource addition:

* [`modules/terraform/aws/eks/main.tf`](diffhunk://#diff-fd5dd7320a4e52fded4d41f24c016f50020f4b1ce1578d83fec5442c437e09ebR103-R109): Added `resource "aws_ec2_tag" "cluster_security_group"` to tag the EKS cluster's security group using the provided tags.