### PR TITLE
Add steps to publish to new storage account

### DIFF
--- a/steps/cloud/azure/upload-storage-account.yml
+++ b/steps/cloud/azure/upload-storage-account.yml
@@ -1,5 +1,5 @@
 parameters:
-  storage_account_name: $(AZURE_STORAGE_ACCOUNT_NAME)
+  storage_account_name: $(AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME)
   source_file_name: $(TEST_RESULTS_FILE)
   destination_file_name: $(RUN_ID).json
   subfolder: $(SCENARIO_NAME)/$(SCENARIO_VERSION)

--- a/steps/cloud/azure/upload-storage-account.yml
+++ b/steps/cloud/azure/upload-storage-account.yml
@@ -1,4 +1,5 @@
 parameters:
+  storage_account_name: $(AZURE_STORAGE_ACCOUNT_NAME)
   source_file_name: $(TEST_RESULTS_FILE)
   destination_file_name: $(RUN_ID).json
   subfolder: $(SCENARIO_NAME)/$(SCENARIO_VERSION)
@@ -33,4 +34,4 @@ steps:
     DESTINATION_FILE_NAME: ${{ parameters.destination_file_name }}
     SUBFOLDER: ${{ parameters.subfolder }}
     CONTAINER_NAME: ${{ parameters.container_name}}
-    AZURE_STORAGE_ACCOUNT_NAME: $(AZURE_STORAGE_ACCOUNT_NAME)
+    AZURE_STORAGE_ACCOUNT_NAME: ${{ parameters.storage_account_name }}

--- a/steps/cloud/azure/upload-storage-account.yml
+++ b/steps/cloud/azure/upload-storage-account.yml
@@ -22,16 +22,16 @@ steps:
       az storage blob upload \
       --file $SOURCE_FILE_NAME \
       --name ${SUBFOLDER}/${DESTINATION_FILE_NAME} \
-      --account-name $AZURE_STORAGE_ACCOUNT_NAME \
+      --account-name $STORAGE_ACCOUNT_NAME \
       --container-name $CONTAINER_NAME \
       --auth-mode login
     else
       echo "File $SOURCE_FILE_NAME does not exist."
     fi
-  displayName: "Upload ${{ parameters.upload_type }}"
+  displayName: "Upload ${{ parameters.upload_type }} to ${{ parameters.storage_account_name}}"
   env:
     SOURCE_FILE_NAME: ${{ parameters.source_file_name }}
     DESTINATION_FILE_NAME: ${{ parameters.destination_file_name }}
     SUBFOLDER: ${{ parameters.subfolder }}
     CONTAINER_NAME: ${{ parameters.container_name}}
-    AZURE_STORAGE_ACCOUNT_NAME: ${{ parameters.storage_account_name }}
+    STORAGE_ACCOUNT_NAME: ${{ parameters.storage_account_name }}

--- a/steps/collect-telescope-metadata.yml
+++ b/steps/collect-telescope-metadata.yml
@@ -95,3 +95,15 @@ steps:
       credential_type: ${{ parameters.credential_type }}
       cloud: ${{ parameters.cloud }}
       upload_type: "Telescope Metadata"
+
+  # TODO: Remove after migration
+  - template: /steps/cloud/azure/upload-storage-account.yml
+    parameters:
+      storage_account_name: $(AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME)
+      source_file_name: $(TELESCOPE_METADATA_FILE)
+      destination_file_name: $(RUN_ID).json
+      subfolder: telescope-metadata/main
+      container_name: perf-eval
+      credential_type: ${{ parameters.credential_type }}
+      cloud: ${{ parameters.cloud }}
+      upload_type: "Telescope Metadata"

--- a/steps/collect-telescope-metadata.yml
+++ b/steps/collect-telescope-metadata.yml
@@ -99,11 +99,11 @@ steps:
   # TODO: Remove after migration
   - template: /steps/cloud/azure/upload-storage-account.yml
     parameters:
-      storage_account_name: $(AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME)
+      storage_account_name: $(AZURE_STORAGE_ACCOUNT_NAME)
       source_file_name: $(TELESCOPE_METADATA_FILE)
       destination_file_name: $(RUN_ID).json
       subfolder: telescope-metadata/main
-      container_name: perf-eval
+      container_name: system
       credential_type: ${{ parameters.credential_type }}
       cloud: ${{ parameters.cloud }}
       upload_type: "Telescope Metadata"

--- a/steps/publish-results.yml
+++ b/steps/publish-results.yml
@@ -33,3 +33,10 @@ steps:
   parameters:
     credential_type: ${{ parameters.credential_type }}
     cloud: ${{ parameters.cloud }}
+
+# TODO: Remove after migration
+- template: /steps/cloud/azure/upload-storage-account.yml
+  parameters:
+    storage_account_name: $(AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME)
+    credential_type: ${{ parameters.credential_type }}
+    cloud: ${{ parameters.cloud }}

--- a/steps/publish-results.yml
+++ b/steps/publish-results.yml
@@ -37,6 +37,6 @@ steps:
 # TODO: Remove after migration
 - template: /steps/cloud/azure/upload-storage-account.yml
   parameters:
-    storage_account_name: $(AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME)
+    storage_account_name: $(AZURE_STORAGE_ACCOUNT_NAME)
     credential_type: ${{ parameters.credential_type }}
     cloud: ${{ parameters.cloud }}


### PR DESCRIPTION
- Update default storage account in [upload-storage-account.yml](https://github.com/Azure/telescope/pull/428/files#diff-64553bc9dfde5362118f64c986d99f593d31c623b2b7be493fd399828c832086) to use the new storage account and parameterize storage account name. Rename the environment variable to avoid confusion in the step
- Add steps to publish to current storage account for results and metadata so we publish to both current and new storage accounts

*Note*:
- AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME is new storage account variable name
- AZURE_STORAGE_ACCOUNT_NAME is the current storage account variable name