### PR TITLE
Decrease frequency for Autoscaler tests

### DIFF
--- a/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes10-pods100.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes10-pods100.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
-  - cron: "0 */2 * * *"
-    displayName: "Every 2 Hour"
+  - cron: "0 1,13 * * *"
+    displayName: "1:00 AM & PM Daily"
     branches:
       include:
         - main

--- a/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes10-pods100.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes10-pods100.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
-  - cron: "0 */2 * * *"
-    displayName: "Every 2 Hour"
+  - cron: "0 1,13 * * *"
+    displayName: "1:00 AM & PM Daily"
     branches:
       include:
         - main


### PR DESCRIPTION
This pull request updates the scheduling of two benchmark pipelines to run at specific times daily instead of every two hours.

Scheduling updates:

* [`pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes10-pods100.yml`](diffhunk://#diff-f1a6502837f61665fdc938595ea2d86e934f1dee2b87e3a3ab0bb60383858317L3-R4): Changed the cron schedule to "1:00 AM & PM Daily" from "Every 2 Hour".
* [`pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes10-pods100.yml`](diffhunk://#diff-739c88c91ccbac7d81ab4ee1ecbf459dd7bb020fdb9aa34deced949bc577cc0bL3-R4): Changed the cron schedule to "1:00 AM & PM Daily" from "Every 2 Hour".