### PR TITLE
Always publish to source branch name for new storage account

### DIFF
--- a/steps/cloud/azure/upload-storage-account.yml
+++ b/steps/cloud/azure/upload-storage-account.yml
@@ -2,7 +2,7 @@ parameters:
   storage_account_name: $(AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME)
   source_file_name: $(TEST_RESULTS_FILE)
   destination_file_name: $(RUN_ID).json
-  subfolder: $(SCENARIO_NAME)/$(SCENARIO_VERSION)
+  subfolder: $(SCENARIO_NAME)/$(Build.SourceBranchName)
   container_name: $(SCENARIO_TYPE)
   credential_type: string
   cloud: string

--- a/steps/publish-results.yml
+++ b/steps/publish-results.yml
@@ -40,3 +40,4 @@ steps:
     storage_account_name: $(AZURE_STORAGE_ACCOUNT_NAME)
     credential_type: ${{ parameters.credential_type }}
     cloud: ${{ parameters.cloud }}
+    subfolder: $(SCENARIO_NAME)/$(SCENARIO_VERSION)


### PR DESCRIPTION
Summary
- Change default value of SUBFOLDER to `$(SCENARIO_NAME)/$(Build.SourceBranchName)`
- For current storage account, we'd still use SCENARIO_VERSION as the subfolder name until migration is complete
- For new storage account, we should use the source branch name as the subfolder name, so we don't need 2 data connections during migration for test scenarios that doesn't use main as the SCENARIO_VERSION