### PR TITLE
Update Nat-Gateway Module

### DIFF
--- a/modules/terraform/azure/network/README.md
+++ b/modules/terraform/azure/network/README.md
@@ -103,8 +103,8 @@ module "virtual_network" {
     nat_gateway_associations = [
       {
         nat_gateway_name = "web-nat-gw"
-        public_ip_name   = "web-nat-gw-public-ip"
-        subnet_name      = "web-subnet"
+        public_ip_names   = ["web-nat-gw-public-ip"]
+        subnet_names      = ["web-subnet"]
       }
     ]
   }

--- a/modules/terraform/azure/network/main.tf
+++ b/modules/terraform/azure/network/main.tf
@@ -101,10 +101,11 @@ module "nat_gateway" {
   source   = "./nat-gateway"
   for_each = local.nat_gateway_associations_map
 
-  nat_gateway_name     = each.value.nat_gateway_name
-  location             = var.location
-  public_ip_address_id = var.public_ips[each.value.public_ip_name]
-  resource_group_name  = var.resource_group_name
-  subnet_id            = local.subnets_map[each.value.subnet_name].id
-  tags                 = local.tags
+  nat_gateway_name        = each.value.nat_gateway_name
+  location                = var.location
+  public_ips              = var.public_ips
+  resource_group_name     = var.resource_group_name
+  nat_gateway_association = each.value
+  subnets_map             = local.subnets_map
+  tags                    = local.tags
 }

--- a/modules/terraform/azure/network/nat-gateway/README.md
+++ b/modules/terraform/azure/network/nat-gateway/README.md
@@ -19,15 +19,15 @@ This module provisions a NAT gateway in Azure. It allows you to create and confi
 - **Description:** Name of the NAT gateway.
 - **Type:** String
 
-### `subnet_id`
+### `subnet_names`
 
-- **Description:** ID of the subnet where the NAT gateway will be deployed.
-- **Type:** String
+- **Description:** List of Names of the subnets where the NAT gateway will be deployed.
+- **Type:** list of strings
 
-### `public_ip_address_id`
+### `public_ip_names`
 
-- **Description:** ID of the public IP address associated with the NAT gateway.
-- **Type:** String
+- **Description:** List of public IP addresses that are associated with the NAT gateway.
+- **Type:** list of strings
 
 ### `tags`
 
@@ -42,8 +42,8 @@ module "nat_gateway" {
   resource_group_name      = "my-rg"
   location                 = "eastus"
   nat_gateway_name         = "my-nat-gateway"
-  subnet_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet"
-  public_ip_address_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/my-public-ip"
+  subnet_names             = ["my-subnet"]
+  public_ip_names          = ["my-public-ip"]
 
   tags = {
     environment = "production"

--- a/modules/terraform/azure/network/nat-gateway/main.tf
+++ b/modules/terraform/azure/network/nat-gateway/main.tf
@@ -8,11 +8,15 @@ resource "azurerm_nat_gateway" "nat_gateway" {
 }
 
 resource "azurerm_nat_gateway_public_ip_association" "nat_gateway_ip_association" {
+  count = length(var.nat_gateway_association.public_ip_names)
+
   nat_gateway_id       = azurerm_nat_gateway.nat_gateway.id
-  public_ip_address_id = var.public_ip_address_id
+  public_ip_address_id = var.public_ips[var.nat_gateway_association.public_ip_names[count.index]]
 }
 
 resource "azurerm_subnet_nat_gateway_association" "nat_gateway_subnet_association" {
-  subnet_id      = var.subnet_id
+  count = length(var.nat_gateway_association.subnet_names)
+
+  subnet_id      = var.subnets_map[var.nat_gateway_association.subnet_names[count.index]].id
   nat_gateway_id = azurerm_nat_gateway.nat_gateway.id
 }

--- a/modules/terraform/azure/network/nat-gateway/variables.tf
+++ b/modules/terraform/azure/network/nat-gateway/variables.tf
@@ -13,16 +13,25 @@ variable "nat_gateway_name" {
   type        = string
 }
 
-variable "subnet_id" {
-  description = "Value of the subnet id"
-  type        = string
-}
-
-variable "public_ip_address_id" {
-  description = "Value of the public ip address id"
-  type        = string
+variable "public_ips" {
+  description = "Map of public IP names to IDs"
+  type        = map(string)
 }
 
 variable "tags" {
   type = map(string)
+}
+
+variable "nat_gateway_association" {
+  description = "NAT Gateway association"
+  type = object({
+    nat_gateway_name = string
+    public_ip_names  = list(string)
+    subnet_names     = list(string)
+  })
+}
+
+variable "subnets_map" {
+  description = "Map of subnets"
+  type        = map(any)
 }

--- a/modules/terraform/azure/network/variables.tf
+++ b/modules/terraform/azure/network/variables.tf
@@ -56,8 +56,8 @@ variable "network_config" {
     }))
     nat_gateway_associations = optional(list(object({
       nat_gateway_name = string
-      public_ip_name   = string
-      subnet_name      = string
+      public_ip_names  = list(string)
+      subnet_names     = list(string)
     })))
   })
 }

