### PR TITLE
Set WARM_PREFIX_TARGET for Slo Svc Discovery equal to max Pods per Node

### DIFF
--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Terraform Test
         working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
-        run: terraform test -test-directory=tests
+        run: terraform test
 
   setup-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -59,6 +59,11 @@ jobs:
 
       - name: Terraform Lint Check
         run: tflint --recursive --config "$GITHUB_WORKSPACE/.tflint.hcl" --minimum-failure-severity=warning
+
+      - name: Terraform Test
+        working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
+        run: test -test-directory=tests
+
   setup-matrix:
     runs-on: ubuntu-latest
     name: Setup terraform plan matrix for test scenarios

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.5.6
+          terraform_version: 1.6.0
 
       - name: Terraform Format Check
         if: always()
@@ -63,8 +63,6 @@ jobs:
       - name: Terraform Test
         working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
         run: terraform test
-        with:
-          terraform_version: 1.6.0
 
   setup-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Terraform Test
         working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
-        run: test -test-directory=tests
+        run: terraform test -test-directory=tests
 
   setup-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Terraform Test
         working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
         run: terraform test
+        with:
+          terraform_version: 1.6.0
 
   setup-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Terraform Test
         working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
         run: terraform test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   setup-matrix:
     runs-on: ubuntu-latest

--- a/modules/terraform/aws/eks/README.md
+++ b/modules/terraform/aws/eks/README.md
@@ -70,6 +70,7 @@ To use the EKS module, follow these steps:
    - This configuration creates two addons related to storage.
    - service_account and policy_attachment_names are optional in general but some addons are required to have IAM permisson values. [Refer here](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html)
    - We can also provide the version of an addon we are created which is an optional input here.
+   - For VPC-CNI, a default configuration is used (see [main.tf](./main.tf)). Use vpc_cni_minimum_ip_target to set MINIMUM_IP_TARGET (default: "0")
    
 ## Terraform Provider References
 

--- a/modules/terraform/aws/eks/README.md
+++ b/modules/terraform/aws/eks/README.md
@@ -70,7 +70,7 @@ To use the EKS module, follow these steps:
    - This configuration creates two addons related to storage.
    - service_account and policy_attachment_names are optional in general but some addons are required to have IAM permisson values. [Refer here](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html)
    - We can also provide the version of an addon we are created which is an optional input here.
-   - For VPC-CNI, a default configuration is used (see [main.tf](./main.tf)). Use vpc_cni_minimum_ip_target to set MINIMUM_IP_TARGET (default: "0")
+   - For VPC-CNI, a default configuration is used (see [main.tf](./main.tf)). Use vpc_cni_warm_prefix_target to set WARM_PREFIX_TARGET (default: 1)
    
 ## Terraform Provider References
 

--- a/modules/terraform/aws/eks/addon/main.tf
+++ b/modules/terraform/aws/eks/addon/main.tf
@@ -67,7 +67,7 @@ resource "aws_eks_addon" "addon" {
   depends_on = [aws_iam_role_policy_attachment.addon_policy_attachments]
 }
 
