### PR TITLE
Change region and add validation for node count for service churn test

### DIFF
--- a/pipelines/perf-eval/slo-servicediscovery.yml
+++ b/pipelines/perf-eval/slo-servicediscovery.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
-  - cron: "0 */6 * * *"
-    displayName: "Every 6 Hour"
+  - cron: "0 */12 * * *"
+    displayName: "Every 12 Hour"
     branches:
       include:
         - main
@@ -13,14 +13,14 @@ variables:
   SCENARIO_VERSION: main
 
 stages:
-  - stage: aws_eastus2
+  - stage: aws_eastus1
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:
           cloud: aws
           regions:
-            - us-east-2
+            - us-east-1
           engine: clusterloader2
           engine_input:
             image: "ghcr.io/azure/clusterloader2:v20241022"

--- a/steps/topology/service-churn/validate-resources.yml
+++ b/steps/topology/service-churn/validate-resources.yml
@@ -11,3 +11,6 @@ steps:
     parameters:
       role: slo
       region: ${{ parameters.regions[0] }}
+  - template: /steps/engine/clusterloader2/slo/validate.yml
+    parameters:
+      desired_nodes: 1006


### PR DESCRIPTION
Summary
- Update AWS region to us-east-1 and reduce frequency to avoid throttling
- Add validation for node count to ensure enough nodes are ready before starting the test. Otherwise, test will fail