### PR TITLE
Add node readiness and pod startup measurement for CRI test case

### DIFF
--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -4,9 +4,11 @@ name: resource-consumer
 {{$memory := DefaultParam .CL2_RESOURCE_CONSUME_MEMORY 100}}
 {{$cpu := DefaultParam .CL2_RESOURCE_CONSUME_CPU 100}}
 {{$repeats := DefaultParam .CL2_REPEATS 1}}
+{{$totalNodes := DefaultParam .CL2_NODE_COUNT 10}}
 {{$nodePools := DefaultParam .CL2_NODEPOOL 1}}
 {{$agentPoolPrefix := DefaultParam .CL2_AGENTPOOL_PREFIX "userpool"}}
 {{$operationTimeout := DefaultParam .CL2_OPERATION_TIMEOUT "5m"}}
+{{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "15s"}}
 
 namespace:
   number: 1
@@ -23,6 +25,12 @@ tuningSets:
 steps:
   - name: Start measurements
     measurements:
+      - Identifier: PodStartupLatency
+        Method: PodStartupLatency
+        Params:
+          action: start
+          labelSelector: group = resource-consumer
+          threshold: {{$podStartupLatencyThreshold}}
       - Identifier: ResourceUsageSummary
         Method: ResourceUsageSummary
         Params:
@@ -64,6 +72,18 @@ steps:
         Params:
           action: gather
 
+  - name: Wait for nodes to be ready
+    measurements:
+      - Identifier: ConfirmNodeCount
+        Method: WaitForNodes
+        Params:
+          action: start
+          minDesiredNodeCount: {{$totalNodes}}
+          maxDesiredNodeCount: {{$totalNodes}}
+          labelSelector: cri-resource-consume = true
+          timeout: {{$operationTimeout}}
+          refreshInterval: 1m
+
   - name: Deleting deployments
     phases:
       - namespaceRange:
@@ -88,5 +108,9 @@ steps:
     measurements:
       - Identifier: ResourceUsageSummary
         Method: ResourceUsageSummary
+        Params:
+          action: gather
+      - Identifier: PodStartupLatency
+        Method: PodStartupLatency
         Params:
           action: gather

