### PR TITLE
Update datetime parser to allow more datetime format

### DIFF
--- a/modules/python/kusto/generate_commands.py
+++ b/modules/python/kusto/generate_commands.py
@@ -35,11 +35,12 @@ def infer_type(value):
         pass
 
     # Check if it's a datetime
-    try:
-        datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
-        return "datetime"
-    except ValueError:
-        pass
+    for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S.%f'):
+        try:
+            datetime.strptime(value, fmt)
+            return "datetime"
+        except ValueError:
+            pass
 
     # If none of the above, take it as string
     return "string"

--- a/modules/python/tests/test_generate_commands.py
+++ b/modules/python/tests/test_generate_commands.py
@@ -38,6 +38,8 @@ class TestInferType(unittest.TestCase):
 
     def test_infer_datetime(self):
         self.assertEqual(infer_type('2022-01-01T12:00:00Z'), 'datetime')
+        self.assertEqual(infer_type('2024-12-26T12:14:50.637517'), 'datetime')
+        self.assertNotEqual(infer_type('2024-12-26T15:02:17.681161609Z'), 'datetime')
         self.assertNotEqual(infer_type('abc'), 'datetime')
         self.assertNotEqual(infer_type('123'), 'datetime')
         self.assertNotEqual(infer_type(123456), 'datetime')


### PR DESCRIPTION
Currently, these types of timestamp formats are evaluated to string instead of datetime when creating Kusto schema for new table:
```
2024-12-26T12:14:50.637517
2024-12-26T15:02:18.775485968Z
```
Thus, this change is needed to allow correct parsing
