### PR TITLE
Enable kubelet scraping

### DIFF
--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -40,6 +40,11 @@ steps:
       #     action: start
       #     labelSelector: group = resource-consumer
       #     threshold: {{$podStartupLatencyThreshold}}
+      # - Identifier: SchedulingThroughput
+      #   Method: SchedulingThroughput
+      #   Params:
+      #     action: start
+      #     labelSelector: group = resource-consumer
       - Identifier: ResourceUsageSummary
         Method: ResourceUsageSummary
         Params:
@@ -152,6 +157,11 @@ steps:
       #   Method: PodStartupLatency
       #   Params:
       #     action: gather
+      # - Identifier: SchedulingThroughput
+      #   Method: SchedulingThroughput
+      #   Params:
+      #     action: gather
+      #     enableViolations: true
   - module:
       path: /kubelet-measurement.yaml
       params:

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -54,6 +54,10 @@ steps:
           kind: Deployment
           labelSelector: group = resource-consumer
           operationTimeout: {{$operationTimeout}}
+  - module:
+      path: /kubelet-measurement.yaml
+      params:
+        action: start
 
 {{range $i := Loop $repeats}}
   {{range $j := Loop $steps}}
@@ -148,3 +152,7 @@ steps:
         Method: PodStartupLatency
         Params:
           action: gather
+  - module:
+      path: /kubelet-measurement.yaml
+      params:
+        action: gather

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -11,13 +11,14 @@ name: resource-consumer
 {{$totalNodes := MultiplyInt $nodePerStep $steps}}
 {{$replicas := MultiplyInt $deploymentSize $totalNodes}}
 {{$scaleReplicas := MultiplyInt $deploymentSize $nodePerStep}}
-{{$scale_enabled := DefaultParam .CL2_SCALE_ENABLED false}}
+{{$scaleEnabled := DefaultParam .CL2_SCALE_ENABLED false}}
 
 {{$operationTimeout := DefaultParam .CL2_OPERATION_TIMEOUT "5m"}}
 {{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "15s"}}
 {{$loadType := DefaultParam .CL2_LOAD_TYPE "memory"}}
 
 {{$provider := DefaultParam .CL2_PROVIDER "aks"}}
+{{$scrapeKubelets := DefaultParam .CL2_SCRAPE_KUBELETS false}}
 
 namespace:
   number: 1
@@ -56,10 +57,13 @@ steps:
           operationTimeout: {{$operationTimeout}}
 
 {{range $i := Loop $repeats}}
+
+  {{if $scrapeKubelets}}
   - module:
       path: /kubelet-measurement.yaml
       params:
         action: start
+  {{end}}
 
   {{range $j := Loop $steps}}
   - name: Create deployment {{$j}}
@@ -73,7 +77,7 @@ steps:
       - basename: resource-consumer-{{$j}}
         objectTemplatePath: deployment_template.yaml
         templateFillMap:
-      {{if $scale_enabled}}
+      {{if $scaleEnabled}}
         {{if eq $j 0}}
           Replicas: {{AddInt $scaleReplicas $deploymentSize}}
         {{else}}
@@ -110,7 +114,7 @@ steps:
         Method: WaitForNodes
         Params:
           action: start
-        {{if $scale_enabled}}
+        {{if $scaleEnabled}}
           minDesiredNodeCount: {{MultiplyInt (AddInt (MultiplyInt $nodePerStep (AddInt $j 1)) 1) 0.8}}
           maxDesiredNodeCount: {{AddInt $totalNodes 1}}
         {{else}}
@@ -122,10 +126,12 @@ steps:
           refreshInterval: 5s
   {{end}}
 
+  {{if $scrapeKubelets}}
   - module:
       path: /kubelet-measurement.yaml
       params:
         action: gather
+  {{end}}
 
   {{range $j := Loop $steps}}
   - name: Deleting deployments {{$j}}

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -34,17 +34,12 @@ tuningSets:
 steps:
   - name: Start measurements
     measurements:
