### PR TITLE
Add Azure network and public-ip module

### DIFF
--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -16,6 +16,8 @@ locals {
     "run_id"            = local.run_id
   }
 
+  network_config_map = { for network in var.network_config_list : network.role => network }
+
   updated_aks_config_list = length(var.aks_config_list) > 0 ? [
     for aks in var.aks_config_list : merge(
       aks,
@@ -51,6 +53,17 @@ locals {
 
 provider "azurerm" {
   features {}
+}
+
+module "virtual_network" {
+  for_each = local.network_config_map
+
+  source                 = "./network"
+  network_config         = each.value
+  resource_group_name    = local.run_id
+  location               = local.region
+  public_ips             = module.public_ips.pip_ids
+  tags                   = local.tags
 }
 
 module "aks" {

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -55,6 +55,14 @@ provider "azurerm" {
   features {}
 }
 
+module "public_ips" {
+  source                = "./public-ip"
+  resource_group_name   = local.run_id
+  location              = local.region
+  public_ip_config_list = var.public_ip_config_list
+  tags                  = local.tags
+}
+
 module "virtual_network" {
   for_each = local.network_config_map
 

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -66,12 +66,12 @@ module "public_ips" {
 module "virtual_network" {
   for_each = local.network_config_map
 
-  source                 = "./network"
-  network_config         = each.value
-  resource_group_name    = local.run_id
-  location               = local.region
-  public_ips             = module.public_ips.pip_ids
-  tags                   = local.tags
+  source              = "./network"
+  network_config      = each.value
+  resource_group_name = local.run_id
+  location            = local.region
+  public_ips          = module.public_ips.pip_ids
+  tags                = local.tags
 }
 
 module "aks" {

--- a/modules/terraform/azure/network/README.md
+++ b/modules/terraform/azure/network/README.md
@@ -9,13 +9,11 @@ This module provisions virtual networks in Azure. It allows you to create and co
 
 - **Description:** Name of the resource group where the virtual network will be created.
 - **Type:** String
-- **Default:** "rg"
 
 ### `location`
 
 - **Description:** Azure region where the virtual network will be deployed.
 - **Type:** String
-- **Default:** "eastus"
 
 ### `public_ips`
 
@@ -51,7 +49,6 @@ This module provisions virtual networks in Azure. It allows you to create and co
 ### `tags`
 
 - **Type:** Map of strings
-- **Default:** None
 
 ## Usage Example
 

--- a/modules/terraform/azure/network/README.md
+++ b/modules/terraform/azure/network/README.md
@@ -1,0 +1,158 @@
+# Azure Virtual Network Module
+
+This module provisions virtual networks in Azure. It allows you to create and configure virtual networks with customizable settings, including subnets, security groups, network interfaces (NICs), and NIC associations.
+
+
+## Input Variables
+
+### `resource_group_name`
+
+- **Description:** Name of the resource group where the virtual network will be created.
+- **Type:** String
+- **Default:** "rg"
+
+### `location`
+
+- **Description:** Azure region where the virtual network will be deployed.
+- **Type:** String
+- **Default:** "eastus"
+
+### `public_ips`
+
+- **Description:** Map of public IP names to IDs.
+- **Type:** Map of string
+- **Default:** {}
+
+### `accelerated_networking`
+
+- **Description:** Indicates whether accelerated networking is enabled.
+- **Type:** Boolean
+- **Default:** true
+
+### `network_config`
+
+- **Description:** Configuration for the virtual network.
+- **Type:** Object
+  - `role`: Role of the virtual network
+  - `vnet_name`: Name of the virtual network
+  - `vnet_address_space`: Address space of the virtual network
+  - `subnet`: List of subnets within the virtual network
+  - `network_security_group_name`: Name of the network security group
+  - `nic_public_ip_associations`: List of NIC public IP associations
+    - `nic_name`: Name of the NIC
+    - `subnet_name`: Name of the subnet
+    - `ip_configuration_name`: Name of the ip configuration
+    - `public_ip_name`: Name of the pip associated to this NIC
+    - `count`: Optional, copies of this nic association to make, with nic_name and public_ip_name acting as prefix
+  - `nsr_rules`: List of network security rules
+  - `nat_gateway_associations`: Optional list of NAT gateway associations
+- **Example:** Refer to your specific configuration
+
+### `tags`
+
+- **Type:** Map of strings
+- **Default:** None
+
+## Usage Example
+
+```hcl
+module "virtual_network" {
+  source = "./virtual-network"
+
+  resource_group_name = "my-rg"
+  location            = "West Europe"
+  public_ips = {
+    "public-ip-1" = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/public-ip-1"
+    "public-ip-2" = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/public-ip-2"
+  }
+  accelerated_networking = true
+  network_config = {
+    role               = "web"
+    vnet_name          = "web-vnet"
+    vnet_address_space = "10.0.0.0/16"
+    subnet = [
+      {
+        name                         = "web-subnet"
+        address_prefix               = "10.0.1.0/24"
+        service_endpoints            = ["Microsoft.Storage"]
+        pls_network_policies_enabled = true
+      }
+    ]
+    network_security_group_name = "web-nsg"
+    nic_public_ip_associations = [
+      {
+        nic_name              = "web-nic"
+        subnet_name           = "web-subnet"
+        ip_configuration_name = "web-ip-config"
+        public_ip_name        = "web-public-ip"
+        count                 = 1 # Optional. Will leave the definition unchanged if its 1, but if greater than 1 
+                                  # will create copies with nic_name web-nic-1 web-nic-2 etc 
+                                  # and public_ip_name web-public-ip-1 web-public-ip-2 etc
+      }
+    ]
+    nsr_rules = [
+      {
+        name                       = "web-nsr"
+        priority                   = 100
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "TCP"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      }
+    ]
+    nat_gateway_associations = [
+      {
+        nat_gateway_name = "web-nat-gw"
+        public_ip_name   = "web-nat-gw-public-ip"
+        subnet_name      = "web-subnet"
+      }
+    ]
+  }
+
+  tags = {
+    environment = "production"
+    project     = "example"
+  }
+}
+```
+
+# Virtual Network Module Outputs
+
+This module provides the following outputs:
+
+## `network_security_group_name`
+
+- **Description:** Name of the network security group associated with the virtual network.
+- **Type:** String
+- **Example:** "my-nsg"
+
+## `nics`
+
+- **Description:** Map of network interface controller (NIC) names to their IDs associated with the virtual network.
+- **Type:** Map
+- **Example:** `{ "nic1" => "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/nic1", "nic2" => "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/networkInterfaces/nic2" }`
+
+## `subnets`
+
+- **Description:** Map of subnet names to their IDs within the virtual network.
+- **Type:** Map
+- **Example:** `{ "subnet1" => "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/subnet1", "subnet2" => "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/subnet2" }`
+
+## `vnet_id`
+
+- **Description:** ID of the virtual network.
+- **Type:** String
+- **Example:** "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet"
+
+## Terraform Provider References
+
+### Resources
+
+- [azurerm_virtual_network Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network)
+- [azurerm_subnet Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)
+- [azurerm_network_security_group Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group)
+- [azurerm_subnet_network_security_group_association Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association)
+- [azurerm_network_interface Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface)

--- a/modules/terraform/azure/network/main.tf
+++ b/modules/terraform/azure/network/main.tf
@@ -1,0 +1,112 @@
+locals {
+  nsr_rules_map                = { for rule in var.network_config.nsr_rules : rule.name => rule }
+  nat_gateway_associations_map = var.network_config.nat_gateway_associations == null ? {} : { for nat in var.network_config.nat_gateway_associations : nat.nat_gateway_name => nat }
+  vnet_name                    = var.network_config.vnet_name
+  input_subnet_map             = { for subnet in var.network_config.subnet : subnet.name => subnet }
+  subnets_map                  = { for subnet in azurerm_subnet.subnets : subnet.name => subnet }
+  network_security_group_name  = var.network_config.network_security_group_name
+  expanded_nic_association_map = flatten([
+    for nic in var.network_config.nic_public_ip_associations : [
+      for i in range(var.nic_count_override > 0 ? var.nic_count_override : nic.count) : {
+        nic_name              = (var.nic_count_override > 0 ? var.nic_count_override : nic.count) > 1 ? "${nic.nic_name}-${i + 1}" : nic.nic_name
+        subnet_name           = nic.subnet_name
+        ip_configuration_name = nic.ip_configuration_name
+        public_ip_name        = (var.nic_count_override > 0 ? var.nic_count_override : nic.count) > 1 ? "${nic.public_ip_name}-${i + 1}" : nic.public_ip_name
+      }
+    ]
+  ])
+  nic_association_map = { for nic in local.expanded_nic_association_map : nic.nic_name => nic }
+  tags                = merge(var.tags, { "role" = var.network_config.role })
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = local.vnet_name
+  address_space       = [var.network_config.vnet_address_space]
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = local.tags
+}
+
+resource "azurerm_subnet" "subnets" {
+  for_each = local.input_subnet_map
+
+  name                                          = each.value.name
+  resource_group_name                           = var.resource_group_name
+  virtual_network_name                          = azurerm_virtual_network.vnet.name
+  address_prefixes                              = [each.value.address_prefix]
+  service_endpoints                             = each.value.service_endpoints != null ? each.value.service_endpoints : []
+  private_link_service_network_policies_enabled = each.value.pls_network_policies_enabled != null ? each.value.pls_network_policies_enabled : true
+  dynamic "delegation" {
+    for_each = each.value.delegations != null ? each.value.delegations : []
+    content {
+      name = delegation.value.name
+      service_delegation {
+        name    = delegation.value.service_delegation_name
+        actions = delegation.value.service_delegation_actions
+      }
+    }
+  }
+}
+
+
+resource "azurerm_network_security_group" "nsg" {
+  count               = local.network_security_group_name != "" ? 1 : 0
+  name                = local.network_security_group_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = local.tags
+}
+
+
+resource "azurerm_subnet_network_security_group_association" "subnet-nsg-associations" {
+  for_each = local.network_security_group_name != "" ? local.subnets_map : {}
+
+  subnet_id                 = each.value.id
+  network_security_group_id = azurerm_network_security_group.nsg[0].id
+}
+
+resource "azurerm_network_interface" "nic" {
+  for_each = local.nic_association_map
+
+  name                           = each.key
+  location                       = var.location
+  resource_group_name            = var.resource_group_name
+  accelerated_networking_enabled = var.accelerated_networking
+  tags                           = local.tags
+
+  ip_configuration {
+    name                          = each.value.ip_configuration_name
+    subnet_id                     = local.subnets_map[each.value.subnet_name].id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = each.value.public_ip_name != null ? var.public_ips[each.value.public_ip_name] : null
+  }
+}
+
+module "nsr" {
+  source   = "./network-security-rule"
+  for_each = local.nsr_rules_map
+
+  name                        = each.value.name
+  priority                    = each.value.priority
+  direction                   = each.value.direction
+  access                      = each.value.access
+  protocol                    = each.value.protocol
+  source_port_range           = each.value.source_port_range
+  destination_port_range      = each.value.destination_port_range
+  source_address_prefix       = each.value.source_address_prefix
+  destination_address_prefix  = each.value.destination_address_prefix
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.nsg[0].name
+}
+
+module "nat_gateway" {
+  source   = "./nat-gateway"
+  for_each = local.nat_gateway_associations_map
+
+  nat_gateway_name     = each.value.nat_gateway_name
+  location             = var.location
+  public_ip_address_id = var.public_ips[each.value.public_ip_name]
+  resource_group_name  = var.resource_group_name
+  subnet_id            = local.subnets_map[each.value.subnet_name].id
+  tags                 = local.tags
+}

--- a/modules/terraform/azure/network/main.tf
+++ b/modules/terraform/azure/network/main.tf
@@ -48,7 +48,6 @@ resource "azurerm_subnet" "subnets" {
   }
 }
 
-
 resource "azurerm_network_security_group" "nsg" {
   count               = local.network_security_group_name != "" ? 1 : 0
   name                = local.network_security_group_name
@@ -56,7 +55,6 @@ resource "azurerm_network_security_group" "nsg" {
   resource_group_name = var.resource_group_name
   tags                = local.tags
 }
-
 
 resource "azurerm_subnet_network_security_group_association" "subnet-nsg-associations" {
   for_each = local.network_security_group_name != "" ? local.subnets_map : {}

--- a/modules/terraform/azure/network/nat-gateway/README.md
+++ b/modules/terraform/azure/network/nat-gateway/README.md
@@ -8,13 +8,11 @@ This module provisions a NAT gateway in Azure. It allows you to create and confi
 
 - **Description:** Name of the resource group where the NAT gateway will be created.
 - **Type:** String
-- **Default:** "rg"
 
 ### `location`
 
 - **Description:** Azure region where the NAT gateway will be deployed.
 - **Type:** String
-- **Default:** "eastus"
 
 ### `nat_gateway_name`
 
@@ -34,7 +32,6 @@ This module provisions a NAT gateway in Azure. It allows you to create and confi
 ### `tags`
 
 - **Type:** Map of strings
-- **Default:** None
 
 ## Usage Example
 

--- a/modules/terraform/azure/network/nat-gateway/README.md
+++ b/modules/terraform/azure/network/nat-gateway/README.md
@@ -1,0 +1,64 @@
+# NAT Gateway Module
+
+This module provisions a NAT gateway in Azure. It allows you to create and configure a NAT gateway with customizable settings.
+
+## Input Variables
+
+### `resource_group_name`
+
+- **Description:** Name of the resource group where the NAT gateway will be created.
+- **Type:** String
+- **Default:** "rg"
+
+### `location`
+
+- **Description:** Azure region where the NAT gateway will be deployed.
+- **Type:** String
+- **Default:** "eastus"
+
+### `nat_gateway_name`
+
+- **Description:** Name of the NAT gateway.
+- **Type:** String
+
+### `subnet_id`
+
+- **Description:** ID of the subnet where the NAT gateway will be deployed.
+- **Type:** String
+
+### `public_ip_address_id`
+
+- **Description:** ID of the public IP address associated with the NAT gateway.
+- **Type:** String
+
+### `tags`
+
+- **Type:** Map of strings
+- **Default:** None
+
+## Usage Example
+
+```hcl
+module "nat_gateway" {
+  source = "./nat-gateway"
+
+  resource_group_name      = "my-rg"
+  location                 = "eastus"
+  nat_gateway_name         = "my-nat-gateway"
+  subnet_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet"
+  public_ip_address_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/my-public-ip"
+
+  tags = {
+    environment = "production"
+    project     = "example"
+  }
+}
+```
+
+## Terraform Provider References
+
+### Resources
+
+- [azurerm_nat_gateway Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway)
+- [azurerm_nat_gateway_public_ip_association Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association)
+- [azurerm_subnet_nat_gateway_association Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association)

--- a/modules/terraform/azure/network/nat-gateway/main.tf
+++ b/modules/terraform/azure/network/nat-gateway/main.tf
@@ -1,0 +1,18 @@
+resource "azurerm_nat_gateway" "nat_gateway" {
+  name                = var.nat_gateway_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku_name            = "Standard"
+
+  tags = var.tags
+}
+
+resource "azurerm_nat_gateway_public_ip_association" "ipng" {
+  nat_gateway_id       = azurerm_nat_gateway.nat_gateway.id
+  public_ip_address_id = var.public_ip_address_id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "subnetng" {
+  subnet_id      = var.subnet_id
+  nat_gateway_id = azurerm_nat_gateway.nat_gateway.id
+}

--- a/modules/terraform/azure/network/nat-gateway/main.tf
+++ b/modules/terraform/azure/network/nat-gateway/main.tf
@@ -7,12 +7,12 @@ resource "azurerm_nat_gateway" "nat_gateway" {
   tags = var.tags
 }
 
-resource "azurerm_nat_gateway_public_ip_association" "ipng" {
+resource "azurerm_nat_gateway_public_ip_association" "nat_gateway_ip_association" {
   nat_gateway_id       = azurerm_nat_gateway.nat_gateway.id
   public_ip_address_id = var.public_ip_address_id
 }
 
-resource "azurerm_subnet_nat_gateway_association" "subnetng" {
+resource "azurerm_subnet_nat_gateway_association" "nat_gateway_subnet_association" {
   subnet_id      = var.subnet_id
   nat_gateway_id = azurerm_nat_gateway.nat_gateway.id
 }

--- a/modules/terraform/azure/network/nat-gateway/variables.tf
+++ b/modules/terraform/azure/network/nat-gateway/variables.tf
@@ -1,13 +1,11 @@
 variable "resource_group_name" {
   description = "Value of the resource group name"
   type        = string
-  default     = "rg"
 }
 
 variable "location" {
   description = "Value of the location"
   type        = string
-  default     = "East US"
 }
 
 variable "nat_gateway_name" {
@@ -27,6 +25,4 @@ variable "public_ip_address_id" {
 
 variable "tags" {
   type = map(string)
-  default = {
-  }
 }

--- a/modules/terraform/azure/network/nat-gateway/variables.tf
+++ b/modules/terraform/azure/network/nat-gateway/variables.tf
@@ -1,0 +1,32 @@
+variable "resource_group_name" {
+  description = "Value of the resource group name"
+  type        = string
+  default     = "rg"
+}
+
+variable "location" {
+  description = "Value of the location"
+  type        = string
+  default     = "East US"
+}
+
+variable "nat_gateway_name" {
+  description = "Value of the nat gateway name"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Value of the subnet id"
+  type        = string
+}
+
+variable "public_ip_address_id" {
+  description = "Value of the public ip address id"
+  type        = string
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+  }
+}

--- a/modules/terraform/azure/network/network-security-rule/README.md
+++ b/modules/terraform/azure/network/network-security-rule/README.md
@@ -1,0 +1,86 @@
+# Network Security Rule Module
+
+This module provisions network security rules in Azure. It allows you to create and configure network security rules with customizable settings.
+
+## Input Variables
+
+### `name`
+
+- **Description:** Name for the network security rule.
+- **Type:** String
+
+### `priority`
+
+- **Description:** Priority for the network security rule.
+- **Type:** Number
+
+### `direction`
+
+- **Description:** Direction for the network security rule (Inbound/Outbound).
+- **Type:** String
+
+### `access`
+
+- **Description:** Access for the network security rule (Allow/Deny).
+- **Type:** String
+
+### `protocol`
+
+- **Description:** Protocol for the network security rule.
+- **Type:** String
+
+### `source_port_range`
+
+- **Description:** Source port range for the network security rule.
+- **Type:** String
+
+### `destination_port_range`
+
+- **Description:** Destination port range for the network security rule.
+- **Type:** String
+
+### `source_address_prefix`
+
+- **Description:** Source address prefix for the network security rule.
+- **Type:** String
+
+### `destination_address_prefix`
+
+- **Description:** Destination address prefix for the network security rule.
+- **Type:** String
+
+### `resource_group_name`
+
+- **Description:** Resource group name for the network security rule.
+- **Type:** String
+
+### `network_security_group_name`
+
+- **Description:** Network security group name for the network security rule.
+- **Type:** String
+
+## Usage Example
+
+```hcl
+module "network_security_rule" {
+  source = "./network-security-rule"
+
+  name                          = "my-nsr"
+  priority                      = 100
+  direction                     = "Inbound"
+  access                        = "Allow"
+  protocol                      = "TCP"
+  source_port_range             = "*"
+  destination_port_range        = "80"
+  source_address_prefix         = "*"
+  destination_address_prefix    = "*"
+  resource_group_name           = "my-rg"
+  network_security_group_name   = "my-nsg"
+}
+```
+
+## Terraform Provider References
+
+### Resources
+
+- [azurerm_network_security_rule Documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule)

--- a/modules/terraform/azure/network/network-security-rule/main.tf
+++ b/modules/terraform/azure/network/network-security-rule/main.tf
@@ -1,0 +1,14 @@
+
+resource "azurerm_network_security_rule" "nsr" {
+  name                        = var.name
+  priority                    = var.priority
+  direction                   = var.direction
+  access                      = var.access
+  protocol                    = var.protocol
+  source_port_range           = var.source_port_range
+  destination_port_range      = var.destination_port_range
+  source_address_prefix       = var.source_address_prefix
+  destination_address_prefix  = var.destination_address_prefix
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = var.network_security_group_name
+}

--- a/modules/terraform/azure/network/network-security-rule/main.tf
+++ b/modules/terraform/azure/network/network-security-rule/main.tf
@@ -1,4 +1,3 @@
-
 resource "azurerm_network_security_rule" "nsr" {
   name                        = var.name
   priority                    = var.priority

--- a/modules/terraform/azure/network/network-security-rule/variables.tf
+++ b/modules/terraform/azure/network/network-security-rule/variables.tf
@@ -1,0 +1,54 @@
+variable "name" {
+  description = "Name for the network security rule."
+  type        = string
+}
+
+variable "priority" {
+  description = "Priority for the network security rule."
+  type        = number
+}
+
+variable "direction" {
+  description = "Direction for the network security rule."
+  type        = string
+}
+
+variable "access" {
+  description = "Access for the network security rule."
+  type        = string
+}
+
+variable "protocol" {
+  description = "Protocol for the network security rule."
+  type        = string
+}
+
+variable "source_port_range" {
+  description = "Source port range for the network security rule."
+  type        = string
+}
+
+variable "destination_port_range" {
+  description = "Destination port range for the network security rule."
+  type        = string
+}
+
+variable "source_address_prefix" {
+  description = "Source address prefix for the network security rule."
+  type        = string
+}
+
+variable "destination_address_prefix" {
+  description = "Destination address prefix for the network security rule."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group name for the network security rule."
+  type        = string
+}
+
+variable "network_security_group_name" {
+  description = "Network security group name for the network security rule."
+  type        = string
+}

--- a/modules/terraform/azure/network/output.tf
+++ b/modules/terraform/azure/network/output.tf
@@ -1,0 +1,18 @@
+output "network_security_group_name" {
+  value = try(azurerm_network_security_group.nsg[0].name, "")
+}
+
+output "nics" {
+  description = "Map of the nics"
+  value       = { for nic in azurerm_network_interface.nic : nic.name => nic.id }
+}
+
+output "subnets" {
+  description = "Map of subnet names to subnet objects"
+  value       = { for subnet in azurerm_subnet.subnets : subnet.name => subnet.id }
+}
+
+output "vnet_id" {
+  description = "vnet id"
+  value       = azurerm_virtual_network.vnet.id
+}

--- a/modules/terraform/azure/network/variables.tf
+++ b/modules/terraform/azure/network/variables.tf
@@ -1,13 +1,11 @@
 variable "resource_group_name" {
   description = "Value of the resource group name"
   type        = string
-  default     = "rg"
 }
 
 variable "location" {
   description = "Value of the location"
   type        = string
-  default     = "East US"
 }
 
 variable "public_ips" {
@@ -64,11 +62,8 @@ variable "network_config" {
   })
 }
 
-
 variable "tags" {
   type = map(string)
-  default = {
-  }
 }
 
 variable "nic_count_override" {

--- a/modules/terraform/azure/network/variables.tf
+++ b/modules/terraform/azure/network/variables.tf
@@ -1,0 +1,78 @@
+variable "resource_group_name" {
+  description = "Value of the resource group name"
+  type        = string
+  default     = "rg"
+}
+
+variable "location" {
+  description = "Value of the location"
+  type        = string
+  default     = "East US"
+}
+
+variable "public_ips" {
+  description = "Map of public IP names to IDs"
+  type        = map(string)
+}
+
+variable "accelerated_networking" {
+  description = "Value of the accelerated networking"
+  type        = bool
+  default     = true
+}
+
+variable "network_config" {
+  type = object({
+    role               = string
+    vnet_name          = string
+    vnet_address_space = string
+    subnet = list(object({
+      name                         = string
+      address_prefix               = string
+      service_endpoints            = optional(list(string))
+      pls_network_policies_enabled = optional(bool)
+      delegations = optional(list(object({
+        name                       = string
+        service_delegation_name    = string
+        service_delegation_actions = list(string)
+      })))
+    }))
+    network_security_group_name = string
+    nic_public_ip_associations = list(object({
+      nic_name              = string
+      subnet_name           = string
+      ip_configuration_name = string
+      public_ip_name        = string
+      count                 = optional(number, 1)
+    }))
+    nsr_rules = list(object({
+      name                       = string
+      priority                   = number
+      direction                  = string
+      access                     = string
+      protocol                   = string
+      source_port_range          = string
+      destination_port_range     = string
+      source_address_prefix      = string
+      destination_address_prefix = string
+    }))
+    nat_gateway_associations = optional(list(object({
+      nat_gateway_name = string
+      public_ip_name   = string
+      subnet_name      = string
+    })))
+  })
+}
+
+
+variable "tags" {
+  type = map(string)
+  default = {
+  }
+}
+
+variable "nic_count_override" {
+  description = "value the number of modules to create, overrides tfvars definition if greater than 0"
+  type        = number
+  default     = 0
+}

--- a/modules/terraform/azure/public-ip/README.md
+++ b/modules/terraform/azure/public-ip/README.md
@@ -1,0 +1,66 @@
+# Azure Public IP Module
+
+This module provisions public IP addresses in Azure. It allows you to create one or more public IP addresses with customizable configurations.
+
+## Input Variables
+
+### `resource_group_name`
+
+- **Description:** Name of the resource group where the public IP address(es) will be created.
+- **Type:** String
+- **Default:** "cle-rg"
+
+### `location`
+
+- **Description:** Azure region where the public IP address(es) will be deployed.
+- **Type:** String
+- **Default:** "eastus"
+
+### `public_ip_config_list`
+
+- **Description:** Configuration for the public IP address(es).
+- **Type:** List of objects
+  - `name`: Name of the public IP address
+  - `allocation_method`: Allocation method for the public IP (optional, default: "Static")
+  - `sku`: SKU for the public IP (optional, default: "Standard")
+  - `zones`: Availability zones for the public IP (optional, default: [])
+  - `count`: Optional parameter to specify how many copies of the module to create, with the name acting as prefix
+- **Example:**
+  ```
+  public_ip_config_list = [
+    {
+      name              = "example-ip-1"
+      allocation_method = "Static"
+      sku               = "Standard"
+      zones             = ["1", "2"]
+    },
+    {
+      name              = "example-ip-copy"
+      allocation_method = "Dynamic"
+      sku               = "Basic"
+      count             = 2 # will copy this pip with names example-ip-copy-1 and example-ip-copy-2
+    }
+  ]
+
+#  Outputs
+
+This module provides the following outputs:
+
+## `pip_ids`
+
+- **Description:** IDs of the created public IP addresses.
+- **Type:** Map
+- **Example:**
+  ```hcl
+  {
+    "example-ip-1" = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cle-rg/providers/Microsoft.Network/publicIPAddresses/example-ip-1"
+    "example-ip-2" = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cle-rg/providers/Microsoft.Network/publicIPAddresses/example-ip-2"
+  }
+```
+
+## Terraform Provider References
+
+### Resources
+
+- [azurerm_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip)
+

--- a/modules/terraform/azure/public-ip/README.md
+++ b/modules/terraform/azure/public-ip/README.md
@@ -8,13 +8,11 @@ This module provisions public IP addresses in Azure. It allows you to create one
 
 - **Description:** Name of the resource group where the public IP address(es) will be created.
 - **Type:** String
-- **Default:** "cle-rg"
 
 ### `location`
 
 - **Description:** Azure region where the public IP address(es) will be deployed.
 - **Type:** String
-- **Default:** "eastus"
 
 ### `public_ip_config_list`
 

--- a/modules/terraform/azure/public-ip/main.tf
+++ b/modules/terraform/azure/public-ip/main.tf
@@ -1,0 +1,26 @@
+locals {
+  expanded_public_ip_config_list = flatten([
+    for ip in var.public_ip_config_list : [
+      for i in range(var.pip_count_override > 0 ? var.pip_count_override : ip.count) : {
+        name              = (var.pip_count_override > 0 ? var.pip_count_override : ip.count) > 1 ? "${ip.name}-${i + 1}" : ip.name
+        zones             = ip.zones
+        allocation_method = ip.allocation_method
+        sku               = ip.sku
+      }
+    ]
+  ])
+
+  public_ip_config_map = { for ip in local.expanded_public_ip_config_list : ip.name => ip }
+}
+
+resource "azurerm_public_ip" "pip" {
+  for_each = local.public_ip_config_map
+
+  name                = each.value.name
+  location            = var.location
+  zones               = each.value.zones
+  resource_group_name = var.resource_group_name
+  allocation_method   = each.value.allocation_method
+  sku                 = each.value.sku
+  tags                = var.tags
+}

--- a/modules/terraform/azure/public-ip/output.tf
+++ b/modules/terraform/azure/public-ip/output.tf
@@ -1,0 +1,3 @@
+output "pip_ids" {
+  value = { for ip in azurerm_public_ip.pip : ip.name => ip.id }
+}

--- a/modules/terraform/azure/public-ip/variables.tf
+++ b/modules/terraform/azure/public-ip/variables.tf
@@ -1,0 +1,34 @@
+variable "resource_group_name" {
+  description = "Value of the resource group name"
+  type        = string
+  default     = "cle-rg"
+}
+
+variable "location" {
+  description = "Value of the location"
+  type        = string
+  default     = "East US"
+}
+
+variable "public_ip_config_list" {
+  description = "Configuration for public Ip's."
+  type = list(object({
+    name              = string
+    count             = optional(number, 1)
+    allocation_method = optional(string, "Static")
+    sku               = optional(string, "Standard")
+    zones             = optional(list(string), [])
+  }))
+}
+
+variable "tags" {
+  type = map(string)
+  default = {
+  }
+}
+
+variable "pip_count_override" {
+  description = "value the number of modules to create, overrides tfvars definition if greater than 0"
+  type        = number
+  default     = 0
+}

--- a/modules/terraform/azure/public-ip/variables.tf
+++ b/modules/terraform/azure/public-ip/variables.tf
@@ -1,13 +1,11 @@
 variable "resource_group_name" {
   description = "Value of the resource group name"
   type        = string
-  default     = "cle-rg"
 }
 
 variable "location" {
   description = "Value of the location"
   type        = string
-  default     = "East US"
 }
 
 variable "public_ip_config_list" {
@@ -23,8 +21,6 @@ variable "public_ip_config_list" {
 
 variable "tags" {
   type = map(string)
-  default = {
-  }
 }
 
 variable "pip_count_override" {

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -53,6 +53,18 @@ variable "deletion_delay" {
   default     = "2h"
 }
 
+variable "public_ip_config_list" {
+  description = "A list of public IP names"
+  type = list(object({
+    name              = string
+    count             = optional(number, 1)
+    allocation_method = optional(string, "Static")
+    sku               = optional(string, "Standard")
+    zones             = optional(list(string), [])
+  }))
+  default = []
+}
+
 variable "network_config_list" {
   description = "Configuration for creating the server network."
   type = list(object({

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -53,6 +53,51 @@ variable "deletion_delay" {
   default     = "2h"
 }
 
+variable "network_config_list" {
+  description = "Configuration for creating the server network."
+  type = list(object({
+    role               = string
+    vnet_name          = string
+    vnet_address_space = string
+    subnet = list(object({
+      name                         = string
+      address_prefix               = string
+      service_endpoints            = optional(list(string))
+      pls_network_policies_enabled = optional(bool)
+      delegations = optional(list(object({
+        name                       = string
+        service_delegation_name    = string
+        service_delegation_actions = list(string)
+      })))
+    }))
+    network_security_group_name = string
+    nic_public_ip_associations = list(object({
+      nic_name              = string
+      subnet_name           = string
+      ip_configuration_name = string
+      public_ip_name        = string
+      count                 = optional(number, 1)
+    }))
+    nsr_rules = list(object({
+      name                       = string
+      priority                   = number
+      direction                  = string
+      access                     = string
+      protocol                   = string
+      source_port_range          = string
+      destination_port_range     = string
+      source_address_prefix      = string
+      destination_address_prefix = string
+    }))
+    nat_gateway_associations = optional(list(object({
+      nat_gateway_name = string
+      public_ip_name   = string
+      subnet_name      = string
+    })))
+  }))
+  default = []
+}
+
 variable "aks_config_list" {
   type = list(object({
     role        = string


### PR DESCRIPTION
Summary:
- The network is now required to configure custom vnet for large cluster. The current default value of vnet and subnet when creating a cluster can't support large ones.
- The public-ip module is required to move network module. Furthermore, public-ip module can be used to configure cluster with nat gateway as outbound type.