### PR TITLE
Use different library for timestamp parser

### DIFF
--- a/modules/python/kusto/generate_commands.py
+++ b/modules/python/kusto/generate_commands.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from dateutil.parser import isoparse
 import sys
 import base64
 
@@ -34,13 +34,12 @@ def infer_type(value):
     except (json.JSONDecodeError, TypeError):
         pass
 
-    # Check if it's a datetime
-    for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S.%f'):
-        try:
-            datetime.strptime(value, fmt)
-            return "datetime"
-        except ValueError:
-            pass
+    # Check if it's a datetime    
+    try:
+        isoparse(value)
+        return "datetime"
+    except ValueError:
+        pass
 
     # If none of the above, take it as string
     return "string"

--- a/modules/python/tests/test_generate_commands.py
+++ b/modules/python/tests/test_generate_commands.py
@@ -39,7 +39,7 @@ class TestInferType(unittest.TestCase):
     def test_infer_datetime(self):
         self.assertEqual(infer_type('2022-01-01T12:00:00Z'), 'datetime')
         self.assertEqual(infer_type('2024-12-26T12:14:50.637517'), 'datetime')
-        self.assertNotEqual(infer_type('2024-12-26T15:02:17.681161609Z'), 'datetime')
+        self.assertEqual(infer_type('2024-12-26T15:02:17.681161609Z'), 'datetime')
         self.assertNotEqual(infer_type('abc'), 'datetime')
         self.assertNotEqual(infer_type('123'), 'datetime')
         self.assertNotEqual(infer_type(123456), 'datetime')


### PR DESCRIPTION
Use a different library which can handle different timestamp formats better.