### PR TITLE
add code owner for CNI test cases

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @alyssa1303 @anson627 @sumanthreddy29 @rafael-mendes-pereira
-pipelines/perf-eval/CNI Benchmark/ @jshr-w
+pipelines/perf-eval/CNI\ Benchmark/ @jshr-w
 scenarios/perf-eval/*cilium* @jshr-w

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @alyssa1303 @anson627 @sumanthreddy29 @rafael-mendes-pereira
-pipelines/perf-eval/CNI Benchmark/* @jshr-w
-scenarios/perf-eval/cilium* @jshr-w
+pipelines/perf-eval/CNI Benchmark/ @jshr-w
+scenarios/perf-eval/*cilium* @jshr-w

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 * @alyssa1303 @anson627 @sumanthreddy29 @rafael-mendes-pereira
+pipelines/perf-eval/CNI Benchmark/* @jshr-w
+scenarios/perf-eval/cilium* @jshr-w


### PR DESCRIPTION
This pull request includes a small change to the `CODEOWNERS` file. The change assigns ownership of specific files to a new team member.

Ownership changes in `CODEOWNERS`:

* Added `@jshr-w` as the owner of files in `pipelines/perf-eval/CNI Benchmark/*` and `scenarios/perf-eval/cilium*`.