-      # - Identifier: PodStartupLatency
-      #   Method: PodStartupLatency
-      #   Params:
-      #     action: start
-      #     labelSelector: group = resource-consumer
-      #     threshold: {{$podStartupLatencyThreshold}}
-      # - Identifier: SchedulingThroughput
-      #   Method: SchedulingThroughput
-      #   Params:
-      #     action: start
-      #     labelSelector: group = resource-consumer
+      - Identifier: PodStartupLatency
+        Method: PodStartupLatency
+        Params:
+          action: start
+          labelSelector: group = resource-consumer
+          threshold: {{$podStartupLatencyThreshold}}
       - Identifier: ResourceUsageSummary
         Method: ResourceUsageSummary
         Params:
@@ -59,13 +54,14 @@ steps:
           kind: Deployment
           labelSelector: group = resource-consumer
           operationTimeout: {{$operationTimeout}}
+
+{{range $i := Loop $repeats}}
+  {{range $j := Loop $steps}}
   - module:
       path: /kubelet-measurement.yaml
       params:
         action: start
 
-{{range $i := Loop $repeats}}
-  {{range $j := Loop $steps}}
   - name: Create deployment {{$j}}
     phases:
     - namespaceRange:
@@ -126,6 +122,11 @@ steps:
           refreshInterval: 5s
   {{end}}
 
+  - module:
+      path: /kubelet-measurement.yaml
+      params:
+        action: gather
+
   {{range $j := Loop $steps}}
   - name: Deleting deployments {{$j}}
     phases:
@@ -153,16 +154,7 @@ steps:
         Method: ResourceUsageSummary
         Params:
           action: gather
-      # - Identifier: PodStartupLatency
-      #   Method: PodStartupLatency
-      #   Params:
-      #     action: gather
-      # - Identifier: SchedulingThroughput
-      #   Method: SchedulingThroughput
-      #   Params:
-      #     action: gather
-      #     enableViolations: true
-  - module:
-      path: /kubelet-measurement.yaml
-      params:
-        action: gather
+      - Identifier: PodStartupLatency
+        Method: PodStartupLatency
+        Params:
+          action: gather

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -34,12 +34,12 @@ tuningSets:
 steps:
   - name: Start measurements
     measurements:
-      - Identifier: PodStartupLatency
-        Method: PodStartupLatency
-        Params:
-          action: start
-          labelSelector: group = resource-consumer
-          threshold: {{$podStartupLatencyThreshold}}
+      # - Identifier: PodStartupLatency
+      #   Method: PodStartupLatency
+      #   Params:
+      #     action: start
+      #     labelSelector: group = resource-consumer
+      #     threshold: {{$podStartupLatencyThreshold}}
       - Identifier: ResourceUsageSummary
         Method: ResourceUsageSummary
         Params:
@@ -148,10 +148,10 @@ steps:
         Method: ResourceUsageSummary
         Params:
           action: gather
-      - Identifier: PodStartupLatency
-        Method: PodStartupLatency
-        Params:
-          action: gather
+      # - Identifier: PodStartupLatency
+      #   Method: PodStartupLatency
+      #   Params:
+      #     action: gather
   - module:
       path: /kubelet-measurement.yaml
       params:

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -56,12 +56,12 @@ steps:
           operationTimeout: {{$operationTimeout}}
 
 {{range $i := Loop $repeats}}
-  {{range $j := Loop $steps}}
   - module:
       path: /kubelet-measurement.yaml
       params:
         action: start
 
+  {{range $j := Loop $steps}}
   - name: Create deployment {{$j}}
     phases:
     - namespaceRange:

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -14,12 +14,12 @@ steps:
           - node
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[10m])) by (node, le))
           threshold: 5
         - name: Perc90
-          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[10m])) by (node, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[10m])) by (node, le))
     - Identifier: KubeletPodStartupDuration
       Method: GenericPrometheusQuery
       Params:
@@ -31,11 +31,11 @@ steps:
           - node
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_bucket[10m])) by (node, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_duration_seconds_bucket[10m])) by (node, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_duration_seconds_bucket[10m])) by (node, le))
     - Identifier: KubeletPodStartupTotalDuration
       Method: GenericPrometheusQuery
       Params:
