### PR TITLE
add parameters to feature testing pipeline

### DIFF
--- a/modules/python/clusterloader2/slo/slo.py
+++ b/modules/python/clusterloader2/slo/slo.py
@@ -30,7 +30,7 @@ def calculate_config(cpu_per_node, node_count, max_pods, provider, service_test,
 
     pods_per_node = DEFAULT_PODS_PER_NODE
     if service_test:
-        pods_per_node = LOAD_PODS_PER_NODE
+        pods_per_node = max_pods
 
     if cnp_test or ccnp_test:
         pods_per_node = max_pods
@@ -54,7 +54,7 @@ def configure_clusterloader2(
     provider,
     cilium_enabled,
     service_test,
-    cnp_test, 
+    cnp_test,
     ccnp_test,
     num_cnps,
     num_ccnps,
@@ -65,6 +65,7 @@ def configure_clusterloader2(
     throughput, nodes_per_namespace, pods_per_node, cpu_request = calculate_config(cpu_per_node, node_per_step, max_pods, provider, service_test, cnp_test, ccnp_test)
 
     with open(override_file, 'w') as file:
+        file.write(f"CL2_NODES: {node_count}\n")
         file.write(f"CL2_LOAD_TEST_THROUGHPUT: {throughput}\n")
         file.write(f"CL2_NODES_PER_NAMESPACE: {nodes_per_namespace}\n")
         file.write(f"CL2_NODES_PER_STEP: {node_per_step}\n")
@@ -136,7 +137,7 @@ def collect_clusterloader2(
     run_id,
     run_url,
     service_test,
-    cnp_test, 
+    cnp_test,
     ccnp_test,
     num_cnps,
     num_ccnps,
@@ -274,7 +275,7 @@ def main():
                                 help="Description of test type")
 
     args = parser.parse_args()
-    
+
     if args.command == "configure":
         configure_clusterloader2(args.cpu_per_node, args.node_count, args.node_per_step, args.max_pods,
                                  args.repeats, args.operation_timeout, args.provider, args.cilium_enabled,

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-ces.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-ces.yml
@@ -32,7 +32,7 @@ stages:
               cpu_per_node: 4
               node_count: 1000
               node_per_step: 1000
-              max_pods: 110
+              max_pods: 20
               repeats: 10
               scale_timeout: "15m"
               cilium_enabled: True

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
@@ -31,7 +31,7 @@ stages:
               cpu_per_node: 4
               node_count: 1000
               node_per_step: 1000
-              max_pods: 110
+              max_pods: 20
               repeats: 10
               scale_timeout: "15m"
               cilium_enabled: True

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-feature.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-feature.yml
@@ -22,10 +22,10 @@ stages:
           matrix:
             azure_cilium:
               cpu_per_node: 4
-              node_count: 1000
-              node_per_step: 1000
-              max_pods: 110
-              repeats: 10
+              node_count: $(NODES)
+              node_per_step: $(NODES)
+              max_pods: $(PODS)
+              repeats: $(REPEATS)
               scale_timeout: "15m"
               cilium_enabled: True
               network_policy: cilium

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-feature.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-feature.yml
@@ -25,7 +25,7 @@ stages:
               node_count: $(NODES)
               node_per_step: $(NODES)
               max_pods: $(PODS)
-              repeats: $(REPEATS)
+              repeats: $(NO_REPEATS)
               scale_timeout: "15m"
               cilium_enabled: True
               network_policy: cilium

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery.yml
@@ -30,7 +30,7 @@ stages:
               cpu_per_node: 4
               node_count: 1000
               node_per_step: 1000
-              max_pods: 110
+              max_pods: 20
               repeats: 10
               scale_timeout: "15m"
               cilium_enabled: False
@@ -57,7 +57,7 @@ stages:
               cpu_per_node: 4
               node_count: 1000
               node_per_step: 1000
-              max_pods: 110
+              max_pods: 20
               repeats: 10
               scale_timeout: "15m"
               cilium_enabled: False
@@ -67,7 +67,7 @@ stages:
               cpu_per_node: 4
               node_count: 1000
               node_per_step: 1000
-              max_pods: 110
+              max_pods: 20
               repeats: 10
               scale_timeout: "15m"
               cilium_enabled: True


### PR DESCRIPTION
Parameterize pod count in service churn pipelines.
Allow node count, pod count and repeats to be overridden in feature pipeline.