### PR TITLE
AKS custom header and optional params for userpools

### DIFF
--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -160,6 +160,13 @@ resource "terraform_data" "aks_nodepool_cli" {
       "--node-count", each.value.node_count,
       "--node-vm-size", each.value.vm_size,
       "--vm-set-type", each.value.vm_set_type,
+      local.aks_custom_headers_flags,
+      length(each.value.optional_parameters) == 0 ?
+      "" :
+      join(" ", [
+        for param in each.value.optional_parameters :
+        format("--%s %s", param.name, param.value)
+      ]),
     ])
   }
 }

--- a/modules/terraform/azure/aks-cli/variables.tf
+++ b/modules/terraform/azure/aks-cli/variables.tf
@@ -44,6 +44,10 @@ variable "aks_cli_config" {
         node_count  = number
         vm_size     = string
         vm_set_type = optional(string, "VirtualMachineScaleSets")
+        optional_parameters = optional(list(object({
+          name  = string
+          value = string
+        })), [])
     })), [])
     optional_parameters = optional(list(object({
       name  = string

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -21,6 +21,10 @@ variable "json_input" {
         node_count  = number
         vm_size     = string
         vm_set_type = string
+        optional_parameters = optional(list(object({
+          name  = string
+          value = string
+        })), [])
       }))
     )
   })
@@ -225,6 +229,10 @@ variable "aks_cli_config_list" {
         node_count  = number
         vm_size     = string
         vm_set_type = optional(string, "VirtualMachineScaleSets")
+        optional_parameters = optional(list(object({
+          name  = string
+          value = string
+        })), [])
     })), [])
     optional_parameters = optional(list(object({
       name  = string


### PR DESCRIPTION
Adds support for AKS custom headers and optional parameters for user pools. The same custom header is used as the one used for default pool creation. Optional parameters are per extra-pool, so that different node-labels can be applied to different pools.