--- a/modules/terraform/azure/network/variables.tf
+++ b/modules/terraform/azure/network/variables.tf
@@ -56,8 +56,8 @@ variable "network_config" {
     }))
     nat_gateway_associations = optional(list(object({
       nat_gateway_name = string
-      public_ip_names  = optional(list(string), [])
-      subnet_names     = optional(list(string), [])
+      public_ip_names  = list(string)
+      subnet_names     = list(string)
     })))
   })
 }

--- a/modules/terraform/azure/network/variables.tf
+++ b/modules/terraform/azure/network/variables.tf
@@ -56,8 +56,8 @@ variable "network_config" {
     }))
     nat_gateway_associations = optional(list(object({
       nat_gateway_name = string
-      public_ip_names  = list(string)
-      subnet_names     = list(string)
+      public_ip_names  = optional(list(string), [])
+      subnet_names     = optional(list(string), [])
     })))
   })
 }

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -114,8 +114,8 @@ variable "network_config_list" {
     }))
     nat_gateway_associations = optional(list(object({
       nat_gateway_name = string
-      public_ip_names  = list(string)
-      subnet_names     = list(string)
+      public_ip_names  = optional(list(string), [])
+      subnet_names     = optional(list(string), [])
     })))
   }))
   default = []

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -114,8 +114,8 @@ variable "network_config_list" {
     }))
     nat_gateway_associations = optional(list(object({
       nat_gateway_name = string
-      public_ip_names  = optional(list(string), [])
-      subnet_names     = optional(list(string), [])
+      public_ip_names  = list(string)
+      subnet_names     = list(string)
     })))
   }))
   default = []

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -114,8 +114,8 @@ variable "network_config_list" {
     }))
     nat_gateway_associations = optional(list(object({
       nat_gateway_name = string
-      public_ip_name   = string
-      subnet_name      = string
+      public_ip_names  = list(string)
+      subnet_names     = list(string)
     })))
   }))
   default = []


### PR DESCRIPTION
This pull request includes several changes to the Azure Network Terraform module to support multiple public IPs and subnets for NAT gateway associations. The most important changes include updating variable definitions, modifying resource configurations, and updating documentation.

### Variable Updates:
* Updated `variables.tf` to replace `subnet_id` and `public_ip_address_id` with `subnet_names` and `public_ip_names`, and added new variables `nat_gateway_association` and `subnets_map` to support multiple associations.
* Updated `network_config` and `network_config_list` variables to use lists of strings for `public_ip_names` and `subnet_names` instead of single string values. [[1]](diffhunk://#diff-2887bd794bdb916b262fac81e76d7a39c28c440aeb3fface88a98f8041613fa8L59-R60) [[2]](diffhunk://#diff-a70d527b3b015f3aa3103f024416bbf9c1e2828c82890a61a97316c23e5402efL117-R118)

### Resource Configuration:
* Modified `main.tf` to handle multiple public IPs and subnets by updating the `azurerm_nat_gateway_public_ip_association` and `azurerm_subnet_nat_gateway_association` resources to use `count` and iterate over the lists of names. [[1]](diffhunk://#diff-72dcd3347bf4d3f128fcef665c145feec13fef9503bff62e37da8e02a4eaf23dR11-R20) [[2]](diffhunk://#diff-90c5a2cef35014d99f8d67f34be196c6c4ca724c0714a9649b6e81322af7cd93L106-R109)

### Documentation Updates:
* Updated `README.md` files to reflect changes in variable names and types, ensuring the documentation aligns with the new configuration structure. [[1]](diffhunk://#diff-d3ba9935a46953d0978e91da0f98c2e775ecd1c5f85dc02174635a8f1f5671bdL22-R30) [[2]](diffhunk://#diff-d3ba9935a46953d0978e91da0f98c2e775ecd1c5f85dc02174635a8f1f5671bdL45-R46)

### Example Configuration:
* Modified example configurations in `README.md` to use the new lists for `subnet_names` and `public_ip_names`.