### PR TITLE
feat: setup recurring runs for cilium nodesubnet

### DIFF
--- a/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
-  - cron: "0 6,18 * * *"
-    displayName: "6:00 AM & PM Daily"
+  - cron: "0 10,22 * * *"
+    displayName: "10:00 AM & PM Daily"
     branches:
       include:
         - main

--- a/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
@@ -1,0 +1,44 @@
+trigger: none
+schedules:
+  - cron: "0 6,18 * * *"
+    displayName: "6:00 AM & PM Daily"
+    branches:
+      include:
+        - main
+    always: true
+
+variables:
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: cilium-cluster-churn-cilium-nodesubnet
+  SCENARIO_VERSION: main
+
+stages:
+  - stage: azure_eastus2
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - $(LOCATION)
+          engine: clusterloader2
+          engine_input:
+            image: "ghcr.io/azure/clusterloader2:v20241022"
+          topology: cilium-usercluster-autoscale
+          matrix:
+            azure_cilium:
+              cpu_per_node: 4
+              node_count: 1000
+              node_per_step: 100
+              max_pods: 110
+              repeats: 1
+              scale_timeout: "30m"
+              cilium_enabled: True
+              network_policy: cilium
+              network_dataplane: cilium
+              cl2_config_file: cluster-scale-config.yaml
+              service_test: False
+          max_parallel: 2
+          timeout_in_minutes: 720
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
-  - cron: "0 6,18 * * *"
-    displayName: "6:00 AM & PM Daily"
+  - cron: "0 4,16 * * *"
+    displayName: "4:00 AM & PM Daily"
     branches:
       include:
         - main

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
@@ -1,0 +1,81 @@
+trigger: none
+schedules:
+  - cron: "0 6,18 * * *"
+    displayName: "6:00 AM & PM Daily"
+    branches:
+      include:
+        - main
+    always: true
+
+variables:
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: slo-servicediscovery
+  SCENARIO_VERSION: main
+
+stages:
+  - stage: aws_eastus1
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: aws
+          regions:
+            - us-east-1
+          engine: clusterloader2
+          engine_input:
+            image: "ghcr.io/azure/clusterloader2:v20241022"
+          topology: service-churn
+          matrix:
+            aws_vpc_cni:
+              cpu_per_node: 4
+              node_count: 1000
+              node_per_step: 1000
+              max_pods: 110
+              repeats: 10
+              scale_timeout: "15m"
+              cilium_enabled: False
+              service_test: True
+              cl2_config_file: load-config.yaml
+          max_parallel: 1
+          timeout_in_minutes: 720
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: azure_eastus2
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: clusterloader2
+          engine_input:
+            image: "ghcr.io/azure/clusterloader2:v20241022"
+          topology: service-churn
+          matrix:
+            azure_cni:
+              cpu_per_node: 4
+              node_count: 1000
+              node_per_step: 1000
+              max_pods: 110
+              repeats: 10
+              scale_timeout: "15m"
+              cilium_enabled: False
+              service_test: True
+              cl2_config_file: load-config.yaml
+            azure_cilium:
+              cpu_per_node: 4
+              node_count: 1000
+              node_per_step: 1000
+              max_pods: 110
+              repeats: 10
+              scale_timeout: "15m"
+              cilium_enabled: True
+              network_policy: cilium
+              network_dataplane: cilium
+              service_test: True
+              cl2_config_file: load-config.yaml
+          max_parallel: 2
+          timeout_in_minutes: 720
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
@@ -13,33 +13,6 @@ variables:
   SCENARIO_VERSION: main
 
 stages:
-  - stage: aws_eastus1
-    dependsOn: []
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: aws
-          regions:
-            - us-east-1
-          engine: clusterloader2
-          engine_input:
-            image: "ghcr.io/azure/clusterloader2:v20241022"
-          topology: service-churn
-          matrix:
-            aws_vpc_cni:
-              cpu_per_node: 4
-              node_count: 1000
-              node_per_step: 1000
-              max_pods: 110
-              repeats: 10
-              scale_timeout: "15m"
-              cilium_enabled: False
-              service_test: True
-              cl2_config_file: load-config.yaml
-          max_parallel: 1
-          timeout_in_minutes: 720
-          credential_type: service_connection
-          ssh_key_enabled: false
   - stage: azure_eastus2
     dependsOn: []
     jobs:
@@ -47,22 +20,12 @@ stages:
         parameters:
           cloud: azure
           regions:
-            - eastus2
+            - $(LOCATION)
           engine: clusterloader2
           engine_input:
             image: "ghcr.io/azure/clusterloader2:v20241022"
-          topology: service-churn
+          topology: cilium-usercluster
           matrix:
-            azure_cni:
-              cpu_per_node: 4
-              node_count: 1000
-              node_per_step: 1000
-              max_pods: 110
-              repeats: 10
-              scale_timeout: "15m"
-              cilium_enabled: False
-              service_test: True
-              cl2_config_file: load-config.yaml
             azure_cilium:
               cpu_per_node: 4
               node_count: 1000

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
@@ -9,7 +9,7 @@ schedules:
 
 variables:
   SCENARIO_TYPE: perf-eval
-  SCENARIO_NAME: slo-servicediscovery
+  SCENARIO_NAME: slo-servicediscovery-cilium-nodesubnet
   SCENARIO_VERSION: main
 
 stages:


### PR DESCRIPTION
This PR adds 2 pipelines:
1. cilium-cluster-churn-cilium-nodesubnet runs the cluster churn scenario twice a day
2. slo-servicediscovery-cilium-nodesubnet runs the service churn scenario twice a day

These pipelines will use custom BYOCNI clusters because cilium nodesubnet is not available on AKS