### PR TITLE
drop test details to save data storage and ingestion

### DIFF
--- a/modules/python/clusterloader2/autoscale/autoscale.py
+++ b/modules/python/clusterloader2/autoscale/autoscale.py
@@ -57,11 +57,11 @@ def collect_clusterloader2(
                 index = match.group()
                 if index not in summary:
                     summary[index] = {
-                        "up": { "failures": 0 }, 
+                        "up": { "failures": 0 },
                         "down": { "failures": 0 }
                     }
             else:
-                continue 
+                continue
 
             failure = testcase["failure"]
             if "WaitForRunningPodsUp" in name:
@@ -76,7 +76,7 @@ def collect_clusterloader2(
             elif "WaitForNodesDown" in name:
                 summary[index]["down"]["wait_for_nodes_seconds"] = -1 if failure else testcase["time"]
                 summary[index]["down"]["failures"] += 1 if failure else 0
-        
+
         content = ""
         for index in summary:
             for key in summary[index]:
@@ -85,6 +85,7 @@ def collect_clusterloader2(
                     "wait_for_pods_seconds": summary[index][key]["wait_for_pods_seconds"],
                     "autoscale_result": "success" if summary[index][key]["failures"] == 0 else "failure"
                 }
+                # TODO: Expose optional parameter to include test details
                 result = {
                     "timestamp": datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
                     "autoscale_type": key,
@@ -92,7 +93,7 @@ def collect_clusterloader2(
                     "node_count": node_count,
                     "pod_count": pod_count,
                     "data": data,
-                    "raw_data": raw_data,
+                    # "raw_data": raw_data,
                     "cloud_info": cloud_info,
                     "run_id": run_id,
                     "run_url": run_url

--- a/modules/python/clusterloader2/slo/slo.py
+++ b/modules/python/clusterloader2/slo/slo.py
@@ -131,6 +131,7 @@ def collect_clusterloader2(
     _, _, pods_per_node, _ = calculate_config(cpu_per_node, node_count, provider, service_test)
     pod_count = node_count * pods_per_node
 
+    # TODO: Expose optional parameter to include test details
     template = {
         "timestamp": datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
         "cpu_per_node": cpu_per_node,
@@ -141,7 +142,7 @@ def collect_clusterloader2(
         "group": None,
         "measurement": None,
         "result": None,
-        "test_details": details,
+        # "test_details": details,
         "cloud_info": cloud_info,
         "run_id": run_id,
         "run_url": run_url,


### PR DESCRIPTION
This pull request includes changes to the `collect_clusterloader2` function in two files to comment out the `raw_data` and `test_details` fields and add TODO comments for exposing optional parameters to include test details.

Changes to `collect_clusterloader2` function:

* [`modules/python/clusterloader2/autoscale/autoscale.py`](diffhunk://#diff-5530514663087773f33c840035ed1b545b1a18a575e0c3e61a222ffca7ee53c8R88-R96): Commented out the `raw_data` field and added a TODO comment to expose an optional parameter to include test details.
* [`modules/python/clusterloader2/slo/slo.py`](diffhunk://#diff-2594888ced631a2698e425dee445068b1b8480a8761e0250ca693e842ddb1d30R134): Commented out the `test_details` field and added a TODO comment to expose an optional parameter to include test details. [[1]](diffhunk://#diff-2594888ced631a2698e425dee445068b1b8480a8761e0250ca693e842ddb1d30R134) [[2]](diffhunk://#diff-2594888ced631a2698e425dee445068b1b8480a8761e0250ca693e842ddb1d30L144-R145)