### PR TITLE
Break down CRI benchmark into separate load type

### DIFF
--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -10,6 +10,7 @@ name: resource-consumer
 {{$agentPoolPrefix := DefaultParam .CL2_AGENTPOOL_PREFIX "userpool"}}
 {{$operationTimeout := DefaultParam .CL2_OPERATION_TIMEOUT "5m"}}
 {{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "15s"}}
+{{$loadType := DefaultParam .CL2_LOAD_TYPE "memory"}}
 
 namespace:
   number: 1
@@ -67,6 +68,7 @@ steps:
           MemoryRequest: {{$memoryKi}}
           CPURequest: {{$cpu}}m
           AgentPool: {{$agentPoolPrefix}}{{$i}}
+          LoadType: {{$loadType}}
 
   - name: Waiting for latency pods to be running
     measurements:

--- a/modules/python/clusterloader2/cri/config/deployment_template.yaml
+++ b/modules/python/clusterloader2/cri/config/deployment_template.yaml
@@ -3,6 +3,7 @@
 {{$MemoryRequest := DefaultParam .MemoryRequest "1000Ki"}}
 {{$CPURequest := DefaultParam .CPURequest "100m"}}
 {{$AgentPool := DefaultParam .AgentPool "userpool1"}}
+{{$LoadType := DefaultParam .LoadType "memory"}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -24,6 +25,7 @@ spec:
       nodeSelector:
         agentpool: {{$AgentPool}}
       containers:
+{{if eq $LoadType "memory"}}
       - name: resource-consumer-memory
         image: registry.k8s.io/e2e-test-images/resource-consumer:1.9
         command:
@@ -40,6 +42,8 @@ spec:
         resources:
           requests:
             memory: {{$MemoryRequest}}
+{{end}}
+{{if eq $LoadType "cpu"}}
       - name: resource-consumer-cpu
         image: registry.k8s.io/e2e-test-images/resource-consumer:1.9
         command:
@@ -50,6 +54,7 @@ spec:
         resources:
           requests:
             cpu: {{$CPURequest}}
+{{end}}
       tolerations:
       - key: "cri-resource-consume"
         operator: "Equal"

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -26,21 +26,42 @@ stages:
             image: "ghcr.io/azure/clusterloader2:v20241016"
           topology: cri-resource-consume
           matrix:
-            n10-p300:
+            n10-p300-memory:
               node_count: 10
               max_pods: 30
               repeats: 1
               operation_timeout: 3m
-            n10-p700:
+              load_type: memory
+            n10-p700-memory:
               node_count: 10
               max_pods: 70
               repeats: 1
               operation_timeout: 7m
-            n10-p1100:
+              load_type: memory
+            n10-p1100-memory:
               node_count: 10
               max_pods: 110
               repeats: 1
               operation_timeout: 11m
+              load_type: memory
+            n10-p300-cpu:
+              node_count: 10
+              max_pods: 30
+              repeats: 1
+              operation_timeout: 3m
+              load_type: cpu
+            n10-p700-cpu:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: cpu
+            n10-p1100-cpu:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: cpu
           max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection
@@ -58,21 +79,42 @@ stages:
             image: "ghcr.io/azure/clusterloader2:v20241016"
           topology: cri-resource-consume
           matrix:
-            n10-p300:
+            n10-p300-memory:
               node_count: 10
               max_pods: 30
               repeats: 1
               operation_timeout: 3m
-            n10-p700:
+              load_type: memory
+            n10-p700-memory:
               node_count: 10
               max_pods: 70
               repeats: 1
               operation_timeout: 7m
-            n10-p1100:
+              load_type: memory
+            n10-p1100-memory:
               node_count: 10
               max_pods: 110
               repeats: 1
               operation_timeout: 11m
+              load_type: memory
+            n10-p300-cpu:
+              node_count: 10
+              max_pods: 30
+              repeats: 1
+              operation_timeout: 3m
+              load_type: cpu
+            n10-p700-cpu:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: cpu
+            n10-p1100-cpu:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: cpu
           max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection

--- a/steps/engine/clusterloader2/cri/execute.yml
+++ b/steps/engine/clusterloader2/cri/execute.yml
@@ -13,7 +13,8 @@ steps:
       set -eo pipefail
 
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE override \
-        $NODE_COUNT $MAX_PODS $REPEATS $OPERATION_TIMEOUT $CLOUD ${CL2_CONFIG_DIR}/overrides.yaml
+        $NODE_COUNT $MAX_PODS $REPEATS $OPERATION_TIMEOUT $LOAD_TYPE \
+        $CLOUD ${CL2_CONFIG_DIR}/overrides.yaml
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \
         ${CL2_IMAGE} ${CL2_CONFIG_DIR} $CL2_REPORT_DIR ${HOME}/.kube/config $CLOUD
     workingDirectory: modules/python/clusterloader2


### PR DESCRIPTION
- Break down deployment template into running either CPU or Memory load
- Add a new parameter in matrix to distinguish between load type