### PR TITLE
Use same k8s version across clouds

### DIFF
--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars
@@ -105,6 +105,13 @@ eks_config_list = [{
   eks_addons = [
     {
       name = "coredns"
+    },
+    {
+      name = "vpc-cni"
+    },
+    {
+      name = "kube-proxy"
     }
   ]
+  kubernetes_version = "1.31"
 }]

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -59,6 +59,6 @@ aks_config_list = [
         node_labels          = { "cri-resource-consume" = "true" }
       }
     ]
-    kubernetes_version = "1.30"
+    kubernetes_version = "1.31"
   }
 ]


### PR DESCRIPTION
- Use k8s version 1.31 across clouds
- Add addons for AWS to get tags properly for ENIs