### PR TITLE
Install bc package

### DIFF
--- a/steps/setup-tests.yml
+++ b/steps/setup-tests.yml
@@ -62,7 +62,9 @@ steps:
     if [ -f "$(Pipeline.Workspace)/s/modules/python/requirements.txt" ]; then
       pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
     fi
-  displayName: "Install Python Dependencies"
+
+    sudo apt-get -y install bc
+  displayName: "Install Dependencies"
 
 - template: /steps/cloud/${{ parameters.cloud }}/login.yml
   parameters:


### PR DESCRIPTION
- In the latest version ubuntu Image bc package was removed. We need to install the package manually, since storage test is failing because of this missing package.