### PR TITLE
Created Cilium Network Policy and Cilium Cluster Wide Network Policy Test

### DIFF
--- a/modules/python/clusterloader2/slo/config/ccnp_template.yaml
+++ b/modules/python/clusterloader2/slo/config/ccnp_template.yaml
@@ -5,10 +5,15 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app: nginx
-  egress:
-  - toEndpoints:
-    - {}
-  ingress:
+      group: cnp-ccnp
+  ingressDeny:
   - fromEndpoints:
-    - {}
+    - matchLabels:
+        io.kubernetes.pod.namespace: default
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+    toEntities:
+    - cluster

--- a/modules/python/clusterloader2/slo/config/ccnp_template.yaml
+++ b/modules/python/clusterloader2/slo/config/ccnp_template.yaml
@@ -1,0 +1,14 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: {{.basename}}
+spec:
+  endpointSelector:
+    matchLabels:
+      app: nginx
+  egress:
+  - toEndpoints:
+    - {}
+  ingress:
+  - fromEndpoints:
+    - {}

--- a/modules/python/clusterloader2/slo/config/cnp_template.yaml
+++ b/modules/python/clusterloader2/slo/config/cnp_template.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{.basename}}
+  namespace: slo-1
+spec:
+  endpointSelector:
+    matchLabels:
+      app: nginx
+  egress:
+  - toEndpoints:
+    - {}

--- a/modules/python/clusterloader2/slo/config/cnp_template.yaml
+++ b/modules/python/clusterloader2/slo/config/cnp_template.yaml
@@ -2,7 +2,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{.basename}}
-  namespace: slo-1
+  namespace: slo-1 # slo-1 was used because tried passing in namespace from load-config but had object mismatch error, revise in future to possibly pass in ns
 spec:
   endpointSelector:
     matchLabels:

--- a/modules/python/clusterloader2/slo/config/cnp_template.yaml
+++ b/modules/python/clusterloader2/slo/config/cnp_template.yaml
@@ -2,7 +2,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{.basename}}
-  namespace: slo-1 # slo-1 was used because tried passing in namespace from load-config but had object mismatch error, revise in future to possibly pass in ns
+  namespace: slo-1 # slo-1 was used because that is the ns pods are deployed in & tried passing in namespace from load-config but had object mismatch error, revise in future to possibly pass in ns
 spec:
   endpointSelector:
     matchLabels:

--- a/modules/python/clusterloader2/slo/config/cnp_template.yaml
+++ b/modules/python/clusterloader2/slo/config/cnp_template.yaml
@@ -6,7 +6,15 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app: nginx
+      group: cnp-ccnp
+  ingressDeny:
+  - fromEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: default
   egress:
-  - toEndpoints:
-    - {}
+  - toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP
+    toCIDR:
+    - 0.0.0.0/0

