### PR TITLE
Update CRI resource consume tests

### DIFF
--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -29,19 +29,19 @@ stages:
             n10-p300:
               node_count: 10
               max_pods: 30
-              repeats: 10
+              repeats: 1
               operation_timeout: 3m
             n10-p700:
               node_count: 10
               max_pods: 70
-              repeats: 10
+              repeats: 1
               operation_timeout: 7m
             n10-p1100:
               node_count: 10
               max_pods: 110
-              repeats: 10
+              repeats: 1
               operation_timeout: 11m
-          max_parallel: 3
+          max_parallel: 1
           timeout_in_minutes: 120
           credential_type: service_connection
           ssh_key_enabled: false
@@ -61,19 +61,19 @@ stages:
             n10-p300:
               node_count: 10
               max_pods: 30
-              repeats: 10
+              repeats: 1
               operation_timeout: 3m
             n10-p700:
               node_count: 10
               max_pods: 70
-              repeats: 10
+              repeats: 1
               operation_timeout: 7m
             n10-p1100:
               node_count: 10
               max_pods: 110
-              repeats: 10
+              repeats: 1
               operation_timeout: 11m
-          max_parallel: 3
+          max_parallel: 1
           timeout_in_minutes: 120
           credential_type: service_connection
           ssh_key_enabled: false

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars
@@ -84,9 +84,9 @@ eks_config_list = [{
       name           = "userpool0"
       ami_type       = "AL2_x86_64"
       instance_types = ["m5.4xlarge"]
-      min_size       = 3
-      max_size       = 3
-      desired_size   = 3
+      min_size       = 10
+      max_size       = 10
+      desired_size   = 10
       capacity_type  = "ON_DEMAND"
       taints = [
         {

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -32,7 +32,7 @@ aks_config_list = [
       },
       {
         name        = "userpool0"
-        node_count  = 3
+        node_count  = 10
         vm_size     = "Standard_D16s_v3"
         node_taints = ["cri-resource-consume=true:NoSchedule"]
         node_labels = { "cri-resource-consume" = "true" }


### PR DESCRIPTION
This pull request includes several changes to the performance evaluation pipeline for the CRI benchmark. The main updates involve reducing the number of repeats for certain stages, adjusting the maximum parallel operations, and modifying the configuration for AWS and Azure scenarios to increase the number of nodes.

Changes to pipeline stages:

* [`pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml`](diffhunk://#diff-b6974b7dd6c85a6e59e64c0ba70d0963e94f0eb5a6ea49cd30359e6efc9aaa56L32-R44): Reduced the `repeats` from 10 to 1 for various node and pod configurations, and changed `max_parallel` from 3 to 1. [[1]](diffhunk://#diff-b6974b7dd6c85a6e59e64c0ba70d0963e94f0eb5a6ea49cd30359e6efc9aaa56L32-R44) [[2]](diffhunk://#diff-b6974b7dd6c85a6e59e64c0ba70d0963e94f0eb5a6ea49cd30359e6efc9aaa56L64-R76)

Configuration changes for AWS:

* [`scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars`](diffhunk://#diff-d833a32e29f9b21994b6a60a83ddf61bfc0af647420db301f9a7950c65873072L87-R89): Increased `min_size`, `max_size`, and `desired_size` from 3 to 10 for the `userpool0` configuration.

Configuration changes for Azure:

* [`scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars`](diffhunk://#diff-12a0e29365f4804cfe7c279c0b4b36aa5de1d3687c4c675596119ccb91a64d34L35-R35): Increased `node_count` from 3 to 10 for the `userpool0` configuration.