### PR TITLE
Use version for python packages to avoid breaking changes

### DIFF
--- a/modules/python/requirements.txt
+++ b/modules/python/requirements.txt
@@ -1,2 +1,2 @@
-docker
-kubernetes
+docker==7.1.0
+kubernetes==31.0.0


### PR DESCRIPTION
Currently we don't specific version for Python packages so broken version can cause breaking changes