### PR TITLE
Update Extended Zone test scenario's deletion_delay to 1h

### DIFF
--- a/scenarios/perf-eval/apiserver-vn10pod100-EZ/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/apiserver-vn10pod100-EZ/terraform-inputs/azure.tfvars
@@ -1,6 +1,6 @@
 scenario_type  = "perf-eval"
 scenario_name  = "apiserver-vn10pod100-EZ"
-deletion_delay = "20h"
+deletion_delay = "1h"
 owner          = "aks"
 
 aks_config_list = [


### PR DESCRIPTION
The test pipeline finishes running within 1 hr, so updating the deletion delay to 1hr.