### PR TITLE
fix role assignment for user assigned identity

### DIFF
--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -63,7 +63,7 @@ resource "azurerm_user_assigned_identity" "userassignedidentity" {
 }
 
 resource "azurerm_role_assignment" "network_contributor" {
-  count                = var.subnet_id == null ? 0 : 1
+  count                = var.aks_cli_config.managed_identity_name == null ? 0 : 1
   role_definition_name = "Network Contributor"
   scope                = var.subnet_id
   principal_id         = azurerm_user_assigned_identity.userassignedidentity[0].principal_id


### PR DESCRIPTION
This pull request includes a change to the `modules/terraform/azure/aks-cli/main.tf` file to improve the logic for assigning the "Network Contributor" role.

* Modified the `count` parameter in the `azurerm_role_assignment` resource to use `var.aks_cli_config.managed_identity_name` instead of `var.subnet_id` for determining whether to create the role assignment.