### PR TITLE
Update CIDR range for CRI test

### DIFF
--- a/modules/terraform/azure/README.md
+++ b/modules/terraform/azure/README.md
@@ -86,7 +86,7 @@ Set `INPUT_JSON` variable. This variable is not exhaustive and may vary dependin
 ```bash
 pushd $TERRAFORM_MODULES_DIR
 terraform init
-terraform plan  -var json_input=$(echo $INPUT_JSON | jq -c .) -var-file $TERRAFORM_INPUT_FILE
+terraform plan -var json_input=$(echo $INPUT_JSON | jq -c .) -var-file $TERRAFORM_INPUT_FILE
 terraform apply -var json_input=$(echo $INPUT_JSON | jq -c .) -var-file $TERRAFORM_INPUT_FILE
 popd
 ```

--- a/modules/terraform/azure/README.md
+++ b/modules/terraform/azure/README.md
@@ -53,7 +53,7 @@ export ARM_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 Create Resource Group for testing
 
 ```bash
-az group create --name $RUN_ID --location $REGION --tags "run_id=$RUN_ID" "scenario=${SCENARIO_TYPE}-${SCENARIO_NAME}" "owner=aks" "creation_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "deletion_due_time=$(date -u -v +2H +'%Y-%m-%dT%H:%M:%SZ')"
+az group create --name $RUN_ID --location $REGION --tags "run_id=$RUN_ID" "scenario=${SCENARIO_TYPE}-${SCENARIO_NAME}" "owner=aks" "creation_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "deletion_due_time=$(date -u -d '+2 hour' +'%Y-%m-%dT%H:%M:%SZ')"
 ```
 
 Set `INPUT_JSON` variable. This variable is not exhaustive and may vary depending on the scenario. For a full list of what can be set, look for `json_input` in file [`modules/terraform/azure/variables.tf`](../../../modules/terraform/azure/variables.tf) as the list will keep changing as we add more features.

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars
@@ -1,6 +1,6 @@
 scenario_type  = "perf-eval"
 scenario_name  = "cri-resource-consume"
-deletion_delay = "120h"
+deletion_delay = "2h"
 owner          = "aks"
 
 network_config_list = [
@@ -11,13 +11,13 @@ network_config_list = [
     subnet = [
       {
         name                    = "client-subnet"
-        cidr_block              = "10.0.0.0/24"
+        cidr_block              = "10.0.0.0/17"
         zone_suffix             = "a"
         map_public_ip_on_launch = true
       },
       {
         name                    = "client-subnet-2"
-        cidr_block              = "10.0.1.0/24"
+        cidr_block              = "10.0.128.0/17"
         zone_suffix             = "b"
         map_public_ip_on_launch = true
       }

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -1,18 +1,38 @@
 scenario_type  = "perf-eval"
 scenario_name  = "cri-resource-consume"
-deletion_delay = "240h"
+deletion_delay = "2h"
 owner          = "aks"
+
+network_config_list = [
+  {
+    role               = "client"
+    vnet_name          = "cri-vnet"
+    vnet_address_space = "10.0.0.0/9"
+    subnet = [
+      {
+        name           = "cri-subnet-1"
+        address_prefix = "10.0.0.0/16"
+      }
+    ]
+    network_security_group_name = ""
+    nic_public_ip_associations  = []
+    nsr_rules                   = []
+  }
+]
 
 aks_config_list = [
   {
     role        = "client"
     aks_name    = "cri-resource-consume"
-    dns_prefix  = "cl2"
-    subnet_name = "aks-network"
+    dns_prefix  = "cri"
+    subnet_name = "cri-vnet"
     sku_tier    = "Standard"
     network_profile = {
       network_plugin      = "azure"
       network_plugin_mode = "overlay"
+      pod_cidr            = "10.0.0.0/9"
+      service_cidr        = "192.168.0.0/16"
+      dns_service_ip      = "192.168.0.10"
     }
     default_node_pool = {
       name                         = "default"
@@ -31,11 +51,12 @@ aks_config_list = [
         node_labels          = { "prometheus" = "true" }
       },
       {
-        name        = "userpool0"
-        node_count  = 10
-        vm_size     = "Standard_D16s_v3"
-        node_taints = ["cri-resource-consume=true:NoSchedule"]
-        node_labels = { "cri-resource-consume" = "true" }
+        name                 = "userpool0"
+        node_count           = 10
+        auto_scaling_enabled = false
+        vm_size              = "Standard_D16s_v3"
+        node_taints          = ["cri-resource-consume=true:NoSchedule"]
+        node_labels          = { "cri-resource-consume" = "true" }
       }
     ]
     kubernetes_version = "1.30"


### PR DESCRIPTION
Increase CIDR range for test so pods can get schedule for scenarios with 70 and 110 pods per node