--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -39,11 +39,13 @@ def override_config_clusterloader2(node_count, max_pods, repeats, operation_time
         file.write(f"CL2_RESOURCE_CONSUME_MEMORY: {memory_request}\n")
         file.write(f"CL2_RESOURCE_CONSUME_CPU: {cpu_request}\n")
         file.write(f"CL2_REPEATS: {repeats}\n")
+        file.write(f"CL2_NODE_COUNT: {node_count}\n")
         file.write(f"CL2_OPERATION_TIMEOUT: {operation_timeout}\n")
         file.write(f"CL2_PROMETHEUS_TOLERATE_MASTER: true\n")
         file.write("CL2_PROMETHEUS_MEMORY_LIMIT_FACTOR: 30.0\n")
         file.write("CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 30.0\n")
         file.write("CL2_PROMETHEUS_NODE_SELECTOR: \"prometheus: \\\"true\\\"\"\n")
+        file.write("CL2_POD_STARTUP_LATENCY_THRESHOLD: 3m\n")
 
     file.close()
 

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -41,7 +41,7 @@ stages:
               max_pods: 110
               repeats: 10
               operation_timeout: 11m
-          max_parallel: 1
+          max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection
           ssh_key_enabled: false
@@ -73,7 +73,7 @@ stages:
               max_pods: 110
               repeats: 10
               operation_timeout: 11m
-          max_parallel: 1
+          max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection
           ssh_key_enabled: false

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -26,11 +26,21 @@ stages:
             image: "ghcr.io/azure/clusterloader2:v20241016"
           topology: cri-resource-consume
           matrix:
-            n10-p500:
+            n10-p300:
               node_count: 10
               max_pods: 30
-              repeats: 1
-              operation_timeout: 5m
+              repeats: 10
+              operation_timeout: 3m
+            n10-p700:
+              node_count: 10
+              max_pods: 70
+              repeats: 10
+              operation_timeout: 7m
+            n10-p1100:
+              node_count: 10
+              max_pods: 110
+              repeats: 10
+              operation_timeout: 11m
           max_parallel: 1
           timeout_in_minutes: 120
           credential_type: service_connection
@@ -48,11 +58,21 @@ stages:
             image: "ghcr.io/azure/clusterloader2:v20241016"
           topology: cri-resource-consume
           matrix:
-            n10-p500:
-              node_count: 3
+            n10-p300:
+              node_count: 10
               max_pods: 30
-              repeats: 1
-              operation_timeout: 5m
+              repeats: 10
+              operation_timeout: 3m
+            n10-p700:
+              node_count: 10
+              max_pods: 70
+              repeats: 10
+              operation_timeout: 7m
+            n10-p1100:
+              node_count: 10
+              max_pods: 110
+              repeats: 10
+              operation_timeout: 11m
           max_parallel: 1
           timeout_in_minutes: 120
           credential_type: service_connection

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -26,9 +26,9 @@ stages:
             image: "ghcr.io/azure/clusterloader2:v20241016"
           topology: cri-resource-consume
           matrix:
-            n3-p330:
-              node_count: 3
-              max_pods: 110
+            n10-p500:
+              node_count: 10
+              max_pods: 30
               repeats: 1
               operation_timeout: 5m
           max_parallel: 1
@@ -48,9 +48,9 @@ stages:
             image: "ghcr.io/azure/clusterloader2:v20241016"
           topology: cri-resource-consume
           matrix:
-            n3-p330:
+            n10-p500:
               node_count: 3
-              max_pods: 110
+              max_pods: 30
               repeats: 1
               operation_timeout: 5m
           max_parallel: 1


### PR DESCRIPTION
This pull request includes several changes to the configuration and benchmarking setup for the `cri-resource-consume` pipeline. The most important changes include adding new parameters to the configuration file, updating the measurement steps, and modifying the node count and pod limits in the benchmarking pipeline.

Configuration updates:

* [`modules/python/clusterloader2/cri/config/config.yaml`](diffhunk://#diff-c5503c64b4e04dc3563dcb183ba27fd6d8805893f99f195ea3d7f84a9dc7c026R7-R11): Added new parameters `CL2_NODE_COUNT` and `CL2_POD_STARTUP_LATENCY_THRESHOLD` to the configuration.
* [`modules/python/clusterloader2/cri/config/config.yaml`](diffhunk://#diff-c5503c64b4e04dc3563dcb183ba27fd6d8805893f99f195ea3d7f84a9dc7c026R75-R86): Added a new measurement step to wait for nodes to be ready, ensuring the node count matches the desired value.

Measurement updates:

* [`modules/python/clusterloader2/cri/config/config.yaml`](diffhunk://#diff-c5503c64b4e04dc3563dcb183ba27fd6d8805893f99f195ea3d7f84a9dc7c026R28-R33): Introduced `PodStartupLatency` measurement to track pod startup latency and set a threshold for this metric. [[1]](diffhunk://#diff-c5503c64b4e04dc3563dcb183ba27fd6d8805893f99f195ea3d7f84a9dc7c026R28-R33) [[2]](diffhunk://#diff-c5503c64b4e04dc3563dcb183ba27fd6d8805893f99f195ea3d7f84a9dc7c026R113-R116)

Benchmarking pipeline updates:

* [`modules/python/clusterloader2/cri/cri.py`](diffhunk://#diff-97db04680354c69b105b2b5991eb78993027db07b934ec8ef2ad2b4d5911a75fR42-R48): Updated the `override_config_clusterloader2` function to include the new parameters `CL2_NODE_COUNT` and `CL2_POD_STARTUP_LATENCY_THRESHOLD`.
* [`pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml`](diffhunk://#diff-b6974b7dd6c85a6e59e64c0ba70d0963e94f0eb5a6ea49cd30359e6efc9aaa56L29-R31): Changed the node count from 3 to 10 and adjusted the maximum pods per node from 110 to 30 in the benchmarking matrix. [[1]](diffhunk://#diff-b6974b7dd6c85a6e59e64c0ba70d0963e94f0eb5a6ea49cd30359e6efc9aaa56L29-R31) [[2]](diffhunk://#diff-b6974b7dd6c85a6e59e64c0ba70d0963e94f0eb5a6ea49cd30359e6efc9aaa56L51-R53)