### PR TITLE
Use Nitro-based instance type in AWS for SLO discovery

### DIFF
--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -23,6 +23,7 @@ locals {
         env = {
           # Enable IPv4 prefix delegation to increase the number of available IP addresses on the provisioned EC2 nodes.
           # This significantly increases number of pods that can be run per node. (see: https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/)
+          # Nodes must be AWS Nitro-based (see: https://docs.aws.amazon.com/ec2/latest/instancetypes/ec2-nitro-instances.html#nitro-instance-types)
           # Note: we've seen that it also prevents ENIs leak caused the issue: https://github.com/aws/amazon-vpc-cni-k8s/issues/608
           ENABLE_PREFIX_DELEGATION = "true"
           WARM_PREFIX_TARGET       = "1"

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
@@ -96,7 +96,7 @@ eks_config_list = [{
     {
       name           = "userpool0"
       ami_type       = "AL2_x86_64"
-      instance_types = ["m4.xlarge"]
+      instance_types = ["m5a.xlarge"]
       min_size       = 300
       max_size       = 300
       desired_size   = 300
@@ -113,7 +113,7 @@ eks_config_list = [{
     {
       name           = "userpool1"
       ami_type       = "AL2_x86_64"
-      instance_types = ["m4.xlarge"]
+      instance_types = ["m5a.xlarge"]
       min_size       = 300
       max_size       = 300
       desired_size   = 300
@@ -130,7 +130,7 @@ eks_config_list = [{
     {
       name           = "userpool2"
       ami_type       = "AL2_x86_64"
-      instance_types = ["m4.xlarge"]
+      instance_types = ["m5a.xlarge"]
       min_size       = 400
       max_size       = 400
       desired_size   = 400

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/azure.tfvars
@@ -58,7 +58,7 @@ aks_config_list = [
         min_count            = 300
         max_count            = 300
         auto_scaling_enabled = true
-        vm_size              = "Standard_D4_v3"
+        vm_size              = "Standard_D4_v5"
         max_pods             = 110
         node_taints          = ["slo=true:NoSchedule"]
         node_labels          = { "slo" = "true" }
@@ -69,7 +69,7 @@ aks_config_list = [
         min_count            = 300
         max_count            = 300
         auto_scaling_enabled = true
-        vm_size              = "Standard_D4_v3"
+        vm_size              = "Standard_D4_v5"
         max_pods             = 110
         node_taints          = ["slo=true:NoSchedule"]
         node_labels          = { "slo" = "true" }
@@ -80,7 +80,7 @@ aks_config_list = [
         min_count            = 400
         max_count            = 400
         auto_scaling_enabled = true
-        vm_size              = "Standard_D4_v3"
+        vm_size              = "Standard_D4_v5"
         max_pods             = 110
         node_taints          = ["slo=true:NoSchedule"]
         node_labels          = { "slo" = "true" }

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/azure.tfvars
@@ -58,7 +58,7 @@ aks_config_list = [
         min_count            = 300
         max_count            = 300
         auto_scaling_enabled = true
-        vm_size              = "Standard_D4_v5"
+        vm_size              = "Standard_D4_v3"
         max_pods             = 110
         node_taints          = ["slo=true:NoSchedule"]
         node_labels          = { "slo" = "true" }
@@ -69,7 +69,7 @@ aks_config_list = [
         min_count            = 300
         max_count            = 300
         auto_scaling_enabled = true
-        vm_size              = "Standard_D4_v5"
+        vm_size              = "Standard_D4_v3"
         max_pods             = 110
         node_taints          = ["slo=true:NoSchedule"]
         node_labels          = { "slo" = "true" }
@@ -80,7 +80,7 @@ aks_config_list = [
         min_count            = 400
         max_count            = 400
         auto_scaling_enabled = true
-        vm_size              = "Standard_D4_v5"
+        vm_size              = "Standard_D4_v3"
         max_pods             = 110
         node_taints          = ["slo=true:NoSchedule"]
         node_labels          = { "slo" = "true" }


### PR DESCRIPTION
Use Nitro instance in AWS to support Prefix delegation and prevent ec2 API throttling 