### PR TITLE
Explicitly set local auth to true for event hubs namespace instead of relying on default value

### DIFF
--- a/modules/terraform/setup/table-data-connections/main.tf
+++ b/modules/terraform/setup/table-data-connections/main.tf
@@ -92,13 +92,14 @@ data "azurerm_eventhub_namespace" "eventhub_ns" {
 }
 
 resource "azurerm_eventhub_namespace" "eventhub_ns" {
-  count               = var.create_eventhub_namespace ? 1 : 0
-  name                = "ADX-EG-telescope-${formatdate("MM-DD-YYYY-hh-mm-ss", timestamp())}"
-  location            = data.azurerm_resource_group.rg.location
-  resource_group_name = data.azurerm_resource_group.rg.name
-  sku                 = "Standard"
-  capacity            = 1
-  tags                = local.tags
+  count                        = var.create_eventhub_namespace ? 1 : 0
+  name                         = "ADX-EG-telescope-${formatdate("MM-DD-YYYY-hh-mm-ss", timestamp())}"
+  location                     = data.azurerm_resource_group.rg.location
+  resource_group_name          = data.azurerm_resource_group.rg.name
+  sku                          = "Standard"
+  capacity                     = 1
+  local_authentication_enabled = true
+  tags                         = local.tags
 }
 
 resource "azurerm_eventhub" "eventhub" {


### PR DESCRIPTION
Local auth needs to be enabled for the event hubs namespace for delivery when delivery_identity for event subscription isn't set