### PR TITLE
Add launch template resource to EKS node groups with default tags

### DIFF
--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -158,7 +158,7 @@ resource "aws_ec2_tag" "cluster_security_group" {
 resource "aws_launch_template" "launch_template" {
   for_each = local.eks_node_group_map
 
-  name = "eks-${aws_eks_cluster.eks.name}"
+  name = "eks-${each.value.name}"
 
   tag_specifications {
     resource_type = "instance"

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -155,6 +155,19 @@ resource "aws_ec2_tag" "cluster_security_group" {
   value       = each.value
 }
 
+resource "aws_launch_template" "launch_template" {
+  for_each = local.eks_node_group_map
+
+  name = "eks-${aws_eks_cluster.eks.name}"
+
+  tag_specifications {
+    resource_type = "instance"
+    tags          = var.tags
+  }
+
+  tags = var.tags
+}
+
 resource "aws_eks_node_group" "eks_managed_node_groups" {
 
   for_each = local.eks_node_group_map
@@ -183,6 +196,11 @@ resource "aws_eks_node_group" "eks_managed_node_groups" {
   instance_types = each.value.instance_types
   capacity_type  = each.value.capacity_type
   labels         = each.value.labels
+
+  launch_template {
+    id      = aws_launch_template.launch_template[each.key].id
+    version = aws_launch_template.launch_template[each.key].latest_version
+  }
 
   tags = {
     "Name" = each.value.name

--- a/modules/terraform/aws/eks/output.tf
+++ b/modules/terraform/aws/eks/output.tf
@@ -18,3 +18,7 @@ output "eks_addon" {
     before_compute : aws_eks_addon.before_compute
   }
 }
+
+output "eks_node_groups_launch_template" {
+  value = aws_launch_template.launch_template
+}

--- a/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
@@ -56,7 +56,7 @@ variables {
     vpc_name    = "nap-vpc"
     policy_arns = ["AmazonEKS_CNI_Policy"]
     eks_managed_node_groups = [
-    {
+      {
         name           = "my_scenario-ng"
         ami_type       = "AL2_x86_64"
         instance_types = ["m4.large"]
@@ -64,7 +64,7 @@ variables {
         max_size       = 5
         desired_size   = 5
     }]
-    eks_addons = []     
+    eks_addons = []
   }]
 }
 

--- a/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
@@ -1,0 +1,86 @@
+variables {
+  scenario_type  = "perf-eval"
+  scenario_name  = "my_scenario"
+  deletion_delay = "2h"
+  owner          = "aks"
+  json_input = {
+    "run_id" : "123456789",
+    "region" : "us-east-1",
+    "creation_time" : "2024-11-12T16:39:54Z"
+  }
+
+  network_config_list = [
+    {
+      role           = "nap"
+      vpc_name       = "nap-vpc"
+      vpc_cidr_block = "10.0.0.0/16"
+      subnet = [
+        {
+          name                    = "nap-subnet"
+          cidr_block              = "10.0.32.0/19"
+          zone_suffix             = "a"
+          map_public_ip_on_launch = true
+        }
+      ]
+      security_group_name = "nap-sg"
+      route_tables = [
+        {
+          name       = "internet-rt"
+          cidr_block = "0.0.0.0/0"
+        }
+      ],
+      route_table_associations = [
+        {
+          name             = "nap-subnet-rt-assoc"
+          subnet_name      = "nap-subnet"
+          route_table_name = "internet-rt"
+        }
+      ]
+      sg_rules = {
+        ingress = []
+        egress = [
+          {
+            from_port  = 0
+            to_port    = 0
+            protocol   = "-1"
+            cidr_block = "0.0.0.0/0"
+          }
+        ]
+      }
+    }
+  ]
+
+  eks_config_list = [{
+    role        = "nap"
+    eks_name    = "eks_name"
+    vpc_name    = "nap-vpc"
+    policy_arns = ["AmazonEKS_CNI_Policy"]
+    eks_managed_node_groups = [
+    {
+        name           = "my_scenario-ng"
+        ami_type       = "AL2_x86_64"
+        instance_types = ["m4.large"]
+        min_size       = 5
+        max_size       = 5
+        desired_size   = 5
+    }]
+    eks_addons = []     
+  }]
+}
+
+run "valid_launch_template_required_tags" {
+
+  command = plan
+
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng"].tag_specifications[0].tags.owner == var.owner
+    error_message = "Error. Expected owner ('${var.owner}') in the launch template tag specifications"
+  }
+
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng"].tag_specifications[0].tags.deletion_due_time == timeadd(var.json_input.creation_time, var.deletion_delay)
+    error_message = "Error. Expected deletion_due_time in the launch template tag specifications"
+  }
+
+  expect_failures = [check.deletion_due_time]
+}


### PR DESCRIPTION
The goal of this change is to add the required tags (i.e. owner and deletion_due_time) to ec2 instances created by the EKS cluster.

Note: AWS does not recommend to update the default launch template created by EKS when no custom launch template is provided: 

> When you don’t provide a launch template, the Amazon EKS API creates one automatically with default values in your account. However, we don’t recommend that you modify auto-generated launch templates. Furthermore, existing node groups that don’t use a custom launch template can’t be updated directly. Instead, you must create a new node group with a custom launch template to do so

https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html