@@ -47,11 +47,11 @@ steps:
           - node
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[10m])) by (node, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[10m])) by (node, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[5m])) by (node, le))
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[10m])) by (node, le))
     - Identifier: KubeletRuntimeOperationDuration
       Method: GenericPrometheusQuery
       Params:
@@ -64,8 +64,8 @@ steps:
           - operation_type
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[10m])) by (node, operation_type, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[10m])) by (node, operation_type, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[10m])) by (node, operation_type, le))

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -1,0 +1,54 @@
+{{$action := .action}} # start, gather
+
+steps:
+  - name: {{$action}} Kubelet Measurements
+    measurements:
+    - Identifier: KubeletPodStartupSLIDuration
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletPodStartupSLIDuration
+        metricVersion: v1
+        unit: s
+        threshold: 5
+        dimensions:
+          - node
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
+    - Identifier: KubeletPodStartupDuration
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletPodStartupDuration
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_bucket[5m])) by (node, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_duration_seconds_bucket[5m])) by (node, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_duration_seconds_bucket[5m])) by (node, le))
+    - Identifier: KubeletPodStartupTotalDuration
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletPodStartupTotalDuration
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[5m])) by (node, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[5m])) by (node, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[5m])) by (node, le))

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -16,7 +16,6 @@ steps:
         - name: Perc99
           query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
           threshold: 5
-          lowerBound: false
         - name: Perc90
           query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
         - name: Perc50

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -16,6 +16,7 @@ steps:
         - name: Perc99
           query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
           threshold: 5
+          lowerBound: false
         - name: Perc90
           query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
         - name: Perc50

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -10,12 +10,12 @@ steps:
         metricName: KubeletPodStartupSLIDuration
         metricVersion: v1
         unit: s
-        threshold: 5
         dimensions:
           - node
         queries:
         - name: Perc99
           query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
+          threshold: 5
         - name: Perc90
           query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[5m])) by (node, le))
         - name: Perc50
@@ -52,3 +52,20 @@ steps:
           query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[5m])) by (node, le))
         - name: Perc50
           query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[5m])) by (node, le))
+    - Identifier: KubeletRuntimeOperationDuration
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletRuntimeOperationDuration
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+          - operation_type
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[5m])) by (node, operation_type, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[5m])) by (node, operation_type, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[5m])) by (node, operation_type, le))

--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -79,6 +79,7 @@ def override_config_clusterloader2(
         file.write(f"CL2_LOAD_TYPE: {load_type}\n")
         file.write(f"CL2_SCALE_ENABLED: {str(scale_enabled).lower()}\n")
         file.write(f"CL2_PROMETHEUS_TOLERATE_MASTER: true\n")
+        file.write(f"CL2_PROMETHEUS_CPU_SCALE_FACTOR: 30.0\n")
         file.write("CL2_PROMETHEUS_MEMORY_LIMIT_FACTOR: 30.0\n")
         file.write("CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 30.0\n")
         file.write("CL2_PROMETHEUS_NODE_SELECTOR: \"prometheus: \\\"true\\\"\"\n")

--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -26,7 +26,8 @@ def _get_daemonsets_pods_allocated_resources(client, node_name):
 
 def override_config_clusterloader2(
     node_count, node_per_step, max_pods, repeats, operation_timeout,
-    load_type, scale_enabled, pod_startup_latency_threshold, provider, override_file):
+    load_type, scale_enabled, pod_startup_latency_threshold, provider, 
+    scrape_kubelets, override_file):
     client = KubernetesClient(os.path.expanduser("~/.kube/config"))
     nodes = client.get_nodes(label_selector="cri-resource-consume=true")
     if len(nodes) == 0:
@@ -64,7 +65,7 @@ def override_config_clusterloader2(
 
     # Calculate the number of steps to scale up
     steps = node_count // node_per_step
-    print(f"Scaled enabled: {scale_enabled}, node per step: {node_per_step}, steps: {steps}")
+    print(f"Scaled enabled: {scale_enabled}, node per step: {node_per_step}, steps: {steps}, scrape kubelets: {scrape_kubelets}")
 
     with open(override_file, 'w') as file:
         file.write(f"CL2_DEPLOYMENT_SIZE: {pod_count}\n")
@@ -85,11 +86,12 @@ def override_config_clusterloader2(
         file.write("CL2_PROMETHEUS_NODE_SELECTOR: \"prometheus: \\\"true\\\"\"\n")
         file.write(f"CL2_POD_STARTUP_LATENCY_THRESHOLD: {pod_startup_latency_threshold}\n")
         file.write(f"CL2_PROVIDER: {provider}\n")
+        file.write(f"CL2_SCRAPE_KUBELETS: {str(scrape_kubelets).lower()}\n")
 
     file.close()
 
-def execute_clusterloader2(cl2_image, cl2_config_dir, cl2_report_dir, kubeconfig, provider):
-    run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, overrides=True, enable_prometheus=True, scrape_kubelets=True)
+def execute_clusterloader2(cl2_image, cl2_config_dir, cl2_report_dir, kubeconfig, provider, scrape_kubelets):
+    run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, overrides=True, enable_prometheus=True, scrape_kubelets=scrape_kubelets)
 
 def verify_measurement():
     client = KubernetesClient(os.path.expanduser("~/.kube/config"))
@@ -102,16 +104,14 @@ def verify_measurement():
         url = f"/api/v1/nodes/{node_name}/proxy/metrics"
 
         try:
-            # Get raw response from the Kubernetes API
             response = api_client.call_api(
                 resource_path=url,
                 method="GET",
                 auth_settings=['BearerToken'],
-                response_type="str",  # Expecting raw text response
-                _preload_content=True  # Return decoded response
+                response_type="str",
+                _preload_content=True
             )
             
-            # Extract response body
             metrics = response[0]  # The first item contains the response data
             filtered_metrics = "\n".join(
                 line for line in metrics.splitlines() if line.startswith("kubelet_pod_start")
@@ -131,9 +131,11 @@ def collect_clusterloader2(
     cloud_info,
     run_id,
     run_url,
-    result_file
+    result_file,
+    scrape_kubelets
 ):
-    verify_measurement()
+    if scrape_kubelets:
+        verify_measurement()
 
     details = parse_xml_to_json(os.path.join(cl2_report_dir, "junit.xml"), indent = 2)
     json_data = json.loads(details)
@@ -212,6 +214,8 @@ def main():
                                  help="Whether scale operation is enabled. Must be either True or False")
     parser_override.add_argument("pod_startup_latency_threshold", type=str, default="15s", help="Pod startup latency threshold")
     parser_override.add_argument("provider", type=str, help="Cloud provider name")
+    parser_override.add_argument("scrape_kubelets", type=eval, choices=[True, False], default=False,
+                                help="Whether to scrape kubelets")
     parser_override.add_argument("cl2_override_file", type=str, help="Path to the overrides of CL2 config file")
 
     # Sub-command for execute_clusterloader2
@@ -221,6 +225,8 @@ def main():
     parser_execute.add_argument("cl2_report_dir", type=str, help="Path to the CL2 report directory")
     parser_execute.add_argument("kubeconfig", type=str, help="Path to the kubeconfig file")
     parser_execute.add_argument("provider", type=str, help="Cloud provider name")
+    parser_execute.add_argument("scrape_kubelets", type=eval, choices=[True, False], default=False,
+                                help="Whether to scrape kubelets")
 
     # Sub-command for collect_clusterloader2
     parser_collect = subparsers.add_parser("collect", help="Collect resource consume data")
@@ -234,18 +240,20 @@ def main():
     parser_collect.add_argument("run_id", type=str, help="Run ID")
     parser_collect.add_argument("run_url", type=str, help="Run URL")
     parser_collect.add_argument("result_file", type=str, help="Path to the result file")
+    parser_collect.add_argument("scrape_kubelets", type=eval, choices=[True, False], default=False,
+                                help="Whether to scrape kubelets")
 
     args = parser.parse_args()
 
     if args.command == "override":
         override_config_clusterloader2(args.node_count, args.node_per_step, args.max_pods, args.repeats, args.operation_timeout,
                                        args.load_type, args.scale_enabled, args.pod_startup_latency_threshold,
-                                       args.provider, args.cl2_override_file)
+                                       args.provider, args.scrape_kubelets, args.cl2_override_file)
     elif args.command == "execute":
