### PR TITLE
Support scaling operation for CRI test

### DIFF
--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -7,7 +7,7 @@ name: resource-consumer
 {{$repeats := DefaultParam .CL2_REPEATS 1}}
 
 {{$steps := DefaultParam .CL2_STEPS 1}}
-{{$nodePerStep := DefaultParam .CL2_NODES_PER_STEP 1}}
+{{$nodePerStep := DefaultParam .CL2_NODE_PER_STEP 1}}
 {{$totalNodes := MultiplyInt $nodePerStep $steps}}
 {{$replicas := MultiplyInt $deploymentSize $totalNodes}}
 {{$scaleReplicas := MultiplyInt $deploymentSize $nodePerStep}}
@@ -66,15 +66,15 @@ steps:
       - basename: resource-consumer-{{$j}}
         objectTemplatePath: deployment_template.yaml
         templateFillMap:
-        {{if $scale_enabled}}
-          {{if eq $j 0}}
-            Replicas: {{AddInt $scaleReplicas $deploymentSize}}
-          {{else}}
-            Replicas: {{$scaleReplicas}}
-          {{end}}
+      {{if $scale_enabled}}
+        {{if eq $j 0}}
+          Replicas: {{AddInt $scaleReplicas $deploymentSize}}
         {{else}}
-          Replicas: {{$replicas}}
+          Replicas: {{$scaleReplicas}}
         {{end}}
+      {{else}}
+          Replicas: {{$replicas}}
+      {{end}}
           Group: resource-consumer
           Memory: {{$memory}}K
           CPU: --millicores={{$cpu}}
@@ -102,13 +102,13 @@ steps:
         Method: WaitForNodes
         Params:
           action: start
-          {{if $scale_enabled}}
-            minDesiredNodeCount: {{MultiplyInt (AddInt $totalNodes 1) 0.8}}
-            maxDesiredNodeCount: {{AddInt $totalNodes 1}}
-          {{else}}
-            minDesiredNodeCount: {{MultiplyInt $totalNodes 0.8}}
-            maxDesiredNodeCount: {{$totalNodes}}
-          {{end}}
+        {{if $scale_enabled}}
+          minDesiredNodeCount: {{MultiplyInt (AddInt (MultiplyInt $nodePerStep (AddInt $j 1)) 1) 0.8}}
+          maxDesiredNodeCount: {{AddInt $totalNodes 1}}
+        {{else}}
+          minDesiredNodeCount: {{MultiplyInt $totalNodes 0.8}}
+          maxDesiredNodeCount: {{$totalNodes}}
+        {{end}}
           labelSelector: cri-resource-consume = true
           timeout: 1m
           refreshInterval: 5s

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -8,8 +8,10 @@ name: resource-consumer
 
 {{$steps := DefaultParam .CL2_STEPS 1}}
 {{$nodePerStep := DefaultParam .CL2_NODES_PER_STEP 1}}
-{{$totalNodes := AddInt (MultiplyInt $nodePerStep $steps) 1}}
-{{$deploymentSizePerStep := DivideInt $deploymentSize $steps}}
+{{$totalNodes := MultiplyInt $nodePerStep $steps}}
+{{$replicas := MultiplyInt $deploymentSize $totalNodes}}
+{{$scaleReplicas := MultiplyInt $deploymentSize $nodePerStep}}
+{{$scale_enabled := DefaultParam .CL2_SCALE_ENABLED false}}
 
 {{$operationTimeout := DefaultParam .CL2_OPERATION_TIMEOUT "5m"}}
 {{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "15s"}}
@@ -64,7 +66,15 @@ steps:
       - basename: resource-consumer-{{$j}}
         objectTemplatePath: deployment_template.yaml
         templateFillMap:
-          Replicas: {{$deploymentSizePerStep}}
+        {{if $scale_enabled}}
+          {{if eq $j 0}}
+            Replicas: {{AddInt $scaleReplicas $deploymentSize}}
+          {{else}}
+            Replicas: {{$scaleReplicas}}
+          {{end}}
+        {{else}}
+          Replicas: {{$replicas}}
+        {{end}}
           Group: resource-consumer
           Memory: {{$memory}}K
           CPU: --millicores={{$cpu}}
@@ -92,8 +102,13 @@ steps:
         Method: WaitForNodes
         Params:
           action: start
-          minDesiredNodeCount: {{MultiplyInt $totalNodes 0.8}}
-          maxDesiredNodeCount: {{$totalNodes}}
+          {{if $scale_enabled}}
+            minDesiredNodeCount: {{MultiplyInt (AddInt $totalNodes 1) 0.8}}
+            maxDesiredNodeCount: {{AddInt $totalNodes 1}}
+          {{else}}
+            minDesiredNodeCount: {{MultiplyInt $totalNodes 0.8}}
+            maxDesiredNodeCount: {{$totalNodes}}
+          {{end}}
           labelSelector: cri-resource-consume = true
           timeout: 1m
           refreshInterval: 5s

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -5,9 +5,12 @@ name: resource-consumer
 {{$memoryKi := DefaultParam .CL2_RESOURCE_CONSUME_MEMORY_KI "100"}}
 {{$cpu := DefaultParam .CL2_RESOURCE_CONSUME_CPU 100}}
 {{$repeats := DefaultParam .CL2_REPEATS 1}}
-{{$totalNodes := DefaultParam .CL2_NODE_COUNT 10}}
-{{$nodePools := DefaultParam .CL2_NODEPOOL 1}}
-{{$agentPoolPrefix := DefaultParam .CL2_AGENTPOOL_PREFIX "userpool"}}
+
+{{$steps := DefaultParam .CL2_STEPS 1}}
+{{$nodePerStep := DefaultParam .CL2_NODES_PER_STEP 1}}
+{{$totalNodes := AddInt (MultiplyInt $nodePerStep $steps) 1}}
+{{$deploymentSizePerStep := DivideInt $deploymentSize $steps}}
+
 {{$operationTimeout := DefaultParam .CL2_OPERATION_TIMEOUT "5m"}}
 {{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "15s"}}
 {{$loadType := DefaultParam .CL2_LOAD_TYPE "memory"}}
@@ -48,8 +51,8 @@ steps:
           labelSelector: group = resource-consumer
           operationTimeout: {{$operationTimeout}}
 
-{{range $i := Loop $nodePools}}
-  {{range $j := Loop $repeats}}
+{{range $i := Loop $repeats}}
+  {{range $j := Loop $steps}}
   - name: Create deployment {{$j}}
     phases:
     - namespaceRange:
@@ -58,16 +61,15 @@ steps:
       replicasPerNamespace: 1
       tuningSet: Uniform1qps
       objectBundle:
-      - basename: resource-consumer
+      - basename: resource-consumer-{{$j}}
         objectTemplatePath: deployment_template.yaml
         templateFillMap:
-          Replicas: {{$deploymentSize}}
+          Replicas: {{$deploymentSizePerStep}}
           Group: resource-consumer
           Memory: {{$memory}}K
           CPU: --millicores={{$cpu}}
           MemoryRequest: {{$memoryKi}}
           CPURequest: {{$cpu}}m
-          AgentPool: {{$agentPoolPrefix}}{{$i}}
           LoadType: {{$loadType}}
 
   - name: Waiting for latency pods to be running
@@ -95,8 +97,10 @@ steps:
           labelSelector: cri-resource-consume = true
           timeout: 1m
           refreshInterval: 5s
+  {{end}}
 
-  - name: Deleting deployments
+  {{range $j := Loop $steps}}
+  - name: Deleting deployments {{$j}}
     phases:
       - namespaceRange:
           min: 1
@@ -104,7 +108,7 @@ steps:
         replicasPerNamespace: 0
         tuningSet: Uniform1qps
         objectBundle:
-          - basename: resource-consumer
+          - basename: resource-consumer-{{$j}}
             objectTemplatePath: deployment_template.yaml
 
   - name: Waiting for latency pods to be deleted

--- a/modules/python/clusterloader2/cri/config/deployment_template.yaml
+++ b/modules/python/clusterloader2/cri/config/deployment_template.yaml
@@ -2,7 +2,6 @@
 {{$CPU := DefaultParam .CPU "--millicores=100"}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "1000Ki"}}
 {{$CPURequest := DefaultParam .CPURequest "100m"}}
-{{$AgentPool := DefaultParam .AgentPool "userpool1"}}
 {{$LoadType := DefaultParam .LoadType "memory"}}
 
 apiVersion: apps/v1
@@ -23,7 +22,7 @@ spec:
         group: {{.Group}}
     spec:
       nodeSelector:
-        agentpool: {{$AgentPool}}
+        cri-resource-consume: "true"
       containers:
 {{if eq $LoadType "memory"}}
       - name: resource-consumer-memory

--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -69,7 +69,7 @@ def override_config_clusterloader2(
         file.write(f"CL2_STEPS: {steps}\n")
         file.write(f"CL2_OPERATION_TIMEOUT: {operation_timeout}\n")
         file.write(f"CL2_LOAD_TYPE: {load_type}\n")
-        file.write(f"CL2_SCALE_ENABLED: {scale_enabled}\n")
+        file.write(f"CL2_SCALE_ENABLED: {str(scale_enabled).lower()}\n")
         file.write(f"CL2_PROMETHEUS_TOLERATE_MASTER: true\n")
         file.write("CL2_PROMETHEUS_MEMORY_LIMIT_FACTOR: 30.0\n")
         file.write("CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 30.0\n")

--- a/steps/engine/clusterloader2/cri/execute.yml
+++ b/steps/engine/clusterloader2/cri/execute.yml
@@ -14,7 +14,8 @@ steps:
 
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE override \
         $NODE_COUNT ${NODE_PER_STEP:-$NODE_COUNT} $MAX_PODS $REPEATS $OPERATION_TIMEOUT \
-        $LOAD_TYPE ${SCALE_ENABLED:-False} $CLOUD ${CL2_CONFIG_DIR}/overrides.yaml
+        $LOAD_TYPE ${SCALE_ENABLED:-False} ${POD_STARTUP_LATENCY_THRESHOLD:-15s} \
+        $CLOUD ${CL2_CONFIG_DIR}/overrides.yaml
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \
         ${CL2_IMAGE} ${CL2_CONFIG_DIR} $CL2_REPORT_DIR ${HOME}/.kube/config $CLOUD
     workingDirectory: modules/python/clusterloader2

--- a/steps/engine/clusterloader2/cri/execute.yml
+++ b/steps/engine/clusterloader2/cri/execute.yml
@@ -13,8 +13,8 @@ steps:
       set -eo pipefail
 
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE override \
-        $NODE_COUNT $MAX_PODS $REPEATS $OPERATION_TIMEOUT $LOAD_TYPE \
-        $CLOUD ${CL2_CONFIG_DIR}/overrides.yaml
+        $NODE_COUNT ${NODE_PER_STEP:-$NODE_COUNT} $MAX_PODS $REPEATS $OPERATION_TIMEOUT \
+        $LOAD_TYPE ${SCALE_ENABLED:-False} $CLOUD ${CL2_CONFIG_DIR}/overrides.yaml
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \
         ${CL2_IMAGE} ${CL2_CONFIG_DIR} $CL2_REPORT_DIR ${HOME}/.kube/config $CLOUD
     workingDirectory: modules/python/clusterloader2


### PR DESCRIPTION
- Update CRI test to allow for scale operation when running resource consume by adding new parameters `NODE_PER_STEP` and `SCALE_ENABLED`
- Parameterize pod_startup_latency_threshold to account for node scale time and set its default value to 15s instead of 3m to align with upstream SLO
- Use node labels to select node instead of agent pool name for deployment