### PR TITLE
Add API server A/B testing json vs protobuf

### DIFF
--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
   - cron: "0 12 * * *"
-    displayName: "Daily noon build"
+    displayName: "Every Day at Noon"
     branches:
       include:
         - main
@@ -37,7 +37,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
+            runner_image: telescope.azurecr.io/oss/kperf:v0.1.56
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -70,14 +70,14 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_l7
+  - stage: azure_eastus2_l7_json
     dependsOn: []
     variables:
       - group: API-Server-L7-Config
@@ -90,34 +90,55 @@ stages:
           engine: kperf
           topology: kperf
           matrix:
-            podsize-10k-json:
+            podsize-10k:
               flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=6114 --content-type json"
-            podsize-10k-exempt-json:
+              extra_benchmark_subcmd_args: "--padding-bytes=6114"
+            podsize-10k-exempt:
               flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=6114 --content-type json"
-            podsize-20k-json:
+              extra_benchmark_subcmd_args: "--padding-bytes=6114"
+            podsize-20k:
               flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384 --content-type json"
-            podsize-20k-exempt-json:
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+            podsize-20k-exempt:
               flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384 --content-type json"
-            podsize-10k-protobuf:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=6114 --content-type protobuf"
-            podsize-10k-exempt-protobuf:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=6114 --content-type protobuf"
-            podsize-20k-protobuf:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384 --content-type protobuf"
-            podsize-20k-exempt-protobuf:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384 --content-type protobuf"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
             benchmark_subcmd: node100_pod10k
-            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192 --content-type json"
+          max_parallel: 2
+          timeout_in_minutes: 760
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: azure_eastus2_l7_protobuf
+    dependsOn: []
+    variables:
+      - group: API-Server-L7-Config
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            podsize-10k:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=6114"
+            podsize-10k-exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=6114"
+            podsize-20k:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+            podsize-20k-exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+          engine_input:
+            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
+            benchmark_subcmd: node100_pod10k
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192 --content-type protobuf"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -37,7 +37,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
-  - cron: "0 */4 * * *"
-    displayName: "Every 4 Hours"
+  - cron: "0 12 * * *"
+    displayName: "Daily noon build"
     branches:
       include:
         - main
@@ -90,18 +90,30 @@ stages:
           engine: kperf
           topology: kperf
           matrix:
-            podsize-10k:
+            podsize-10k-json:
               flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=6114"
-            podsize-10k-exempt:
+              extra_benchmark_subcmd_args: "--padding-bytes=6114 --content-type json"
+            podsize-10k-exempt-json:
               flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=6114"
-            podsize-20k:
+              extra_benchmark_subcmd_args: "--padding-bytes=6114 --content-type json"
+            podsize-20k-json:
               flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-            podsize-20k-exempt:
+              extra_benchmark_subcmd_args: "--padding-bytes=16384 --content-type json"
+            podsize-20k-exempt-json:
               flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384 --content-type json"
+            podsize-10k-protobuf:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=6114 --content-type protobuf"
+            podsize-10k-exempt-protobuf:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=6114 --content-type protobuf"
+            podsize-20k-protobuf:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384 --content-type protobuf"
+            podsize-20k-exempt-protobuf:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384 --content-type protobuf"
           engine_input:
             runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
             benchmark_subcmd: node100_pod10k

--- a/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -37,7 +37,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.56
+            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2

--- a/steps/engine/kperf/collect.yml
+++ b/steps/engine/kperf/collect.yml
@@ -8,6 +8,9 @@ parameters:
 - name: flowcontrol
   type: string
   default: "workload-low:1000"
+- name: extra_benchmark_subcmd_args
+  type: string
+  default: ""
 - name: region
   type: string
 

--- a/steps/engine/kperf/collect.yml
+++ b/steps/engine/kperf/collect.yml
@@ -20,11 +20,13 @@ steps:
     set -x
 
     cat ${TEST_RESULTS_DIR}/tmp_results.json \
-      | jq -c ".info += { flowcontrol: \"$FLOWCONTROL\"}" \
+      | jq -c ".info += { flowcontrol: \"$FLOWCONTROL\", subcmdArgs: \"$BENCHMARK_SUBCMD_ARGS\", extraArgs: \"$EXTRA_BENCHMARK_SUBCMD_ARGS\" }" \
       | jq -c ". += { timestamp: $(date -u +\"%Y-%m-%dT%H:%M:%SZ\") }" \
       | jq -c ". += { runID: \"$RUN_ID\", runURL: \"$RUN_URL\", cloud: $CLOUD_INFO}" > "${TEST_RESULTS_FILE}"
 
     cat $TEST_RESULTS_FILE | jq .
   env:
+    BENCHMARK_SUBCMD_ARGS: ${{ parameters.engine_input.benchmark_subcmd_args }}
+    EXTRA_BENCHMARK_SUBCMD_ARGS: ${{ parameters.extra_benchmark_subcmd_args }}
     FLOWCONTROL: ${{ parameters.flowcontrol }}
   displayName: "Collect Results"

--- a/steps/topology/kperf/collect-kperf.yml
+++ b/steps/topology/kperf/collect-kperf.yml
@@ -14,5 +14,6 @@ steps:
   parameters:
     cloud: ${{ parameters.cloud }}
     engine_input: ${{ parameters.engine_input }}
-    flowcontrol: $(flowcontrol) # should be defined by matrix
+    flowcontrol: $(flowcontrol)
+    extra_benchmark_subcmd_args: $(extra_benchmark_subcmd_args)
     region: ${{ parameters.regions[0] }}


### PR DESCRIPTION
This pull request includes several updates to the performance evaluation pipeline configuration, primarily focusing on scheduling, image version updates, and additional parameters for benchmarking. The most important changes include modifying the cron schedule, updating the runner image version, and adding new stages and parameters for more detailed benchmarking.

### Pipeline Configuration Updates:

* `pipelines/perf-eval/apiserver-benchmark-virtualnodes100-pods10k.yml`: 
  - Changed the cron schedule from every 4 hours to every day at noon.
  - Updated the `runner_image` version from `v0.1.5` to `v0.1.56` and `v0.1.6` in multiple stages. [[1]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454L40-R40) [[2]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454L73-R80) [[3]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454L106-R141)
  - Added new stages `azure_eastus2_l7_json` and `azure_eastus2_l7_protobuf` with specific configurations and parameters. [[1]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454L73-R80) [[2]](diffhunk://#diff-dbc4e7ba42f92265c77e27300cb0af9c3406ba8d59877581edf205e50c8ce454L106-R141)

### Parameter and Step Enhancements:

* `steps/engine/kperf/collect.yml`: 
  - Added a new parameter `extra_benchmark_subcmd_args` and updated the `jq` command to include this in the results. [[1]](diffhunk://#diff-98a6a17d0163183a4a6c134589abf063a41cbf4ebce69c3bb916a7aa0cfa27f9R11-R13) [[2]](diffhunk://#diff-98a6a17d0163183a4a6c134589abf063a41cbf4ebce69c3bb916a7aa0cfa27f9L23-R33)

* `steps/topology/kperf/collect-kperf.yml`: 
  - Included the new parameter `extra_benchmark_subcmd_args` in the step parameters.