-        execute_clusterloader2(args.cl2_image, args.cl2_config_dir, args.cl2_report_dir, args.kubeconfig, args.provider)
+        execute_clusterloader2(args.cl2_image, args.cl2_config_dir, args.cl2_report_dir, args.kubeconfig, args.provider, args.scrape_kubelets)
     elif args.command == "collect":
         collect_clusterloader2(args.node_count, args.max_pods, args.repeats, args.load_type,
-                               args.cl2_report_dir, args.cloud_info, args.run_id, args.run_url, args.result_file)
+                               args.cl2_report_dir, args.cloud_info, args.run_id, args.run_url, args.result_file, args.scrape_kubelets)
 
 if __name__ == "__main__":
     main()

--- a/modules/python/clusterloader2/utils.py
+++ b/modules/python/clusterloader2/utils.py
@@ -14,12 +14,13 @@ NETWORK_METRIC_PREFIXES = ["APIResponsivenessPrometheus", "InClusterNetworkLaten
 PROM_QUERY_PREFIX = "GenericPrometheusQuery"
 RESOURCE_USAGE_SUMMARY_PREFIX = "ResourceUsageSummary"
 
-def run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, cl2_config_file="config.yaml", overrides=False, enable_prometheus=False, enable_exec_service=False):
+def run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, cl2_config_file="config.yaml", overrides=False, enable_prometheus=False, enable_exec_service=False, scrape_kubelets=False):
     docker_client = DockerClient()
 
     command=f"""--provider={provider} --v=2
 --enable-exec-service={enable_exec_service}
 --enable-prometheus-server={enable_prometheus}
+--prometheus-scrape-kubelets={scrape_kubelets}
 --kubeconfig /root/.kube/config
 --testconfig /root/perf-tests/clusterloader2/config/{cl2_config_file}
 --report-dir /root/perf-tests/clusterloader2/results

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -33,6 +33,7 @@ stages:
               operation_timeout: 3m
               load_type: memory
               kubernetes_version: "1.30"
+              scrape_kubelets: True
             n10-p700-memory-1-30:
               node_count: 10
               max_pods: 70
@@ -40,6 +41,7 @@ stages:
               operation_timeout: 7m
               load_type: memory
               kubernetes_version: "1.30"
+              scrape_kubelets: True
             n10-p1100-memory-1-30:
               node_count: 10
               max_pods: 110
@@ -47,6 +49,7 @@ stages:
               operation_timeout: 11m
               load_type: memory
               kubernetes_version: "1.30"
+              scrape_kubelets: True
             n10-p300-memory-1-31:
               node_count: 10
               max_pods: 30
@@ -54,6 +57,7 @@ stages:
               operation_timeout: 3m
               load_type: memory
               kubernetes_version: "1.31"
+              scrape_kubelets: True
             n10-p700-memory-1-31:
               node_count: 10
               max_pods: 70
@@ -61,6 +65,7 @@ stages:
               operation_timeout: 7m
               load_type: memory
               kubernetes_version: "1.31"
+              scrape_kubelets: True
             n10-p1100-memory-1-31:
               node_count: 10
               max_pods: 110
@@ -68,6 +73,7 @@ stages:
               operation_timeout: 11m
               load_type: memory
               kubernetes_version: "1.31"
+              scrape_kubelets: True
             n10-p300-cpu-1-30:
               node_count: 10
               max_pods: 30
@@ -75,6 +81,7 @@ stages:
               operation_timeout: 3m
               load_type: cpu
               kubernetes_version: "1.30"
+              scrape_kubelets: True
             n10-p700-cpu-1-30:
               node_count: 10
               max_pods: 70
@@ -82,6 +89,7 @@ stages:
               operation_timeout: 7m
               load_type: cpu
               kubernetes_version: "1.30"
+              scrape_kubelets: True
             n10-p1100-cpu-1-30:
               node_count: 10
               max_pods: 110
@@ -89,6 +97,7 @@ stages:
               operation_timeout: 11m
               load_type: cpu
               kubernetes_version: "1.30"
+              scrape_kubelets: True
             n10-p300-cpu-1-31:
               node_count: 10
               max_pods: 30
@@ -96,6 +105,7 @@ stages:
               operation_timeout: 3m
               load_type: cpu
               kubernetes_version: "1.31"
+              scrape_kubelets: True
             n10-p700-cpu-1-31:
               node_count: 10
               max_pods: 70
@@ -103,6 +113,7 @@ stages:
               operation_timeout: 7m
               load_type: cpu
               kubernetes_version: "1.31"
+              scrape_kubelets: True
             n10-p1100-cpu-1-31:
               node_count: 10
               max_pods: 110
@@ -110,6 +121,7 @@ stages:
               operation_timeout: 11m
               load_type: cpu
               kubernetes_version: "1.31"
+              scrape_kubelets: True
           max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection
@@ -133,36 +145,42 @@ stages:
               repeats: 1
               operation_timeout: 3m
               load_type: memory
+              scrape_kubelets: True
             n10-p700-memory:
               node_count: 10
               max_pods: 70
               repeats: 1
               operation_timeout: 7m
               load_type: memory
+              scrape_kubelets: True
             n10-p1100-memory:
               node_count: 10
               max_pods: 110
               repeats: 1
               operation_timeout: 11m
               load_type: memory
+              scrape_kubelets: True
             n10-p300-cpu:
               node_count: 10
               max_pods: 30
               repeats: 1
               operation_timeout: 3m
               load_type: cpu
+              scrape_kubelets: True
             n10-p700-cpu:
               node_count: 10
               max_pods: 70
               repeats: 1
               operation_timeout: 7m
               load_type: cpu
+              scrape_kubelets: True
             n10-p1100-cpu:
               node_count: 10
               max_pods: 110
               repeats: 1
               operation_timeout: 11m
               load_type: cpu
+              scrape_kubelets: True
           max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection

--- a/steps/engine/clusterloader2/cri/collect.yml
+++ b/steps/engine/clusterloader2/cri/collect.yml
@@ -17,7 +17,8 @@ steps:
 
     PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE collect \
       $NODE_COUNT $MAX_PODS $REPEATS $LOAD_TYPE \
-      $CL2_REPORT_DIR "$CLOUD_INFO" $RUN_ID $RUN_URL $TEST_RESULTS_FILE
+      $CL2_REPORT_DIR "$CLOUD_INFO" $RUN_ID $RUN_URL $TEST_RESULTS_FILE \
+      ${SCRAPE_KUBELETS:-False}
   workingDirectory: modules/python/clusterloader2
   env:
     CLOUD: ${{ parameters.cloud }}

--- a/steps/engine/clusterloader2/cri/execute.yml
+++ b/steps/engine/clusterloader2/cri/execute.yml
@@ -15,9 +15,10 @@ steps:
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE override \
         $NODE_COUNT ${NODE_PER_STEP:-$NODE_COUNT} $MAX_PODS $REPEATS $OPERATION_TIMEOUT \
         $LOAD_TYPE ${SCALE_ENABLED:-False} ${POD_STARTUP_LATENCY_THRESHOLD:-15s} \
-        $CLOUD ${CL2_CONFIG_DIR}/overrides.yaml
+        $CLOUD ${SCRAPE_KUBELETS:-False} ${CL2_CONFIG_DIR}/overrides.yaml
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \
-        ${CL2_IMAGE} ${CL2_CONFIG_DIR} $CL2_REPORT_DIR ${HOME}/.kube/config $CLOUD
+        ${CL2_IMAGE} ${CL2_CONFIG_DIR} $CL2_REPORT_DIR ${HOME}/.kube/config $CLOUD \
+        ${SCRAPE_KUBELETS:-False}
     workingDirectory: modules/python/clusterloader2
     env:
       ${{ if eq(parameters.cloud, 'azure') }}:


### PR DESCRIPTION
- Enable kubelet scraping for prometheus in clusterloader2, but only enabled it for cri-resource-consume.yml file by adding a new argument
- Scrape metrics related to kubelet pod start and operation runtime
- Add a function to verify the data directly from kubelet metrics