### PR TITLE
Update branch used for cluster churn runs in nodesubnet

### DIFF
--- a/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
@@ -4,7 +4,7 @@ schedules:
     displayName: "10:00 AM & PM Daily"
     branches:
       include:
-        - sanprabhu/40kpods
+        - main
     always: true
 
 variables:


### PR DESCRIPTION
Update the branch in the pipeline file to use main branch instead of sanprabhu/40kpods.