### PR TITLE
Show warning message if deletion due time is in the past

### DIFF
--- a/modules/terraform/aws/main.tf
+++ b/modules/terraform/aws/main.tf
@@ -32,7 +32,7 @@ provider "aws" {
 check "deletion_due_time" {
   assert {
     condition     = timecmp(local.non_computed_tags.deletion_due_time, plantimestamp()) > 0
-    error_message = "Deletion due time is in the past: ${local.non_computed_tags.deletion_due_time}. This might result in the deletion of resources currenty in use. To resolve it, update the creation_tim (${local.creation_time}) to current time"
+    error_message = "Deletion due time is in the past: ${local.non_computed_tags.deletion_due_time}. This might result in the deletion of resources currenty in use. To resolve it, update the creation_time (${local.creation_time}) to current time"
   }
 }
 

--- a/modules/terraform/aws/main.tf
+++ b/modules/terraform/aws/main.tf
@@ -29,6 +29,13 @@ provider "aws" {
   }
 }
 
+check "deletion_due_time" {
+  assert {
+    condition     = timecmp(local.non_computed_tags.deletion_due_time, plantimestamp()) > 0
+    error_message = "Deletion due time is in the past: ${local.non_computed_tags.deletion_due_time}. This might result in the deletion of resources currenty in use. To resolve it, update the creation_tim (${local.creation_time}) to current time"
+  }
+}
+
 module "virtual_network" {
   for_each = local.network_config_map
 

--- a/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
@@ -7,7 +7,7 @@ variables {
   json_input = {
     "run_id" : "123456789",
     "region" : "us-east-1",
-    "creation_time" : "2024-11-12T16:39:54Z"
+    "creation_time" : timestamp()
   }
 
   network_config_list = [

--- a/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
@@ -7,7 +7,7 @@ variables {
   json_input = {
     "run_id" : "123456789",
     "region" : "us-east-1",
-    "creation_time" : timestamp()
+    "creation_time" : "2024-11-12T16:39:54Z"
   }
 
   network_config_list = [
@@ -86,6 +86,8 @@ run "valid_vpc_config_default" {
     error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
   }
 
+  expect_failures = [check.deletion_due_time]
+
 }
 
 run "valid_vpc_config_set" {
@@ -124,6 +126,8 @@ run "valid_vpc_config_set" {
     condition     = jsondecode(module.eks["eks_name"].eks_addon.before_compute.vpc-cni.configuration_values).env.WARM_PREFIX_TARGET == "4"
     error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
   }
+
+  expect_failures = [check.deletion_due_time]
 }
 
 run "valid_karpenter_set" {
@@ -160,6 +164,8 @@ run "valid_karpenter_set" {
     condition     = jsondecode(module.eks["eks_name"].eks_addon.before_compute.vpc-cni.configuration_values).env.WARM_PREFIX_TARGET == "1"
     error_message = "Error WARM_PREFIX_TARGET expected value: '1'"
   }
+
+  expect_failures = [check.deletion_due_time]
 }
 
 run "valid_add_after_before_compute" {
@@ -203,4 +209,6 @@ run "valid_add_after_before_compute" {
     condition     = contains(keys(module.eks["eks_name"].eks_addon.before_compute), "addon_before_compute")
     error_message = "Error addon should be created before compute"
   }
+
+  expect_failures = [check.deletion_due_time]
 }


### PR DESCRIPTION
Note: this check does not fail the provisioning. It shows the warning message if the condition is false, and ask to confirm to continue. If terraform is run with `--auto-approve` the check only shows the warning message, but doesn't ask to confirm to continue.

Output:
```
Plan: 31 to add, 2 to change, 0 to destroy.
╷
│ Warning: Check block assertion failed
│ 
│   on main.tf line 34, in check "certificate":
│   34:     condition     = timecmp(local.non_computed_tags.deletion_due_time , plantimestamp()) > 0
│     ├────────────────
│     │ local.non_computed_tags.deletion_due_time is "2024-11-12T18:39:54Z"
│ 
│ Deletion due time is in the past: 2024-11-12T18:39:54Z. This might result in the deletion of resources currenty in use. To resolve it, update the creation_time (2024-11-12T16:39:54Z) to current time
```