### PR TITLE
*: store response errors for apiserver benchmark

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -37,7 +37,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.1.6
+            runner_image: ghcr.io/azure/kperf:0.1.8
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -70,7 +70,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.1.6
+            runner_image: ghcr.io/azure/kperf:0.1.8
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -103,7 +103,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.1.6
+            runner_image: ghcr.io/azure/kperf:0.1.8
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192 --content-type json"
           max_parallel: 2
@@ -136,7 +136,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.1.6
+            runner_image: ghcr.io/azure/kperf:0.1.8
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192 --content-type protobuf"
           max_parallel: 2

--- a/steps/engine/kperf/collect.yml
+++ b/steps/engine/kperf/collect.yml
@@ -18,18 +18,46 @@ steps:
 - template: /steps/cloud/${{ parameters.cloud }}/collect-cloud-info.yml
   parameters:
     region: ${{ parameters.region }}
+
+- template: /steps/cloud/azure/login.yml
+  parameters:
+    region: eastus
+    credential_type: service_connection
+
 - script: |
     set -euo pipefail
     set -x
 
+    errors_number=$(jq -r '.result.errors | length' ${TEST_RESULTS_DIR}/tmp_results.json)
+    error_rate_too_high=$(jq -r '(1 - .result.total / (.loadSpec.count * .loadSpec.loadProfile.spec.total)) > 0.1' ${TEST_RESULTS_DIR}/tmp_results.json)
+    if [[ "${errors_number}" != "0" && "${error_rate_too_high}" == "true" ]]; then
+
+      cat ${TEST_RESULTS_DIR}/tmp_results.json \
+        | jq -cr ".result.errors | map(. + {runID: \"$RUN_ID\", cloud: \"$CLOUD_NAME\"}) | .[]" > ${TEST_RESULTS_DIR}/errors_raw_data.json
+
+      cat $TEST_RESULTS_DIR/errors_raw_data.json
+
+      az storage blob upload \
+        --account-name ${ERRORRAWDATA_STORAGE_ACCOUNT_NAME} \
+        --container-name ${ERRORRAWDATA_STORAGE_CONTAINER_NAME} \
+        --name ${ERRORRAWDATA_STORAGE_CONTAINER_FILENAME} \
+        --file ${TEST_RESULTS_DIR}/errors_raw_data.json \
+        --auth-mode login
+    fi
+
     cat ${TEST_RESULTS_DIR}/tmp_results.json \
+      | jq 'del(.result.errors)' \
       | jq -c ".info += { flowcontrol: \"$FLOWCONTROL\", subcmdArgs: \"$BENCHMARK_SUBCMD_ARGS\", extraArgs: \"$EXTRA_BENCHMARK_SUBCMD_ARGS\" }" \
       | jq -c ". += { timestamp: $(date -u +\"%Y-%m-%dT%H:%M:%SZ\") }" \
-      | jq -c ". += { runID: \"$RUN_ID\", runURL: \"$RUN_URL\", cloud: $CLOUD_INFO}" > "${TEST_RESULTS_FILE}"
+      | jq -c ". += { runID: \"$RUN_ID\", runURL: \"$RUN_URL\", cloud: \"$CLOUD_NAME\" }" > "${TEST_RESULTS_FILE}"
 
     cat $TEST_RESULTS_FILE | jq .
   env:
+    CLOUD_NAME: ${{ parameters.cloud }}
     BENCHMARK_SUBCMD_ARGS: ${{ parameters.engine_input.benchmark_subcmd_args }}
     EXTRA_BENCHMARK_SUBCMD_ARGS: ${{ parameters.extra_benchmark_subcmd_args }}
     FLOWCONTROL: ${{ parameters.flowcontrol }}
+    ERRORRAWDATA_STORAGE_ACCOUNT_NAME: $(AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME)
+    ERRORRAWDATA_STORAGE_CONTAINER_NAME: $(SCENARIO_TYPE)
+    ERRORRAWDATA_STORAGE_CONTAINER_FILENAME: $(SCENARIO_NAME)-errorrawdata/$(Build.SourceBranchName)/$(RUN_ID).json
   displayName: "Collect Results"

--- a/steps/engine/kperf/execute.yml
+++ b/steps/engine/kperf/execute.yml
@@ -45,7 +45,13 @@ steps:
       exit 0
     fi
 
-    sudo -E $(command -v runkperf) -v 3 ekswarmup \
+    cmd_name=ekswarmup
+    new_version=$(runkperf ekswarmup -h 2> /dev/null || echo true)
+    if [[ "${new_version}" == "true" ]]; then
+      cmd_name=warmup
+    fi
+
+    sudo -E $(command -v runkperf) -v 3 ${cmd_name} \
       --kubeconfig ~/.kube/config \
       --runner-image ${RUNNER_IMAGE} \
       --total 12000
@@ -61,6 +67,11 @@ steps:
     is_eks=""
     if [[ "${CLOUD}" == "aws" ]]; then
       is_eks="--eks"
+    fi
+
+    new_version=$(runkperf ekswarmup -h 2> /dev/null || echo true)
+    if [[ "${new_version}" == "true" ]]; then
+      is_eks=""
     fi
 
     sudo -E $(command -v runkperf) -v 3 bench ${is_eks} \


### PR DESCRIPTION
Starting from version v0.1.8, kperf supports storing response errors with timestamps. This feature allows us to review errors and their occurrence times, such as unexpected OOMKilled events causing 500 errors or unexpected EOF errors. Without timestamps, it's challenging to analyze error distribution during benchmarking, and this change addresses that issue effectively.

Due to Kusto's limitation on the size of a single column, I’ve moved the error data into a separate table. The new table will be named ${scenario_name}-errorrawdata. Additionally, in order to reduce cost, that raw data only be stored when error rate is higher than 10%.