### PR TITLE
Add support to use custom subnet for AKS CLI module

### DIFF
--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -36,6 +36,14 @@ locals {
       format("--%s %s", param.name, param.value)
     ])
   )
+
+  subnet_id_paramter = (var.subnet_id == null ?
+    "" :
+    format(
+      "%s %s",
+      "--vnet-subnet-id", var.subnet_id,
+    )
+  )
 }
 
 resource "terraform_data" "aks_cli_preview" {
@@ -92,6 +100,7 @@ resource "terraform_data" "aks_cli" {
       "--node-vm-size", var.aks_cli_config.default_node_pool.vm_size,
       "--vm-set-type", var.aks_cli_config.default_node_pool.vm_set_type,
       local.optional_parameters,
+      local.subnet_id_paramter,
     ])
   }
 

--- a/modules/terraform/azure/aks-cli/variables.tf
+++ b/modules/terraform/azure/aks-cli/variables.tf
@@ -16,11 +16,18 @@ variable "tags" {
   }
 }
 
+variable "subnet_id" {
+  description = "Value of the subnet id"
+  type        = string
+  default     = null
+}
+
 variable "aks_cli_config" {
   type = object({
     role                          = string
     aks_name                      = string
     sku_tier                      = string
+    subnet_name                   = optional(string, null)
     kubernetes_version            = optional(string, null)
     aks_custom_headers            = optional(list(string), [])
     use_aks_preview_cli_extension = optional(bool, true)

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -95,6 +95,7 @@ module "aks-cli" {
   source              = "./aks-cli"
   resource_group_name = local.run_id
   location            = local.region
+  subnet_id           = try(local.all_subnets[each.value.subnet_name], null)
   aks_cli_config      = each.value
   tags                = local.tags
 }

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -207,6 +207,7 @@ variable "aks_cli_config_list" {
     aks_name = string
     sku_tier = string
 
+    subnet_name                   = optional(string, null)
     kubernetes_version            = optional(string, null)
     aks_custom_headers            = optional(list(string), [])
     use_aks_preview_cli_extension = optional(bool, true)


### PR DESCRIPTION
This pull request introduces changes to support the optional inclusion of a subnet ID parameter in the Azure AKS CLI module. The most important changes include adding a new variable for the subnet ID, updating the local parameters to conditionally include the subnet ID, and modifying the resource configurations to use this new parameter.

### Support for optional subnet ID parameter:

* [`modules/terraform/azure/aks-cli/variables.tf`](diffhunk://#diff-dd28825e80ba149f3e743940a83f0b935bc0fca41dd07c8f9beb10b21a3815b4R19-R30): Added a new variable `subnet_id` with a default value of `null` and updated `aks_cli_config` to include an optional `subnet_name`.
* [`modules/terraform/azure/aks-cli/main.tf`](diffhunk://#diff-1c09e32cd63aa3f4a6cfae577b3db448daedf498df32bd8834fd4344f6b86ab4R39-R46): Updated the `locals` block to conditionally format the `subnet_id_paramter` and included it in the `resource "terraform_data" "aks_cli"` configuration. [[1]](diffhunk://#diff-1c09e32cd63aa3f4a6cfae577b3db448daedf498df32bd8834fd4344f6b86ab4R39-R46) [[2]](diffhunk://#diff-1c09e32cd63aa3f4a6cfae577b3db448daedf498df32bd8834fd4344f6b86ab4R103)
* [`modules/terraform/azure/variables.tf`](diffhunk://#diff-a70d527b3b015f3aa3103f024416bbf9c1e2828c82890a61a97316c23e5402efR210): Updated the `aks_cli_config_list` variable to include an optional `subnet_name`.
* [`modules/terraform/azure/main.tf`](diffhunk://#diff-0f7f598ee8901914ae02cf0a5c9c9c1237e1bbe208688856f72a3af4e1cc12bbR98): Modified the `module "aks-cli"` block to use the `subnet_id` parameter by trying to fetch it from the local subnets.