--- a/modules/python/clusterloader2/slo/config/deployment_template.yaml
+++ b/modules/python/clusterloader2/slo/config/deployment_template.yaml
@@ -1,5 +1,10 @@
 {{$CpuRequest := DefaultParam .CpuRequest "5m"}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
+{{$cnpsPerNamespace := .cnpsPerNamespace}}
+{{$ccnps := .ccnps}}
+{{$cnp_test:= .cnp_test}}
+{{$ccnp_test:= .ccnp_test}}
+{{$dualstack := .dualstack}}
 
 {{$Image := DefaultParam .Image "mcr.microsoft.com/oss/kubernetes/pause:3.6"}}
 
@@ -35,6 +40,23 @@ spec:
       nodeSelector:
         slo: "true"
       containers:
+{{if or $cnp_test $ccnp_test}}
+  {{if $dualstack}}
+      - name: nginx
+        image: mcr.microsoft.com/mirror/docker/library/nginx:1.25
+        command: ["sh", "-c", "while true; do curl ipv6.bing.com; sleep 6; done"]
+        ports:
+        - name: http
+          containerPort: 80
+  {{else}}
+      - name: nginx
+        image: mcr.microsoft.com/mirror/docker/library/nginx:1.25
+        command: ["sh", "-c", "while true; do curl ipv4.bing.com; sleep 6; done"]
+        ports:
+        - name: http
+          containerPort: 80
+  {{end}}
+{{else}}
       - env:
         - name: ENV_VAR
           value: a
@@ -42,6 +64,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:
+{{end}}
         resources:
           requests:
             cpu: {{$CpuRequest}}

--- a/modules/python/clusterloader2/slo/config/deployment_template.yaml
+++ b/modules/python/clusterloader2/slo/config/deployment_template.yaml
@@ -1,10 +1,7 @@
 {{$CpuRequest := DefaultParam .CpuRequest "5m"}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
-{{$cnpsPerNamespace := .cnpsPerNamespace}}
-{{$ccnps := .ccnps}}
 {{$cnp_test:= .cnp_test}}
 {{$ccnp_test:= .ccnp_test}}
-{{$dualstack := .dualstack}}
 
 {{$Image := DefaultParam .Image "mcr.microsoft.com/oss/kubernetes/pause:3.6"}}
 
@@ -40,23 +37,6 @@ spec:
       nodeSelector:
         slo: "true"
       containers:
-{{if or $cnp_test $ccnp_test}}
-  {{if $dualstack}}
-      - name: nginx
-        image: mcr.microsoft.com/mirror/docker/library/nginx:1.25
-        command: ["sh", "-c", "while true; do curl ipv6.bing.com; sleep 6; done"]
-        ports:
-        - name: http
-          containerPort: 80
-  {{else}}
-      - name: nginx
-        image: mcr.microsoft.com/mirror/docker/library/nginx:1.25
-        command: ["sh", "-c", "while true; do curl ipv4.bing.com; sleep 6; done"]
-        ports:
-        - name: http
-          containerPort: 80
-  {{end}}
-{{else}}
       - env:
         - name: ENV_VAR
           value: a
@@ -64,7 +44,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:
-{{end}}
         resources:
           requests:
             cpu: {{$CpuRequest}}

--- a/modules/python/clusterloader2/slo/config/load-config.yaml
+++ b/modules/python/clusterloader2/slo/config/load-config.yaml
@@ -39,7 +39,6 @@ name: load-config
 # CNP & CCNP Test
 {{$CNPS_PER_NAMESPACE := DefaultParam .CL2_CNPS_PER_NAMESPACE 0}}
 {{$CCNPS := DefaultParam .CL2_CCNPS 0}}
-{{$nameOfNs := "slo-1"}}
 {{$DUALSTACK := DefaultParam .CL2_DUALSTACK false}}
 
 namespace:
@@ -99,7 +98,6 @@ steps:
       params:
         actionName: "Creating"
         namespaces: {{$namespaces}}
-        nameOfNs: {{$nameOfNs}}
         cnpsPerNamespace: {{$CNPS_PER_NAMESPACE}}
 {{end}}
 

--- a/modules/python/clusterloader2/slo/config/load-config.yaml
+++ b/modules/python/clusterloader2/slo/config/load-config.yaml
@@ -98,6 +98,7 @@ steps:
       params:
         actionName: "Creating"
         namespaces: {{$namespaces}}
+        Group: {{$groupName}}
         cnpsPerNamespace: {{$CNPS_PER_NAMESPACE}}
 {{end}}
 
@@ -106,6 +107,7 @@ steps:
       path: /modules/ciliumclusternetworkpolicy.yaml
       params:
         actionName: "Creating"
+        Group: {{$groupName}}
         ccnps: {{$CCNPS}}
 {{end}}
         
@@ -119,17 +121,14 @@ steps:
     {{if or $CCNP_TEST $CNP_TEST}}
         bigDeploymentSize: 0
         bigDeploymentsPerNamespace: 0
+        cnp_test: {{$CNP_TEST}}
+        ccnp_test: {{$CCNP_TEST}}
     {{else}}
         bigDeploymentSize: {{$BIG_GROUP_SIZE}}
         bigDeploymentsPerNamespace: {{$bigDeploymentsPerNamespace}}
     {{end}}
         smallDeploymentSize: {{$SMALL_GROUP_SIZE}}
         smallDeploymentsPerNamespace: {{$smallDeploymentsPerNamespace}}
-        cnpsPerNamespace: {{$CNPS_PER_NAMESPACE}}
-        ccnps: {{$CCNPS}}
-        cnp_test: {{$CNP_TEST}}
-        ccnp_test: {{$CCNP_TEST}}
-        dualstack: {{$DUALSTACK}}
         CpuRequest: {{$latencyPodCpu}}m
         MemoryRequest: {{$latencyPodMemory}}M
         Group: {{$groupName}}
@@ -145,17 +144,14 @@ steps:
     {{if or $CCNP_TEST $CNP_TEST}}
         bigDeploymentSize: 0
         bigDeploymentsPerNamespace: 0
+        cnp_test: {{$CNP_TEST}}
+        ccnp_test: {{$CCNP_TEST}}
     {{else}}
         bigDeploymentSize: {{$BIG_GROUP_SIZE}}
         bigDeploymentsPerNamespace: {{$bigDeploymentsPerNamespace}}
     {{end}}
         smallDeploymentSize: {{$SMALL_GROUP_SIZE}}
         smallDeploymentsPerNamespace: {{$smallDeploymentsPerNamespace}}
-        cnpsPerNamespace: {{$CNPS_PER_NAMESPACE}}
-        ccnps: {{$CCNPS}}
-        cnp_test: {{$CNP_TEST}}
-        ccnp_test: {{$CCNP_TEST}}
-        dualstack: {{$DUALSTACK}}
         CpuRequest: {{$latencyPodCpu}}m
         MemoryRequest: {{$latencyPodMemory}}M
         Group: {{$groupName}}
@@ -171,6 +167,8 @@ steps:
     {{if or $CCNP_TEST $CNP_TEST}}
         bigDeploymentSize: 0
         bigDeploymentsPerNamespace: 0
+        cnp_test: {{$CNP_TEST}}
+        ccnp_test: {{$CCNP_TEST}}
     {{else}}
         bigDeploymentSize: {{$BIG_GROUP_SIZE}}
         bigDeploymentsPerNamespace: 0
@@ -188,15 +186,15 @@ steps:
         smallServicesPerNamespace: 0
         bigServicesPerNamespace: 0
 {{end}}
-{{if or $CCNP_TEST $CNP_TEST}}
+{{if $CNP_TEST}}
   - module:
       path: /modules/ciliumnetworkpolicy.yaml
       params:
         actionName: "Deleting"
         namespaces: {{$namespaces}}
-        nameOfNs: {{$nameOfNs}}
         cnpsPerNamespace: 0
-
+{{end}}
+{{if $CCNP_TEST}}
   - module:
       path: /modules/ciliumclusternetworkpolicy.yaml
       params:

--- a/modules/python/clusterloader2/slo/config/load-config.yaml
+++ b/modules/python/clusterloader2/slo/config/load-config.yaml
@@ -2,6 +2,8 @@ name: load-config
 
 # Config options for test type
 {{$SERVICE_TEST := DefaultParam .CL2_SERVICE_TEST true}}
+{{$CNP_TEST := DefaultParam .CL2_CNP_TEST false}}
+{{$CCNP_TEST := DefaultParam .CL2_CCNP_TEST false}}
 
 # Config options for test parameters
 {{$nodesPerNamespace := DefaultParam .CL2_NODES_PER_NAMESPACE 100}}
@@ -33,6 +35,12 @@ name: load-config
 {{$bigDeploymentsPerNamespace := DefaultParam .bigDeploymentsPerNamespace 1}}
 {{$smallDeploymentPods := SubtractInt $podsPerNamespace (MultiplyInt $bigDeploymentsPerNamespace $BIG_GROUP_SIZE)}}
 {{$smallDeploymentsPerNamespace := DivideInt $smallDeploymentPods $SMALL_GROUP_SIZE}}
+
+# CNP & CCNP Test
+{{$CNPS_PER_NAMESPACE := DefaultParam .CL2_CNPS_PER_NAMESPACE 0}}
+{{$CCNPS := DefaultParam .CL2_CCNPS 0}}
+{{$nameOfNs := "slo-1"}}
+{{$DUALSTACK := DefaultParam .CL2_DUALSTACK false}}
 
 namespace:
   number: {{$namespaces}}
@@ -85,6 +93,24 @@ steps:
         bigServicesPerNamespace: {{$bigDeploymentsPerNamespace}}
 {{end}}
 
+{{if $CNP_TEST}}
+  - module:
+      path: /modules/ciliumnetworkpolicy.yaml
+      params:
+        actionName: "Creating"
+        namespaces: {{$namespaces}}
+        nameOfNs: {{$nameOfNs}}
+        cnpsPerNamespace: {{$CNPS_PER_NAMESPACE}}
+{{end}}
+
+{{if $CCNP_TEST}}
+  - module:
+      path: /modules/ciliumclusternetworkpolicy.yaml
+      params:
+        actionName: "Creating"
+        ccnps: {{$CCNPS}}
+{{end}}
+        
   - module:
       path: /modules/reconcile-objects.yaml
       params:
@@ -92,10 +118,20 @@ steps:
         namespaces: {{$namespaces}}
         tuningSet: DeploymentCreateQps
         operationTimeout: {{$operationTimeout}}
+    {{if or $CCNP_TEST $CNP_TEST}}
+        bigDeploymentSize: 0
+        bigDeploymentsPerNamespace: 0
+    {{else}}
         bigDeploymentSize: {{$BIG_GROUP_SIZE}}
         bigDeploymentsPerNamespace: {{$bigDeploymentsPerNamespace}}
+    {{end}}
         smallDeploymentSize: {{$SMALL_GROUP_SIZE}}
         smallDeploymentsPerNamespace: {{$smallDeploymentsPerNamespace}}
+        cnpsPerNamespace: {{$CNPS_PER_NAMESPACE}}
+        ccnps: {{$CCNPS}}
+        cnp_test: {{$CNP_TEST}}
+        ccnp_test: {{$CCNP_TEST}}
+        dualstack: {{$DUALSTACK}}
         CpuRequest: {{$latencyPodCpu}}m
         MemoryRequest: {{$latencyPodMemory}}M
         Group: {{$groupName}}
@@ -108,10 +144,20 @@ steps:
         namespaces: {{$namespaces}}
         tuningSet: Sequence
         operationTimeout: {{$operationTimeout}}
+    {{if or $CCNP_TEST $CNP_TEST}}
+        bigDeploymentSize: 0
+        bigDeploymentsPerNamespace: 0
+    {{else}}
         bigDeploymentSize: {{$BIG_GROUP_SIZE}}
         bigDeploymentsPerNamespace: {{$bigDeploymentsPerNamespace}}
+    {{end}}
         smallDeploymentSize: {{$SMALL_GROUP_SIZE}}
         smallDeploymentsPerNamespace: {{$smallDeploymentsPerNamespace}}
+        cnpsPerNamespace: {{$CNPS_PER_NAMESPACE}}
+        ccnps: {{$CCNPS}}
+        cnp_test: {{$CNP_TEST}}
+        ccnp_test: {{$CCNP_TEST}}
+        dualstack: {{$DUALSTACK}}
         CpuRequest: {{$latencyPodCpu}}m
         MemoryRequest: {{$latencyPodMemory}}M
         Group: {{$groupName}}
@@ -124,13 +170,18 @@ steps:
         namespaces: {{$namespaces}}
         tuningSet: DeploymentDeleteQps
         operationTimeout: {{$operationTimeout}}
+    {{if or $CCNP_TEST $CNP_TEST}}
+        bigDeploymentSize: 0
+        bigDeploymentsPerNamespace: 0
+    {{else}}
         bigDeploymentSize: {{$BIG_GROUP_SIZE}}
         bigDeploymentsPerNamespace: 0
+    {{end}}
         smallDeploymentSize: {{$SMALL_GROUP_SIZE}}
         smallDeploymentsPerNamespace: 0
         deploymentLabel: restart
         Group: {{$groupName}}
-
+{{if $SERVICE_TEST}}
   - module:
       path: /modules/services.yaml
       params:
@@ -138,6 +189,23 @@ steps:
         namespaces: {{$namespaces}}
         smallServicesPerNamespace: 0
         bigServicesPerNamespace: 0
+{{end}}
+{{if or $CCNP_TEST $CNP_TEST}}
+  - module:
+      path: /modules/ciliumnetworkpolicy.yaml
+      params:
+        actionName: "Deleting"
+        namespaces: {{$namespaces}}
+        nameOfNs: {{$nameOfNs}}
+        cnpsPerNamespace: 0
+
+  - module:
+      path: /modules/ciliumclusternetworkpolicy.yaml
+      params:
+        actionName: "Deleting"
+        namespaces: {{$namespaces}}
+        ccnps: 0
+{{end}}
 {{end}}
 
 {{if $CILIUM_METRICS_ENABLED}}

--- a/modules/python/clusterloader2/slo/config/modules/ciliumclusternetworkpolicy.yaml
+++ b/modules/python/clusterloader2/slo/config/modules/ciliumclusternetworkpolicy.yaml
@@ -3,9 +3,10 @@
 ## Input params
 {{$actionName := .actionName}}
 {{$ccnps := .ccnps}}
+{{$Group := .Group}}
 
 steps:
-- name: "{{$actionName}} k8s CCNPs"
+- name: "{{$actionName}} {{$ccnps}} k8s CCNPs"
   phases:
   - namespaceRange: null
     replicasPerNamespace: {{$ccnps}}

--- a/modules/python/clusterloader2/slo/config/modules/ciliumclusternetworkpolicy.yaml
+++ b/modules/python/clusterloader2/slo/config/modules/ciliumclusternetworkpolicy.yaml
@@ -1,0 +1,15 @@
+## CCNP module provides a module for creating / deleting CCNPs.
+
+## Input params
+{{$actionName := .actionName}}
+{{$ccnps := .ccnps}}
+
+steps:
+- name: "{{$actionName}} k8s CCNPs"
+  phases:
+  - namespaceRange: null
+    replicasPerNamespace: {{$ccnps}}
+    tuningSet: Sequence
+    objectBundle:
+    - basename: ccnp
+      objectTemplatePath: ccnp_template.yaml

--- a/modules/python/clusterloader2/slo/config/modules/ciliumnetworkpolicy.yaml
+++ b/modules/python/clusterloader2/slo/config/modules/ciliumnetworkpolicy.yaml
@@ -1,0 +1,20 @@
+## CNP module provides a module for creating / deleting CNPs.
+
+## Input params
+{{$actionName := .actionName}}
+{{$namespaces := .namespaces}}
+{{$cnpsPerNamespace := .cnpsPerNamespace}}
+{{$nameOfNs := .nameOfNs}}
+
+steps:
+- name: "{{$actionName}} k8s CNPs"
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: {{$cnpsPerNamespace}}
+    tuningSet: Sequence
+    objectBundle:
+    - basename: cnp
+      objectTemplatePath: cnp_template.yaml
+    

--- a/modules/python/clusterloader2/slo/config/modules/ciliumnetworkpolicy.yaml
+++ b/modules/python/clusterloader2/slo/config/modules/ciliumnetworkpolicy.yaml
@@ -4,7 +4,6 @@
 {{$actionName := .actionName}}
 {{$namespaces := .namespaces}}
 {{$cnpsPerNamespace := .cnpsPerNamespace}}
-{{$nameOfNs := .nameOfNs}}
 
 steps:
 - name: "{{$actionName}} k8s CNPs"

--- a/modules/python/clusterloader2/slo/config/modules/ciliumnetworkpolicy.yaml
+++ b/modules/python/clusterloader2/slo/config/modules/ciliumnetworkpolicy.yaml
@@ -4,9 +4,10 @@
 {{$actionName := .actionName}}
 {{$namespaces := .namespaces}}
 {{$cnpsPerNamespace := .cnpsPerNamespace}}
+{{$Group := .Group}}
 
 steps:
-- name: "{{$actionName}} k8s CNPs"
+- name: "{{$actionName}} {{$cnpsPerNamespace}} k8s CNPs"
   phases:
   - namespaceRange:
       min: 1
@@ -16,4 +17,3 @@ steps:
     objectBundle:
     - basename: cnp
       objectTemplatePath: cnp_template.yaml
-    

--- a/modules/python/clusterloader2/slo/config/modules/reconcile-objects.yaml
+++ b/modules/python/clusterloader2/slo/config/modules/reconcile-objects.yaml
@@ -14,6 +14,12 @@
 {{$smallDeploymentSize := .smallDeploymentSize}}
 {{$smallDeploymentsPerNamespace := .smallDeploymentsPerNamespace}}
 
+{{$cnpsPerNamespace := .cnpsPerNamespace}}
+{{$ccnps := .ccnps}}
+{{$cnp_test:= .cnp_test}}
+{{$ccnp_test:= .ccnp_test}}
+{{$dualstack:= .dualstack}}
+
 steps:
 - name: Starting measurement for '{{$actionName}}'
   measurements:
@@ -55,7 +61,13 @@ steps:
       objectTemplatePath: deployment_template.yaml
       templateFillMap:
         Replicas: {{$smallDeploymentSize}}
+  {{if or $cnp_test $ccnp_test}}
+        cnp_test: {{$cnp_test}}
+        ccnp_test: {{$ccnp_test}}
+        dualstack: {{$dualstack}}
+  {{else}}
         SvcName: small-service
+  {{end}}
         Group: {{.Group}}
         deploymentLabel: {{.deploymentLabel}}
 

--- a/modules/python/clusterloader2/slo/config/modules/reconcile-objects.yaml
+++ b/modules/python/clusterloader2/slo/config/modules/reconcile-objects.yaml
@@ -14,11 +14,8 @@
 {{$smallDeploymentSize := .smallDeploymentSize}}
 {{$smallDeploymentsPerNamespace := .smallDeploymentsPerNamespace}}
 
-{{$cnpsPerNamespace := .cnpsPerNamespace}}
-{{$ccnps := .ccnps}}
 {{$cnp_test:= .cnp_test}}
 {{$ccnp_test:= .ccnp_test}}
-{{$dualstack:= .dualstack}}
 
 steps:
 - name: Starting measurement for '{{$actionName}}'
@@ -64,7 +61,6 @@ steps:
   {{if or $cnp_test $ccnp_test}}
         cnp_test: {{$cnp_test}}
         ccnp_test: {{$ccnp_test}}
-        dualstack: {{$dualstack}}
   {{else}}
         SvcName: small-service
   {{end}}

--- a/modules/python/clusterloader2/slo/slo.py
+++ b/modules/python/clusterloader2/slo/slo.py
@@ -24,7 +24,7 @@ CPU_CAPACITY = {
 }
 # TODO: Remove aks once CL2 update provider name to be azure
 
-def calculate_config(cpu_per_node, node_count, pods_in_node, provider, service_test, cnp_test, ccnp_test):
+def calculate_config(cpu_per_node, node_count, max_pods, provider, service_test, cnp_test, ccnp_test):
     throughput = 100
     nodes_per_namespace = min(node_count, DEFAULT_NODES_PER_NAMESPACE)
 
@@ -33,7 +33,7 @@ def calculate_config(cpu_per_node, node_count, pods_in_node, provider, service_t
         pods_per_node = LOAD_PODS_PER_NODE
 
     if cnp_test or ccnp_test:
-        pods_per_node = pods_in_node
+        pods_per_node = max_pods
     # Different cloud has different reserved values and number of daemonsets
     # Using the same percentage will lead to incorrect nodes number as the number of nodes grow
     # For AWS, see: https://github.com/awslabs/amazon-eks-ami/blob/main/templates/al2/runtime/bootstrap.sh#L290
@@ -49,7 +49,6 @@ def configure_clusterloader2(
     node_count,
     node_per_step,
     max_pods,
-    pods_in_node,
     repeats,
     operation_timeout,
     provider,
@@ -63,7 +62,7 @@ def configure_clusterloader2(
     override_file):
 
     steps = node_count // node_per_step
-    throughput, nodes_per_namespace, pods_per_node, cpu_request = calculate_config(cpu_per_node, node_per_step, pods_in_node, provider, service_test, cnp_test, ccnp_test)
+    throughput, nodes_per_namespace, pods_per_node, cpu_request = calculate_config(cpu_per_node, node_per_step, max_pods, provider, service_test, cnp_test, ccnp_test)
 
     with open(override_file, 'w') as file:
         file.write(f"CL2_LOAD_TEST_THROUGHPUT: {throughput}\n")
@@ -131,7 +130,6 @@ def collect_clusterloader2(
     cpu_per_node,
     node_count,
     max_pods,
-    pods_in_node,
     repeats,
     cl2_report_dir,
     cloud_info,
@@ -156,7 +154,7 @@ def collect_clusterloader2(
     else:
         raise Exception(f"No testsuites found in the report! Raw data: {details}")
 
-    _, _, pods_per_node, _ = calculate_config(cpu_per_node, node_count, pods_in_node, provider, service_test, cnp_test, ccnp_test)
+    _, _, pods_per_node, _ = calculate_config(cpu_per_node, node_count, max_pods, provider, service_test, cnp_test, ccnp_test)
     pod_count = node_count * pods_per_node
 
     # TODO: Expose optional parameter to include test details
@@ -219,8 +217,7 @@ def main():
     parser_configure.add_argument("cpu_per_node", type=int, help="CPU per node")
     parser_configure.add_argument("node_count", type=int, help="Number of nodes")
     parser_configure.add_argument("node_per_step", type=int, help="Number of nodes per scaling step")
-    parser_configure.add_argument("max_pods", type=int, help="Maximum number of pods per node")
-    parser_configure.add_argument("pods_in_node", type=int, nargs='?', default=0, help="Number of pods per node")
+    parser_configure.add_argument("max_pods", type=int, nargs='?', default=0, help="Maximum number of pods per node")
     parser_configure.add_argument("repeats", type=int, help="Number of times to repeat the deployment churn")
     parser_configure.add_argument("operation_timeout", type=str, help="Timeout before failing the scale up test")
     parser_configure.add_argument("provider", type=str, help="Cloud provider name")
@@ -256,8 +253,7 @@ def main():
     parser_collect = subparsers.add_parser("collect", help="Collect scale up data")
     parser_collect.add_argument("cpu_per_node", type=int, help="CPU per node")
     parser_collect.add_argument("node_count", type=int, help="Number of nodes")
-    parser_collect.add_argument("max_pods", type=int, help="Maximum number of pods per node")
-    parser_collect.add_argument("pods_in_node", type=int, nargs='?', default=0, help="Number of pods per node")
+    parser_collect.add_argument("max_pods", type=int, nargs='?', default=0, help="Maximum number of pods per node")
     parser_collect.add_argument("repeats", type=int, help="Number of times to repeat the deployment churn")
     parser_collect.add_argument("cl2_report_dir", type=str, help="Path to the CL2 report directory")
     parser_collect.add_argument("cloud_info", type=str, help="Cloud information")
@@ -281,7 +277,7 @@ def main():
     
     if args.command == "configure":
         configure_clusterloader2(args.cpu_per_node, args.node_count, args.node_per_step, args.max_pods,
-                                 args.pods_in_node, args.repeats, args.operation_timeout, args.provider, args.cilium_enabled,
+                                 args.repeats, args.operation_timeout, args.provider, args.cilium_enabled,
                                  args.service_test, args.cnp_test, args.ccnp_test, args.num_cnps, args.num_ccnps, args.dualstack, args.cl2_override_file)
     elif args.command == "validate":
         validate_clusterloader2(args.node_count, args.operation_timeout)
@@ -289,7 +285,7 @@ def main():
         execute_clusterloader2(args.cl2_image, args.cl2_config_dir, args.cl2_report_dir, args.cl2_config_file,
                                args.kubeconfig, args.provider)
     elif args.command == "collect":
-        collect_clusterloader2(args.cpu_per_node, args.node_count, args.max_pods, args.pods_in_node, args.repeats,
+        collect_clusterloader2(args.cpu_per_node, args.node_count, args.max_pods, args.repeats,
                                args.cl2_report_dir, args.cloud_info, args.run_id, args.run_url,
                                args.service_test, args.cnp_test, args.ccnp_test, args.num_cnps, args.num_ccnps, args.dualstack, args.result_file, args.test_type)
 

--- a/pipelines/perf-eval/CNI Benchmark/cnp-ccnp-feature.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cnp-ccnp-feature.yml
@@ -1,0 +1,44 @@
+trigger: none
+
+variables:
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: cnp-ccnp-feature
+  SCENARIO_VERSION: main
+  OWNER: aks
+
+stages:
+  - stage: azure_eastus2
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - $(LOCATION)
+          engine: clusterloader2
+          engine_input:
+            image: "ghcr.io/azure/clusterloader2:v20241022"
+          topology: cilium-usercluster
+          matrix:
+            azure_cilium:
+              cpu_per_node: 4
+              node_count: $(NODES)
+              node_per_step: $(STEP_NODES)
+              max_pods: 110
+              pods_in_node: $(PODS)
+              repeats: 1
+              scale_timeout: "15m"
+              cilium_enabled: True
+              network_policy: cilium
+              network_dataplane: cilium
+              service_test: False
+              cnp_test: $(CNP)
+              ccnp_test: $(CCNP)
+              num_cnps: $(CNPS_NUM)
+              num_ccnps: $(CCNPS_NUM)
+              dualstack: $(DUAL)
+              cl2_config_file: load-config.yaml
+          max_parallel: 2
+          timeout_in_minutes: 720
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/perf-eval/CNI Benchmark/cnp-ccnp-feature.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cnp-ccnp-feature.yml
@@ -24,8 +24,7 @@ stages:
               cpu_per_node: 4
               node_count: $(NODES)
               node_per_step: $(STEP_NODES)
-              max_pods: 110
-              pods_in_node: $(PODS)
+              max_pods: $(MAX_PODS_IN_NODE)
               repeats: 1
               scale_timeout: "15m"
               cilium_enabled: True

--- a/steps/engine/clusterloader2/slo/collect.yml
+++ b/steps/engine/clusterloader2/slo/collect.yml
@@ -16,8 +16,8 @@ steps:
     set -eo pipefail
 
     PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE collect \
-      $CPU_PER_NODE $NODE_COUNT $MAX_PODS $REPEATS \
-      $CL2_REPORT_DIR "$CLOUD_INFO" $RUN_ID $RUN_URL $SERVICE_TEST $TEST_RESULTS_FILE \
+      $CPU_PER_NODE $NODE_COUNT $MAX_PODS ${PODS_IN_NODE:-0} \
+      $REPEATS $CL2_REPORT_DIR "$CLOUD_INFO" $RUN_ID $RUN_URL $SERVICE_TEST ${CNP_TEST:-False} ${CCNP_TEST:-False} ${NUM_CNPS:-0} ${NUM_CCNPS:-0} ${DUALSTACK:-False} $TEST_RESULTS_FILE \
       $TEST_TYPE
   workingDirectory: modules/python/clusterloader2
   env:

--- a/steps/engine/clusterloader2/slo/collect.yml
+++ b/steps/engine/clusterloader2/slo/collect.yml
@@ -15,9 +15,6 @@ steps:
 - script: |
     set -eo pipefail
 
-    echo "max : ${MAX_PODS}"
-    echo "${MAX_PODS:-0}"
-
     PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE collect \
       $CPU_PER_NODE $NODE_COUNT ${MAX_PODS:-0} \
       $REPEATS $CL2_REPORT_DIR "$CLOUD_INFO" $RUN_ID $RUN_URL $SERVICE_TEST ${CNP_TEST:-False} ${CCNP_TEST:-False} ${NUM_CNPS:-0} ${NUM_CCNPS:-0} ${DUALSTACK:-False} $TEST_RESULTS_FILE \

--- a/steps/engine/clusterloader2/slo/collect.yml
+++ b/steps/engine/clusterloader2/slo/collect.yml
@@ -15,8 +15,11 @@ steps:
 - script: |
     set -eo pipefail
 
+    echo "max : ${MAX_PODS}"
+    echo "${MAX_PODS:-0}"
+
     PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE collect \
-      $CPU_PER_NODE $NODE_COUNT $MAX_PODS ${PODS_IN_NODE:-0} \
+      $CPU_PER_NODE $NODE_COUNT ${MAX_PODS:-0} \
       $REPEATS $CL2_REPORT_DIR "$CLOUD_INFO" $RUN_ID $RUN_URL $SERVICE_TEST ${CNP_TEST:-False} ${CCNP_TEST:-False} ${NUM_CNPS:-0} ${NUM_CCNPS:-0} ${DUALSTACK:-False} $TEST_RESULTS_FILE \
       $TEST_TYPE
   workingDirectory: modules/python/clusterloader2

--- a/steps/engine/clusterloader2/slo/execute.yml
+++ b/steps/engine/clusterloader2/slo/execute.yml
@@ -12,8 +12,11 @@ steps:
   - script: |
       set -eo pipefail
 
+      echo "max : ${MAX_PODS}"
+      echo "${MAX_PODS:-0}"
+
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE configure \
-        $CPU_PER_NODE $NODE_COUNT $NODE_PER_STEP $MAX_PODS ${PODS_IN_NODE:-0} \
+        $CPU_PER_NODE $NODE_COUNT $NODE_PER_STEP ${MAX_PODS:-0} \
         $REPEATS $SCALE_TIMEOUT $CLOUD $CILIUM_ENABLED \
         $SERVICE_TEST ${CNP_TEST:-False} ${CCNP_TEST:-False} ${NUM_CNPS:-0} ${NUM_CCNPS:-0} ${DUALSTACK:-False} ${CL2_CONFIG_DIR}/overrides.yaml
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \

--- a/steps/engine/clusterloader2/slo/execute.yml
+++ b/steps/engine/clusterloader2/slo/execute.yml
@@ -13,9 +13,9 @@ steps:
       set -eo pipefail
 
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE configure \
-        $CPU_PER_NODE $NODE_COUNT $NODE_PER_STEP $MAX_PODS \
+        $CPU_PER_NODE $NODE_COUNT $NODE_PER_STEP $MAX_PODS ${PODS_IN_NODE:-0} \
         $REPEATS $SCALE_TIMEOUT $CLOUD $CILIUM_ENABLED \
-        $SERVICE_TEST ${CL2_CONFIG_DIR}/overrides.yaml
+        $SERVICE_TEST ${CNP_TEST:-False} ${CCNP_TEST:-False} ${NUM_CNPS:-0} ${NUM_CCNPS:-0} ${DUALSTACK:-False} ${CL2_CONFIG_DIR}/overrides.yaml
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \
         ${CL2_IMAGE} ${CL2_CONFIG_DIR} $CL2_REPORT_DIR $CL2_CONFIG_FILE \
         ${HOME}/.kube/config $CLOUD

--- a/steps/engine/clusterloader2/slo/execute.yml
+++ b/steps/engine/clusterloader2/slo/execute.yml
@@ -12,9 +12,6 @@ steps:
   - script: |
       set -eo pipefail
 
-      echo "max : ${MAX_PODS}"
-      echo "${MAX_PODS:-0}"
-
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE configure \
         $CPU_PER_NODE $NODE_COUNT $NODE_PER_STEP ${MAX_PODS:-0} \
         $REPEATS $SCALE_TIMEOUT $CLOUD $CILIUM_ENABLED \


### PR DESCRIPTION
I created a Cilium Network Policy and Cilium Cluster Wide Network Policy pipeline that will deploy a set number of CCNPS and CNPS that match to pods. It will also scale to a certain number of nodes and scale to a set number of pods. The policies have egress and ingress rules to reflect customer usage and to be able to test control plane resource usage consumption. This test is created based on the existing service churn pipeline framework. 

I created this test to be able to find the cilium cpu, memory, and apiserver usage through testing a 1000 node cilium cluster with endpoints as well as a 3000 node cilium cluster with CES enabled. This is for the upcoming official release of the cnp/ccnp feature. 

Here is the link to my pipeline: https://dev.azure.com/akstelescope/telescope/_build?definitionId=37 and here is a link to a successful run: https://dev.azure.com/akstelescope/telescope/_build/results?buildId=9548&view=results

Since I made changes to files that the other pipelines use, I'm running Service & Cluster Churn:

Regular Pipelines:
- Service Churn: https://dev.azure.com/akstelescope/telescope/_build/results?buildId=9545&view=results
- Cluster Churn: https://dev.azure.com/akstelescope/telescope/_build/results?buildId=9546&view=results