### PR TITLE
Remove second stages from cilium nodesubnet pipelines to have first stage run without interference

### DIFF
--- a/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
@@ -42,32 +42,4 @@ stages:
           timeout_in_minutes: 720
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_cilium_overlay
-    dependsOn: []
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - $(LOCATION)
-          engine: clusterloader2
-          engine_input:
-            image: "ghcr.io/azure/clusterloader2:v20241022"
-          topology: slo
-          matrix:
-            azure_cilium:
-              cpu_per_node: 4
-              node_count: 1000
-              node_per_step: 100
-              max_pods: 110
-              repeats: 1
-              scale_timeout: "30m"
-              cilium_enabled: True
-              network_policy: cilium
-              network_dataplane: cilium
-              cl2_config_file: cluster-scale-config.yaml
-              service_test: False
-          max_parallel: 2
-          timeout_in_minutes: 720
-          credential_type: service_connection
-          ssh_key_enabled: false
+

--- a/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
@@ -42,4 +42,3 @@ stages:
           timeout_in_minutes: 720
           credential_type: service_connection
           ssh_key_enabled: false
-

--- a/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
@@ -4,7 +4,7 @@ schedules:
     displayName: "10:00 AM & PM Daily"
     branches:
       include:
-        - main
+        - sanprabhu/40kpods
     always: true
 
 variables:

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
@@ -42,32 +42,4 @@ stages:
           timeout_in_minutes: 720
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_cilium_overlay
-    dependsOn: []
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - $(LOCATION)
-          engine: clusterloader2
-          engine_input:
-            image: "ghcr.io/azure/clusterloader2:v20241022"
-          topology: service-churn
-          matrix:
-            azure_cilium:
-              cpu_per_node: 4
-              node_count: 1000
-              node_per_step: 1000
-              max_pods: 110
-              repeats: 10
-              scale_timeout: "15m"
-              cilium_enabled: True
-              network_policy: cilium
-              network_dataplane: cilium
-              service_test: True
-              cl2_config_file: load-config.yaml
-          max_parallel: 2
-          timeout_in_minutes: 720
-          credential_type: service_connection
-          ssh_key_enabled: false
+          

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
@@ -42,4 +42,3 @@ stages:
           timeout_in_minutes: 720
           credential_type: service_connection
           ssh_key_enabled: false
-          


### PR DESCRIPTION
With the second stage enabled, the same cluster is being used to run both stages. This needs to be fixed with deeper changes to the pipelines, so that we can create a separate cluster with a different run_id to run the second stage. While we work on that, this PR disables the second stage in both cilium nodesubnet pipelines.