### PR TITLE
add API server benchmark with lower max inflight

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
@@ -40,7 +40,7 @@ stages:
           timeout_in_minutes: 360
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_free
+  - stage: azure_eastus2_default
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
@@ -54,12 +54,10 @@ stages:
             workload-low:
               flowcontrol: "workload-low:1000"
               extra_benchmark_subcmd_args: ""
-              sku_tier: Free
               disable_warmup: "true"
             exempt:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
-              sku_tier: Free
               disable_warmup: "true"
           engine_input:
             runner_image: ghcr.io/azure/kperf:0.2.0
@@ -69,8 +67,10 @@ stages:
           timeout_in_minutes: 360
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_standard
+  - stage: azure_eastus2_lower_max_inflight
     dependsOn: []
+    variables:
+      - group: API-Server-L4-Config-MI50
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:
@@ -83,12 +83,10 @@ stages:
             workload-low:
               flowcontrol: "workload-low:1000"
               extra_benchmark_subcmd_args: ""
-              sku_tier: Standard
               disable_warmup: "true"
             exempt:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
-              sku_tier: Standard
               disable_warmup: "true"
           engine_input:
             runner_image: ghcr.io/azure/kperf:0.2.0

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -67,7 +67,36 @@ stages:
           timeout_in_minutes: 760
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_l7_json
+  - stage: azure_eastus2_l4_MI50
+    dependsOn: []
+    variables:
+      - group: API-Server-L4-Config-MI50
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            podsize-20k:
+              disable_warmup: "true"
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+            podsize-20k-exempt:
+              disable_warmup: "true"
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.2.0
+            benchmark_subcmd: node100_pod10k
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+          max_parallel: 2
+          timeout_in_minutes: 760
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: azure_eastus2_l7
     dependsOn: []
     variables:
       - group: API-Server-L7-Config
@@ -91,44 +120,15 @@ stages:
           engine_input:
             runner_image: ghcr.io/azure/kperf:0.2.0
             benchmark_subcmd: node100_pod10k
-            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192 --content-type json"
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_l7_protobuf
+  - stage: azure_eastus2_l4_c32
     dependsOn: []
     variables:
-      - group: API-Server-L7-Config
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - eastus2
-          engine: kperf
-          topology: kperf
-          matrix:
-            podsize-20k:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-              disable_warmup: "true"
-            podsize-20k-exempt:
-              disable_warmup: "true"
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.2.0
-            benchmark_subcmd: node100_pod10k
-            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192 --content-type protobuf"
-          max_parallel: 2
-          timeout_in_minutes: 760
-          credential_type: service_connection
-          ssh_key_enabled: false
-  - stage: azure_eastus2_l7_custom_json
-    dependsOn: []
-    variables:
-      - group: API-Server-L7-Custom-Config
+      - group: API-Server-L4-Config-C32
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -67,7 +67,7 @@ stages:
           timeout_in_minutes: 760
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_l4_MI50
+  - stage: azure_eastus2_lower_max_inflight
     dependsOn: []
     variables:
       - group: API-Server-L4-Config-MI50
@@ -125,7 +125,7 @@ stages:
           timeout_in_minutes: 760
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_l4_c32
+  - stage: azure_eastus2_l4_high_resources
     dependsOn: []
     variables:
       - group: API-Server-L4-Config-C32

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -65,7 +65,7 @@ stages:
           timeout_in_minutes: 360
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_default
+  - stage: azure_eastus2_lower_max_inflight
     dependsOn: []
     variables:
       - group: API-Server-L4-Config-MI50

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -38,8 +38,37 @@ stages:
           timeout_in_minutes: 360
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2
+  - stage: azure_eastus2_default
     dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "false"
+            exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "false"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.2.0
+            benchmark_subcmd: node100_job1_pod3k
+            benchmark_subcmd_args: "--total 36000"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: azure_eastus2_default
+    dependsOn: []
+    variables:
+      - group: API-Server-L4-Config-MI50
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:


### PR DESCRIPTION
This pull request includes several changes to the `pipelines/perf-eval/API Server Benchmark` YAML files to update stage names, remove `sku_tier` parameters, and modify benchmark command arguments. The most important changes are summarized below:

### Stage Name Updates:
* Changed stage names from `azure_eastus2_free` to `azure_eastus2_default`, `azure_eastus2_standard` to `azure_eastus2_lower_max_inflight`, and `azure_eastus2_l7_json` to `azure_eastus2_l4_MI50` in `apiserver-benchmark-virtualnodes10-pods100.yml` and `apiserver-benchmark-virtualnodes100-pods10k.yml`. [[1]](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67L43-R43) [[2]](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67L72-R73) [[3]](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0L70-R73)

### Parameter Removals:
* Removed `sku_tier` parameters from the `workload-low` and `exempt` sections in `apiserver-benchmark-virtualnodes10-pods100.yml`. [[1]](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67L57-L62) [[2]](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67L86-L91)

### Benchmark Command Modifications:
* Updated benchmark command arguments by removing the `--content-type` parameter in `apiserver-benchmark-virtualnodes100-pods10k.yml`. [[1]](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0L94-R99) [[2]](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0R113-R131)

### Additional Stage Configuration:
* Added a new stage `azure_eastus2_default` with specific variables and job parameters in `apiserver-benchmark-virtualnodes100-pods3k.yml`.