-
+# tflint-ignore: terraform_unused_declarations # (variable used for unit tests)
 variable "addons" {
   type    = object({})
   default = {}

--- a/modules/terraform/aws/eks/addon/main.tf
+++ b/modules/terraform/aws/eks/addon/main.tf
@@ -66,3 +66,13 @@ resource "aws_eks_addon" "addon" {
 
   depends_on = [aws_iam_role_policy_attachment.addon_policy_attachments]
 }
+
+
+variable "addons" {
+  type    = object({})
+  default = {}
+}
+
+output "addons" {
+  value = aws_eks_addon.addon
+}

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -26,7 +26,11 @@ locals {
           # Nodes must be AWS Nitro-based (see: https://docs.aws.amazon.com/ec2/latest/instancetypes/ec2-nitro-instances.html#nitro-instance-types)
           # Note: we've seen that it also prevents ENIs leak caused the issue: https://github.com/aws/amazon-vpc-cni-k8s/issues/608
           ENABLE_PREFIX_DELEGATION = "true"
-          WARM_PREFIX_TARGET       = "1"
+
+          # Should set either WARM_PREFIX_TARGET or both MINIMUM_IP_TARGET and WARM_IP_TARGET (see: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/prefix-and-ip-target.md)
+          WARM_PREFIX_TARGET = var.eks_config.vpc_cni_minimum_ip_target == "0" ? "1" : "0"
+          MINIMUM_IP_TARGET  = var.eks_config.vpc_cni_minimum_ip_target
+          WARM_IP_TARGET     = var.eks_config.vpc_cni_minimum_ip_target != "0" ? "1" : "0"
 
           ADDITIONAL_ENI_TAGS = jsonencode(var.tags)
         }
@@ -250,4 +254,13 @@ resource "terraform_data" "install_cni_metrics_helper" {
       EOT
   }
   depends_on = [module.eks_addon]
+}
+
+variable "eks_addon" {
+  type    = object({})
+  default = {}
+}
+
+output "eks_addon" {
+  value = module.eks_addon
 }

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -28,9 +28,7 @@ locals {
           ENABLE_PREFIX_DELEGATION = "true"
 
           # Should set either WARM_PREFIX_TARGET or both MINIMUM_IP_TARGET and WARM_IP_TARGET (see: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/prefix-and-ip-target.md)
-          WARM_PREFIX_TARGET = var.eks_config.vpc_cni_minimum_ip_target == "0" ? "1" : "0"
-          MINIMUM_IP_TARGET  = var.eks_config.vpc_cni_minimum_ip_target
-          WARM_IP_TARGET     = var.eks_config.vpc_cni_minimum_ip_target != "0" ? "1" : "0"
+          WARM_PREFIX_TARGET = tostring(local.eks_config_addons_map["vpc-cni"].vpc_cni_warm_prefix_target)
 
           ADDITIONAL_ENI_TAGS = jsonencode(var.tags)
         }

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -256,6 +256,7 @@ resource "terraform_data" "install_cni_metrics_helper" {
   depends_on = [module.eks_addon]
 }
 
+# tflint-ignore: terraform_unused_declarations # (variable used for unit tests)
 variable "eks_addon" {
   type    = object({})
   default = {}

--- a/modules/terraform/aws/eks/variables.tf
+++ b/modules/terraform/aws/eks/variables.tf
@@ -52,7 +52,8 @@ variable "eks_config" {
         env = optional(map(string))
       }))
     }))
