### PR TITLE
Use kperf github package

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100-EZ.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100-EZ.yml
@@ -32,7 +32,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.3
+            runner_image: ghcr.io/azure/kperf:v0.1.3
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 1

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
@@ -33,7 +33,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:v0.1.5
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2
@@ -60,7 +60,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               sku_tier: Free
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:v0.1.5
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2
@@ -87,7 +87,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               sku_tier: Standard
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:v0.1.5
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -37,7 +37,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
+            runner_image: ghcr.io/azure/kperf:v0.1.6
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -70,7 +70,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
+            runner_image: ghcr.io/azure/kperf:v0.1.6
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -103,7 +103,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
+            runner_image: ghcr.io/azure/kperf:v0.1.6
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192 --content-type json"
           max_parallel: 2
@@ -136,7 +136,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.6
+            runner_image: ghcr.io/azure/kperf:v0.1.6
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192 --content-type protobuf"
           max_parallel: 2

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -31,7 +31,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:v0.1.5
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2
@@ -56,7 +56,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: telescope.azurecr.io/oss/kperf:v0.1.5
+            runner_image: ghcr.io/azure/kperf:v0.1.5
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2


### PR DESCRIPTION
This pull request includes changes to update the `runner_image` references in various YAML files under the `pipelines/perf-eval/API Server Benchmark` directory. The updates are primarily focused on changing the image source from `telescope.azurecr.io` to `ghcr.io`.

Updates to `runner_image` references:

* [`pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100-EZ.yml`](diffhunk://#diff-694ec8250ebe47292cfe5756d03e69e86d7c55fe0e8ce9aa6421d8c26729290dL35-R35): Updated `runner_image` to `ghcr.io/azure/kperf:v0.1.3`.
* [`pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml`](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67L36-R36): Updated `runner_image` to `ghcr.io/azure/kperf:v0.1.5` [[1]](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67L36-R36) [[2]](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67L63-R63) [[3]](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67L90-R90).
* [`pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml`](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0L40-R40): Updated `runner_image` to `ghcr.io/azure/kperf:v0.1.6` [[1]](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0L40-R40) [[2]](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0L73-R73) [[3]](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0L106-R106) [[4]](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0L139-R139).
* [`pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml`](diffhunk://#diff-958ba5049aa0309c1f097c99a46cec23442642fa6c5643a30f40fa553e1999fcL34-R34): Updated `runner_image` to `ghcr.io/azure/kperf:v0.1.5` [[1]](diffhunk://#diff-958ba5049aa0309c1f097c99a46cec23442642fa6c5643a30f40fa553e1999fcL34-R34) [[2]](diffhunk://#diff-958ba5049aa0309c1f097c99a46cec23442642fa6c5643a30f40fa553e1999fcL59-R59).