### PR TITLE
Collect timestamp and add metadata only when results file exists

### DIFF
--- a/steps/collect-telescope-metadata.yml
+++ b/steps/collect-telescope-metadata.yml
@@ -73,11 +73,15 @@ steps:
     REGIONS: ${{ convertToJson(parameters.regions) }}
 
 - script: |
-    # Read the test results file and add the telescope metadata to it for each json record in the file
+    # Add telescope metadata to each JSON record in the test results file if it exists
     set -eux
-    jq --argfile telescope_metadata $(TELESCOPE_METADATA_FILE) \
+    if [ -f "$(TEST_RESULTS_FILE)" ]; then
+      jq --argfile telescope_metadata $(TELESCOPE_METADATA_FILE) \
       -c '. + {telescope_metadata: $telescope_metadata}' $(TEST_RESULTS_FILE) > temp-$RUN_ID.json \
-       && mv temp-$RUN_ID.json $(TEST_RESULTS_FILE)
+      && mv temp-$RUN_ID.json $(TEST_RESULTS_FILE)
+    else
+      echo "File $(TEST_RESULTS_FILE) does not exist."
+    fi
   displayName: "Add Telescope Metadata to Test Results"
   condition: always()
 

--- a/steps/collect-telescope-metadata.yml
+++ b/steps/collect-telescope-metadata.yml
@@ -23,7 +23,7 @@ steps:
       --arg requester "$(Build.RequestedFor)" \
       --arg scenario_name "$SCENARIO_NAME" \
       --arg scenario_type "$SCENARIO_TYPE" \
-      --arg owner ${OWNER//\"/} \
+      --arg owner $OWNER \
       --arg engine "$ENGINE" \
       --arg topology "$TOPOLOGY" \
       --arg engine_input "$(echo $ENGINE_INPUT | jq -r '.')" \

--- a/steps/collect-telescope-metadata.yml
+++ b/steps/collect-telescope-metadata.yml
@@ -17,12 +17,13 @@ steps:
       --arg run_id $RUN_ID \
       --arg run_url  $RUN_URL \
       --arg code_url  $CODE_URL \
+      --arg time_stamp "$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")" \
       --arg reason "$(Build.Reason)" \
       --arg pipeline_branch "$(Build.SourceBranchName)" \
       --arg requester "$(Build.RequestedFor)" \
       --arg scenario_name "$SCENARIO_NAME" \
       --arg scenario_type "$SCENARIO_TYPE" \
-      --arg owner $OWNER \
+      --arg owner ${OWNER//\"/} \
       --arg engine "$ENGINE" \
       --arg topology "$TOPOLOGY" \
       --arg engine_input "$(echo $ENGINE_INPUT | jq -r '.')" \
@@ -43,7 +44,8 @@ steps:
             pipeline_name: $pipeline_name,
             cron_schedule_display_name: $cron_schedule_display_name,
             project_name: $project_name,
-            code_url: $code_url
+            code_url: $code_url,
+            time_stamp: $time_stamp
           },
           scenario_info: {
             scenario_name: $scenario_name,


### PR DESCRIPTION
This pull request includes changes to the `steps/collect-telescope-metadata.yml` file to enhance the metadata collection and error handling process. The most important changes are:

Enhancements to metadata collection:

* Added a new `time_stamp` argument to capture the current UTC time in a specific format.
* Included the `time_stamp` in the JSON payload for metadata.

Error handling improvements:

* Added a conditional check to ensure the test results file exists before attempting to add telescope metadata to it. If the file does not exist, an appropriate message is logged.

Code cleanup:

* Modified the `owner` argument to remove any double quotes from its value.