-    kubernetes_version = optional(string, null)
+    vpc_cni_minimum_ip_target = optional(string, "0")
+    kubernetes_version        = optional(string, null)
     auto_scaler_profile = optional(object({
       balance_similar_node_groups      = optional(bool, false)
       expander                         = optional(string, "random")

--- a/modules/terraform/aws/eks/variables.tf
+++ b/modules/terraform/aws/eks/variables.tf
@@ -51,9 +51,9 @@ variable "eks_config" {
       configuration_values = optional(object({
         env = optional(map(string))
       }))
+      vpc_cni_warm_prefix_target = optional(number, 1)
     }))
-    vpc_cni_minimum_ip_target = optional(string, "0")
-    kubernetes_version        = optional(string, null)
+    kubernetes_version = optional(string, null)
     auto_scaler_profile = optional(object({
       balance_similar_node_groups      = optional(bool, false)
       expander                         = optional(string, "random")

--- a/modules/terraform/aws/main.tf
+++ b/modules/terraform/aws/main.tf
@@ -48,3 +48,13 @@ module "eks" {
   tags       = local.tags
   depends_on = [module.virtual_network]
 }
+
+
+variable "eks" {
+  type    = object({})
+  default = {}
+}
+
+output "eks" {
+  value = module.eks
+} 

--- a/modules/terraform/aws/main.tf
+++ b/modules/terraform/aws/main.tf
@@ -50,6 +50,7 @@ module "eks" {
 }
 
 
+# tflint-ignore: terraform_unused_declarations # (variable used for unit tests)
 variable "eks" {
   type    = object({})
   default = {}

--- a/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
@@ -1,0 +1,145 @@
+
+variables {
+  scenario_type  = "perf-eval"
+  scenario_name  = "my_scenario"
+  deletion_delay = "2h"
+  owner          = "aks"
+  json_input = {
+    "run_id" : "123456789",
+    "region" : "us-east-1",
+    "creation_time" : "2024-11-12T16:39:54Z"
+  }
+
+  network_config_list = [
+    {
+      role           = "nap"
+      vpc_name       = "nap-vpc"
+      vpc_cidr_block = "10.0.0.0/16"
+      subnet = [
+        {
+          name                    = "nap-subnet"
+          cidr_block              = "10.0.32.0/19"
+          zone_suffix             = "a"
+          map_public_ip_on_launch = true
+        }
+      ]
+      security_group_name = "nap-sg"
+      route_tables = [
+        {
+          name       = "internet-rt"
+          cidr_block = "0.0.0.0/0"
+        }
+      ],
+      route_table_associations = [
+        {
+          name             = "nap-subnet-rt-assoc"
+          subnet_name      = "nap-subnet"
+          route_table_name = "internet-rt"
+        }
+      ]
+      sg_rules = {
+        ingress = []
+        egress = [
+          {
+            from_port  = 0
+            to_port    = 0
+            protocol   = "-1"
+            cidr_block = "0.0.0.0/0"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+run "valid_vpc_config_default" {
+
+  command = plan
+
+  variables {
+    eks_config_list = [{
+      role        = "nap"
+      eks_name    = "eks_name"
+      vpc_name    = "nap-vpc"
+      policy_arns = ["AmazonEKS_CNI_Policy"]
+      eks_managed_node_groups = [
+        {
+          name           = "my_scenario-ng"
+          ami_type       = "AL2_x86_64"
+          instance_types = ["m4.large"]
+          min_size       = 5
+          max_size       = 5
+          desired_size   = 5
+        }
+      ]
+      eks_addons = [{ name = "vpc-cni" }]
+    }]
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.ENABLE_PREFIX_DELEGATION == "true"
+    error_message = "Error ENABLE_PREFIX_DELEGATION expected value: 'true'"
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_PREFIX_TARGET == "1"
+    error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.MINIMUM_IP_TARGET == "0"
+    error_message = "Error MINIMUM_IP_TARGET expected value == '0'"
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_IP_TARGET == "0"
+    error_message = "Error WARM_IP_TARGET expected value == '0'"
+  }
+
+}
+
+run "valid_vpc_config_minimum_ip_target" {
+
+  command = plan
+
+  variables {
+    eks_config_list = [{
+      role        = "nap"
+      eks_name    = "eks_name"
+      vpc_name    = "nap-vpc"
+      policy_arns = ["AmazonEKS_CNI_Policy"]
+      eks_managed_node_groups = [
+        {
+          name           = "my_scenario-ng"
+          ami_type       = "AL2_x86_64"
+          instance_types = ["m5a.xlarge"]
+          min_size       = 5
+          max_size       = 5
+          desired_size   = 5
+        }
+      ]
+      eks_addons                = [{ name = "vpc-cni" }]
+      vpc_cni_minimum_ip_target = 50
+    }]
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.ENABLE_PREFIX_DELEGATION == "true"
+    error_message = "Error ENABLE_PREFIX_DELEGATION expected value: 'true'"
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_PREFIX_TARGET == "0"
+    error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.MINIMUM_IP_TARGET == var.eks_config_list[0].vpc_cni_minimum_ip_target
+    error_message = "Error MINIMUM_IP_TARGET expected value == var.vpc_cni_minimum_ip_target"
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_IP_TARGET == "1"
+    error_message = "Error WARM_IP_TARGET expected value == '1'"
+  }
+}

--- a/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
@@ -86,16 +86,6 @@ run "valid_vpc_config_default" {
     error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
   }
 
-  assert {
-    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.MINIMUM_IP_TARGET == "0"
-    error_message = "Error MINIMUM_IP_TARGET expected value == '0'"
-  }
-
-  assert {
-    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_IP_TARGET == "0"
-    error_message = "Error WARM_IP_TARGET expected value == '0'"
-  }
-
 }
 
 run "valid_vpc_config_minimum_ip_target" {
@@ -118,8 +108,10 @@ run "valid_vpc_config_minimum_ip_target" {
           desired_size   = 5
         }
       ]
-      eks_addons                = [{ name = "vpc-cni" }]
-      vpc_cni_minimum_ip_target = 50
+      eks_addons = [{
+        name                       = "vpc-cni"
+        vpc_cni_warm_prefix_target = 4
+      }]
     }]
   }
 
@@ -129,17 +121,7 @@ run "valid_vpc_config_minimum_ip_target" {
   }
 
   assert {
-    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_PREFIX_TARGET == "0"
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_PREFIX_TARGET == "4"
     error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
-  }
-
-  assert {
-    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.MINIMUM_IP_TARGET == var.eks_config_list[0].vpc_cni_minimum_ip_target
-    error_message = "Error MINIMUM_IP_TARGET expected value == var.vpc_cni_minimum_ip_target"
-  }
-
-  assert {
-    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_IP_TARGET == "1"
-    error_message = "Error WARM_IP_TARGET expected value == '1'"
   }
 }

--- a/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
@@ -88,7 +88,7 @@ run "valid_vpc_config_default" {
 
 }
 
-run "valid_vpc_config_minimum_ip_target" {
+run "valid_vpc_config_set" {
 
   command = plan
 
@@ -122,6 +122,42 @@ run "valid_vpc_config_minimum_ip_target" {
 
   assert {
     condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_PREFIX_TARGET == "4"
+    error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
+  }
+}
+
+run "valid_karpenter_set" {
+
+  command = plan
+
+  variables {
+    eks_config_list = [{
+      role        = "nap"
+      eks_name    = "eks_name"
+      vpc_name    = "nap-vpc"
+      policy_arns = ["AmazonEKS_CNI_Policy"]
+      eks_managed_node_groups = [
+        {
+          name           = "my_scenario-ng"
+          ami_type       = "AL2_x86_64"
+          instance_types = ["m5a.xlarge"]
+          min_size       = 5
+          max_size       = 5
+          desired_size   = 5
+        }
+      ]
+      enable_karpenter = true
+      eks_addons       = []
+    }]
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.ENABLE_PREFIX_DELEGATION == "true"
+    error_message = "Error ENABLE_PREFIX_DELEGATION expected value: 'true'"
+  }
+
+  assert {
+    condition     = jsondecode(module.eks["eks_name"].eks_addon[0].addons.vpc-cni.configuration_values).env.WARM_PREFIX_TARGET == "1"
     error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
   }
 }

--- a/modules/terraform/aws/variables.tf
+++ b/modules/terraform/aws/variables.tf
@@ -125,7 +125,8 @@ variable "eks_config_list" {
         env = optional(map(string))
       }))
     }))
-    kubernetes_version = optional(string, null)
+    vpc_cni_minimum_ip_target = optional(string, "0")
+    kubernetes_version        = optional(string, null)
     auto_scaler_profile = optional(object({
       balance_similar_node_groups      = optional(bool, false)
       expander                         = optional(string, "random")

--- a/modules/terraform/aws/variables.tf
+++ b/modules/terraform/aws/variables.tf
@@ -124,9 +124,9 @@ variable "eks_config_list" {
       configuration_values = optional(object({
         env = optional(map(string))
       }))
+      vpc_cni_warm_prefix_target = optional(number, 1)
     }))
-    vpc_cni_minimum_ip_target = optional(string, "0")
-    kubernetes_version        = optional(string, null)
+    kubernetes_version = optional(string, null)
     auto_scaler_profile = optional(object({
       balance_similar_node_groups      = optional(bool, false)
       expander                         = optional(string, "random")

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
@@ -146,11 +146,13 @@ eks_config_list = [{
     }
   ]
 
+  # Set IP target to max number of Pods per Node (58 for m5a.xlarge) + 2 for extras
+  vpc_cni_minimum_ip_target = "60"
+
   eks_addons = [
     { name = "vpc-cni" },
     { name = "kube-proxy" },
     { name = "coredns" }
   ]
   kubernetes_version = "1.30"
-  vpc_cni_minimum_ip_target = "58"  # Set IP target to max number of Pods per Node (58 for m5a.xlarge)
 }]

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
@@ -152,4 +152,5 @@ eks_config_list = [{
     { name = "coredns" }
   ]
   kubernetes_version = "1.30"
+  vpc_cni_minimum_ip_target = "58"  # Set IP target to max number of Pods per Node (58 for m5a.xlarge)
 }]

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
@@ -146,11 +146,11 @@ eks_config_list = [{
     }
   ]
 
-  # Set IP target to max number of Pods per Node (58 for m5a.xlarge) + 2 for extras
-  vpc_cni_minimum_ip_target = "60"
-
   eks_addons = [
-    { name = "vpc-cni" },
+    {
+      name                       = "vpc-cni",
+      vpc_cni_warm_prefix_target = 4 # 64 IPs to accomodate 58 Pods (max for m5a.xlarge) + 2 for extras
+    },
     { name = "kube-proxy" },
     { name = "coredns" }
   ]


### PR DESCRIPTION
Set WARM_PREFIX_TARGET for Slo Svc Discovery equal to max Pods per Node to prevent throttling for ec2 API AssignPrivateIpAddresses.

- Add parameter to EKS configuration to set the WARM_PREFIX_TARGET
- Add unit tests for VPC config (test it locally with: `terraform test`)

