### PR TITLE
Fix collection step for PodStartUp measurement

### DIFF
--- a/modules/python/clusterloader2/slo/config/modules/measurements.yaml
+++ b/modules/python/clusterloader2/slo/config/modules/measurements.yaml
@@ -16,13 +16,13 @@
 steps:
   - name: {{$action}} Additional Measurements
     measurements:
-      - Identifier: APIResponsivenessPrometheusSimple
+      - Identifier: APIResponsivenessPrometheus
         Method: APIResponsivenessPrometheus
         Params:
           action: {{$action}}
           enableViolations: {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE}}
           useSimpleLatencyQuery: true
-      - Identifier: CreatePhasePodStartupLatency
+      - Identifier: PodStartupLatency
         Method: PodStartupLatency
         Params:
           action: {{$action}}

--- a/modules/python/clusterloader2/slo/slo.py
+++ b/modules/python/clusterloader2/slo/slo.py
@@ -146,6 +146,7 @@ def collect_clusterloader2(
     for f in os.listdir(cl2_report_dir):
         file_path = os.path.join(cl2_report_dir, f)
         with open(file_path, 'r') as f:
+            print(f"Processing {file_path}")
             measurement, group_name = get_measurement(file_path)
             if not measurement:
                 continue


### PR DESCRIPTION
Identifier name was changed in previous [PR](https://github.com/Azure/telescope/pull/389), which led to PodStartUpLatency measurement not being collected. Suspecting service churn pipeline has had this same issue from the beginning because originally, only service churn use `measurement` module.