### PR TITLE
Tune CRI test to work with Ephemeral disk

### DIFF
--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -106,7 +106,7 @@ steps:
       - Identifier: Sleep
         Method: Sleep
         Params:
-          duration: 3m
+          duration: 1m
 
   - name: Wait for nodes to be ready
     measurements:

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -101,13 +101,6 @@ steps:
         Params:
           action: gather
 
-  {{if $scrapeKubelets}}
-  - module:
-      path: /kubelet-measurement.yaml
-      params:
-        action: gather
-  {{end}}
-
   - name: Wait for resource consumption
     measurements:
       - Identifier: Sleep
@@ -131,6 +124,13 @@ steps:
           labelSelector: cri-resource-consume = true
           timeout: 1m
           refreshInterval: 5s
+  {{end}}
+
+  {{if $scrapeKubelets}}
+  - module:
+      path: /kubelet-measurement.yaml
+      params:
+        action: gather
   {{end}}
 
   {{range $j := Loop $steps}}

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -101,6 +101,13 @@ steps:
         Params:
           action: gather
 
+  {{if $scrapeKubelets}}
+  - module:
+      path: /kubelet-measurement.yaml
+      params:
+        action: gather
+  {{end}}
+
   - name: Wait for resource consumption
     measurements:
       - Identifier: Sleep
@@ -124,13 +131,6 @@ steps:
           labelSelector: cri-resource-consume = true
           timeout: 1m
           refreshInterval: 5s
-  {{end}}
-
-  {{if $scrapeKubelets}}
-  - module:
-      path: /kubelet-measurement.yaml
-      params:
-        action: gather
   {{end}}
 
   {{range $j := Loop $steps}}

--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -101,19 +101,12 @@ steps:
         Params:
           action: gather
 
-  {{if $scrapeKubelets}}
-  - module:
-      path: /kubelet-measurement.yaml
-      params:
-        action: gather
-  {{end}}
-
   - name: Wait for resource consumption
     measurements:
       - Identifier: Sleep
         Method: Sleep
         Params:
-          duration: 1m
+          duration: 3m
 
   - name: Wait for nodes to be ready
     measurements:
@@ -131,6 +124,13 @@ steps:
           labelSelector: cri-resource-consume = true
           timeout: 1m
           refreshInterval: 5s
+  {{end}}
+
+  {{if $scrapeKubelets}}
+  - module:
+      path: /kubelet-measurement.yaml
+      params:
+        action: gather
   {{end}}
 
   {{range $j := Loop $steps}}

--- a/modules/python/clusterloader2/cri/config/deployment_template.yaml
+++ b/modules/python/clusterloader2/cri/config/deployment_template.yaml
@@ -70,3 +70,7 @@ spec:
         operator: "Equal"
         value: "true"
         effect: "NoSchedule"
+      - key: "cri-resource-consume"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -83,10 +83,10 @@ steps:
           - operation_type
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.99, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m]) + 0.000000001) by (node, operation_type, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.90, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m]) + 0.000000001) by (node, operation_type, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.50, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m]) + 0.000000001) by (node, operation_type, le))
         - name: Sum
           query: kubelet_runtime_operations_duration_seconds_sum{operation_type="pull_image"} by (node, operation_type)

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -64,8 +64,8 @@ steps:
           - operation_type
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[10m])) by (node, operation_type, le))
+          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[20m])) by (node, operation_type, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[10m])) by (node, operation_type, le))
+          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[20m])) by (node, operation_type, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{node=~".*"}[10m])) by (node, operation_type, le))
+          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[20m])) by (node, operation_type, le))

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -69,6 +69,8 @@ steps:
           query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
         - name: Perc50
           query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
+        - name: Sum
+          query: kubelet_runtime_operations_duration_seconds_sum{operation_type!="pull_image"} by (node, operation_type)
     - Identifier: KubeletRuntimeOperationDurationWithPullImage
       Method: GenericPrometheusQuery
       Params:
@@ -81,8 +83,10 @@ steps:
           - operation_type
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[10m])) by (node, operation_type, le))
+          query: histogram_quantile(0.99, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[10m])) by (node, operation_type, le))
+          query: histogram_quantile(0.90, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[10m])) by (node, operation_type, le))
+          query: histogram_quantile(0.50, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
+        - name: Sum
+          query: kubelet_runtime_operations_duration_seconds_sum{operation_type="pull_image"} by (node, operation_type)

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -70,7 +70,7 @@ steps:
         - name: Perc50
           query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
         - name: Sum
-          query: kubelet_runtime_operations_duration_seconds_sum{operation_type!="pull_image"} by (node, operation_type)
+          query: kubelet_runtime_operations_duration_seconds_sum{operation_type!="pull_image"}
     - Identifier: KubeletRuntimeOperationDurationWithPullImage
       Method: GenericPrometheusQuery
       Params:
@@ -83,10 +83,10 @@ steps:
           - operation_type
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m]) + 0.000000001) by (node, operation_type, le))
+          query: histogram_quantile(0.99, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m]) + 0.000000001) by (node, operation_type, le))
+          query: histogram_quantile(0.90, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m]) + 0.000000001) by (node, operation_type, le))
+          query: histogram_quantile(0.50, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
         - name: Sum
-          query: kubelet_runtime_operations_duration_seconds_sum{operation_type="pull_image"} by (node, operation_type)
+          query: kubelet_runtime_operations_duration_seconds_sum{operation_type="pull_image"}

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -52,11 +52,11 @@ steps:
           query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[10m])) by (node, le))
         - name: Perc50
           query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[10m])) by (node, le))
-    - Identifier: KubeletRuntimeOperationDuration
+    - Identifier: KubeletRuntimeOperationDurationWithoutPullImage
       Method: GenericPrometheusQuery
       Params:
         action: {{$action}}
-        metricName: KubeletRuntimeOperationDuration
+        metricName: KubeletRuntimeOperationDurationWithoutPullImage
         metricVersion: v1
         unit: s
         dimensions:
@@ -64,8 +64,25 @@ steps:
           - operation_type
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[5m])) by (node, operation_type, le))
+          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
+    - Identifier: KubeletRuntimeOperationDurationWithPullImage
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletRuntimeOperationDurationWithPullImage
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+          - operation_type
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[10m])) by (node, operation_type, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[10m])) by (node, operation_type, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[10m])) by (node, operation_type, le))

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -64,8 +64,8 @@ steps:
           - operation_type
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[1h])) by (node, operation_type, le))
+          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[5m])) by (node, operation_type, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[1h])) by (node, operation_type, le))
+          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[5m])) by (node, operation_type, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[1h])) by (node, operation_type, le))
+          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[5m])) by (node, operation_type, le))

--- a/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -64,8 +64,8 @@ steps:
           - operation_type
         queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[20m])) by (node, operation_type, le))
+          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[1h])) by (node, operation_type, le))
         - name: Perc90
-          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[20m])) by (node, operation_type, le))
+          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[1h])) by (node, operation_type, le))
         - name: Perc50
-          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[20m])) by (node, operation_type, le))
+          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket[1h])) by (node, operation_type, le))

--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -92,7 +92,7 @@ def override_config_clusterloader2(
 
 def execute_clusterloader2(cl2_image, cl2_config_dir, cl2_report_dir, kubeconfig, provider, scrape_kubelets):
     run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, overrides=True, enable_prometheus=True,
-                    tear_down_prometheus=True, scrape_kubelets=scrape_kubelets)
+                    tear_down_prometheus=False, scrape_kubelets=scrape_kubelets)
 
 def verify_measurement():
     client = KubernetesClient(os.path.expanduser("~/.kube/config"))

--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -115,10 +115,9 @@ def verify_measurement():
             
             metrics = response[0]  # The first item contains the response data
             filtered_metrics = "\n".join(
-                # line for line in metrics.splitlines() if line.startswith("kubelet_pod_start"),
-                line for line in metrics.splitlines() if line.startswith("kubelet_runtime_operations")
+                line for line in metrics.splitlines() if line.startswith("kubelet_pod_start") or line.startswith("kubelet_runtime_operations")
             )
-            print("Metrics for node:", node_name)
+            print("##[section]Metrics for node:", node_name)
             print(filtered_metrics)
 
         except k8s_client.ApiException as e:

--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -91,7 +91,8 @@ def override_config_clusterloader2(
     file.close()
 
 def execute_clusterloader2(cl2_image, cl2_config_dir, cl2_report_dir, kubeconfig, provider, scrape_kubelets):
-    run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, overrides=True, enable_prometheus=True, scrape_kubelets=scrape_kubelets)
+    run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, overrides=True, enable_prometheus=True,
+                    tear_down_prometheus=True, scrape_kubelets=scrape_kubelets)
 
 def verify_measurement():
     client = KubernetesClient(os.path.expanduser("~/.kube/config"))
@@ -114,12 +115,13 @@ def verify_measurement():
             
             metrics = response[0]  # The first item contains the response data
             filtered_metrics = "\n".join(
-                line for line in metrics.splitlines() if line.startswith("kubelet_pod_start")
+                # line for line in metrics.splitlines() if line.startswith("kubelet_pod_start"),
+                line for line in metrics.splitlines() if line.startswith("kubelet_runtime_operations")
             )
             print("Metrics for node:", node_name)
             print(filtered_metrics)
 
-        except client.ApiException as e:
+        except k8s_client.ApiException as e:
             print(f"Error fetching metrics: {e}")
 
 def collect_clusterloader2(

--- a/modules/python/clusterloader2/utils.py
+++ b/modules/python/clusterloader2/utils.py
@@ -14,7 +14,8 @@ NETWORK_METRIC_PREFIXES = ["APIResponsivenessPrometheus", "InClusterNetworkLaten
 PROM_QUERY_PREFIX = "GenericPrometheusQuery"
 RESOURCE_USAGE_SUMMARY_PREFIX = "ResourceUsageSummary"
 
-def run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, cl2_config_file="config.yaml", overrides=False, enable_prometheus=False, enable_exec_service=False, scrape_kubelets=False):
+def run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, cl2_config_file="config.yaml", overrides=False, enable_prometheus=False, tear_down_prometheus=True,
+                    enable_exec_service=False, scrape_kubelets=False):
     docker_client = DockerClient()
 
     command=f"""--provider={provider} --v=2
@@ -24,7 +25,7 @@ def run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provi
 --kubeconfig /root/.kube/config
 --testconfig /root/perf-tests/clusterloader2/config/{cl2_config_file}
 --report-dir /root/perf-tests/clusterloader2/results
---tear-down-prometheus-server={enable_prometheus}"""
+--tear-down-prometheus-server={tear_down_prometheus}"""
     if overrides:
         command += f" --testoverrides=/root/perf-tests/clusterloader2/config/overrides.yaml"
 

--- a/modules/terraform/azure/README.md
+++ b/modules/terraform/azure/README.md
@@ -66,6 +66,7 @@ Set `INPUT_JSON` variable. This variable is not exhaustive and may vary dependin
   --arg aks_kubernetes_version "$KUBERNETES_VERSION" \
   --arg aks_network_policy "$NETWORK_POLICY" \
   --arg aks_network_dataplane "$NETWORK_DATAPLANE" \
+  --arg k8s_machine_type "$K8S_MACHINE_TYPE" \
   --argjson aks_cli_system_node_pool "$SYSTEM_NODE_POOL" \
   --argjson aks_cli_user_node_pool "$USER_NODE_POOL" \
   '{
@@ -75,6 +76,7 @@ Set `INPUT_JSON` variable. This variable is not exhaustive and may vary dependin
     aks_kubernetes_version: $aks_kubernetes_version,
     aks_network_policy: $aks_network_policy,
     aks_network_dataplane: $aks_network_dataplane,
+    k8s_machine_type: $k8s_machine_type,
     aks_cli_system_node_pool: $aks_cli_system_node_pool,
     aks_cli_user_node_pool: $aks_cli_user_node_pool
   }' | jq 'with_entries(select(.value != null and .value != ""))')

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -34,25 +34,22 @@ stages:
               load_type: memory
               kubernetes_version: "1.30"
               scrape_kubelets: True
-              k8s_machine_type: Standard_D16ds_v4
-            # n10-p700-memory-1-30:
-            #   node_count: 10
-            #   max_pods: 70
-            #   repeats: 1
-            #   operation_timeout: 7m
-            #   load_type: memory
-            #   kubernetes_version: "1.30"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16ds_v4
-            # n10-p1100-memory-1-30:
-            #   node_count: 10
-            #   max_pods: 110
-            #   repeats: 1
-            #   operation_timeout: 11m
-            #   load_type: memory
-            #   kubernetes_version: "1.30"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16ds_v4
+            n10-p700-memory-1-30:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: memory
+              kubernetes_version: "1.30"
+              scrape_kubelets: True
+            n10-p1100-memory-1-30:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: memory
+              kubernetes_version: "1.30"
+              scrape_kubelets: True
             n10-p300-memory-1-31:
               node_count: 10
               max_pods: 30
@@ -61,83 +58,155 @@ stages:
               load_type: memory
               kubernetes_version: "1.31"
               scrape_kubelets: True
-              k8s_machine_type: Standard_D16ds_v4
-            # n10-p700-memory-1-31:
-            #   node_count: 10
-            #   max_pods: 70
-            #   repeats: 1
-            #   operation_timeout: 7m
-            #   load_type: memory
-            #   kubernetes_version: "1.31"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16ds_v4
-            # n10-p1100-memory-1-31:
-            #   node_count: 10
-            #   max_pods: 110
-            #   repeats: 1
-            #   operation_timeout: 11m
-            #   load_type: memory
-            #   kubernetes_version: "1.31"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16ds_v4
-            # n10-p300-memory-1-30-v5:
-            #   node_count: 10
-            #   max_pods: 30
-            #   repeats: 1
-            #   operation_timeout: 3m
-            #   load_type: memory
-            #   kubernetes_version: "1.30"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16s_v5
-            # n10-p700-memory-1-30-v5:
-            #   node_count: 10
-            #   max_pods: 70
-            #   repeats: 1
-            #   operation_timeout: 7m
-            #   load_type: memory
-            #   kubernetes_version: "1.30"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16s_v5
-            # n10-p1100-memory-1-30-v5:
-            #   node_count: 10
-            #   max_pods: 110
-            #   repeats: 1
-            #   operation_timeout: 11m
-            #   load_type: memory
-            #   kubernetes_version: "1.30"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16s_v5
-            # n10-p300-memory-1-31-v5:
-            #   node_count: 10
-            #   max_pods: 30
-            #   repeats: 1
-            #   operation_timeout: 3m
-            #   load_type: memory
-            #   kubernetes_version: "1.31"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16s_v5
-            # n10-p700-memory-1-31-v5:
-            #   node_count: 10
-            #   max_pods: 70
-            #   repeats: 1
-            #   operation_timeout: 7m
-            #   load_type: memory
-            #   kubernetes_version: "1.31"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16s_v5
-            # n10-p1100-memory-1-31-v5:
-            #   node_count: 10
-            #   max_pods: 110
-            #   repeats: 1
-            #   operation_timeout: 11m
-            #   load_type: memory
-            #   kubernetes_version: "1.31"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16s_v5
+            n10-p700-memory-1-31:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: memory
+              kubernetes_version: "1.31"
+              scrape_kubelets: True
+            n10-p1100-memory-1-31:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: memory
+              kubernetes_version: "1.31"
+              scrape_kubelets: True
           max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection
           ssh_key_enabled: false
+
+  - stage: azure_swedencentral_ephemeral
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - swedencentral
+          engine: clusterloader2
+          engine_input:
+            image: "ghcr.io/azure/clusterloader2:v20241016"
+          topology: cri-resource-consume
+          matrix:
+            n10-p300-memory-1-30:
+              node_count: 10
+              max_pods: 30
+              repeats: 1
+              operation_timeout: 3m
+              load_type: memory
+              kubernetes_version: "1.30"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+            n10-p700-memory-1-30:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: memory
+              kubernetes_version: "1.30"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+            n10-p1100-memory-1-30:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: memory
+              kubernetes_version: "1.30"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+            n10-p300-memory-1-31:
+              node_count: 10
+              max_pods: 30
+              repeats: 1
+              operation_timeout: 3m
+              load_type: memory
+              kubernetes_version: "1.31"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+            n10-p700-memory-1-31:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: memory
+              kubernetes_version: "1.31"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+            n10-p1100-memory-1-31:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: memory
+              kubernetes_version: "1.31"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+          max_parallel: 3
+          timeout_in_minutes: 120
+          credential_type: service_connection
+          ssh_key_enabled: false
+
+  - stage: azure_swedencentral_disabled_parallel_pull
+    dependsOn: []
+    variables:
+      - group: Parallel-Pull-Disabled
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - swedencentral
+          engine: clusterloader2
+          engine_input:
+            image: "ghcr.io/azure/clusterloader2:v20241016"
+          topology: cri-resource-consume
+          matrix:
+            n10-p300-memory-1-31:
+              node_count: 10
+              max_pods: 30
+              repeats: 1
+              operation_timeout: 3m
+              load_type: memory
+              kubernetes_version: "1.31"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+            n10-p700-memory-1-31:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: memory
+              kubernetes_version: "1.31"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+            n10-p1100-memory-1-31:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: memory
+              kubernetes_version: "1.31"
+              k8s_machine_type: Standard_D16ds_v4
+              k8s_os_disk_type: Ephemeral
+              scrape_kubelets: True
+          max_parallel: 3
+          timeout_in_minutes: 120
+          credential_type: service_connection
+          ssh_key_enabled: false
+
   - stage: aws_westeurope
     dependsOn: []
     jobs:
@@ -158,41 +227,20 @@ stages:
               operation_timeout: 3m
               load_type: memory
               scrape_kubelets: True
-            # n10-p700-memory:
-            #   node_count: 10
-            #   max_pods: 70
-            #   repeats: 1
-            #   operation_timeout: 7m
-            #   load_type: memory
-            #   scrape_kubelets: True
-            # n10-p1100-memory:
-            #   node_count: 10
-            #   max_pods: 110
-            #   repeats: 1
-            #   operation_timeout: 11m
-            #   load_type: memory
-            #   scrape_kubelets: True
-            # n10-p300-cpu:
-            #   node_count: 10
-            #   max_pods: 30
-            #   repeats: 1
-            #   operation_timeout: 3m
-            #   load_type: cpu
-            #   scrape_kubelets: True
-            # n10-p700-cpu:
-            #   node_count: 10
-            #   max_pods: 70
-            #   repeats: 1
-            #   operation_timeout: 7m
-            #   load_type: cpu
-            #   scrape_kubelets: True
-            # n10-p1100-cpu:
-            #   node_count: 10
-            #   max_pods: 110
-            #   repeats: 1
-            #   operation_timeout: 11m
-            #   load_type: cpu
-            #   scrape_kubelets: True
+            n10-p700-memory:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: memory
+              scrape_kubelets: True
+            n10-p1100-memory:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: memory
+              scrape_kubelets: True
           max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -35,51 +35,51 @@ stages:
               kubernetes_version: "1.30"
               scrape_kubelets: True
               k8s_machine_type: Standard_D16ds_v4
-            n10-p700-memory-1-30:
-              node_count: 10
-              max_pods: 70
-              repeats: 1
-              operation_timeout: 7m
-              load_type: memory
-              kubernetes_version: "1.30"
-              scrape_kubelets: True
-              k8s_machine_type: Standard_D16ds_v4
-            n10-p1100-memory-1-30:
-              node_count: 10
-              max_pods: 110
-              repeats: 1
-              operation_timeout: 11m
-              load_type: memory
-              kubernetes_version: "1.30"
-              scrape_kubelets: True
-              k8s_machine_type: Standard_D16ds_v4
-            n10-p300-memory-1-31:
-              node_count: 10
-              max_pods: 30
-              repeats: 1
-              operation_timeout: 3m
-              load_type: memory
-              kubernetes_version: "1.31"
-              scrape_kubelets: True
-              k8s_machine_type: Standard_D16ds_v4
-            n10-p700-memory-1-31:
-              node_count: 10
-              max_pods: 70
-              repeats: 1
-              operation_timeout: 7m
-              load_type: memory
-              kubernetes_version: "1.31"
-              scrape_kubelets: True
-              k8s_machine_type: Standard_D16ds_v4
-            n10-p1100-memory-1-31:
-              node_count: 10
-              max_pods: 110
-              repeats: 1
-              operation_timeout: 11m
-              load_type: memory
-              kubernetes_version: "1.31"
-              scrape_kubelets: True
-              k8s_machine_type: Standard_D16ds_v4
+            # n10-p700-memory-1-30:
+            #   node_count: 10
+            #   max_pods: 70
+            #   repeats: 1
+            #   operation_timeout: 7m
+            #   load_type: memory
+            #   kubernetes_version: "1.30"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16ds_v4
+            # n10-p1100-memory-1-30:
+            #   node_count: 10
+            #   max_pods: 110
+            #   repeats: 1
+            #   operation_timeout: 11m
+            #   load_type: memory
+            #   kubernetes_version: "1.30"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16ds_v4
+            # n10-p300-memory-1-31:
+            #   node_count: 10
+            #   max_pods: 30
+            #   repeats: 1
+            #   operation_timeout: 3m
+            #   load_type: memory
+            #   kubernetes_version: "1.31"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16ds_v4
+            # n10-p700-memory-1-31:
+            #   node_count: 10
+            #   max_pods: 70
+            #   repeats: 1
+            #   operation_timeout: 7m
+            #   load_type: memory
+            #   kubernetes_version: "1.31"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16ds_v4
+            # n10-p1100-memory-1-31:
+            #   node_count: 10
+            #   max_pods: 110
+            #   repeats: 1
+            #   operation_timeout: 11m
+            #   load_type: memory
+            #   kubernetes_version: "1.31"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16ds_v4
             # n10-p300-memory-1-30-v5:
             #   node_count: 10
             #   max_pods: 30

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -53,15 +53,15 @@ stages:
             #   kubernetes_version: "1.30"
             #   scrape_kubelets: True
             #   k8s_machine_type: Standard_D16ds_v4
-            # n10-p300-memory-1-31:
-            #   node_count: 10
-            #   max_pods: 30
-            #   repeats: 1
-            #   operation_timeout: 3m
-            #   load_type: memory
-            #   kubernetes_version: "1.31"
-            #   scrape_kubelets: True
-            #   k8s_machine_type: Standard_D16ds_v4
+            n10-p300-memory-1-31:
+              node_count: 10
+              max_pods: 30
+              repeats: 1
+              operation_timeout: 3m
+              load_type: memory
+              kubernetes_version: "1.31"
+              scrape_kubelets: True
+              k8s_machine_type: Standard_D16ds_v4
             # n10-p700-memory-1-31:
             #   node_count: 10
             #   max_pods: 70

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -158,20 +158,20 @@ stages:
               operation_timeout: 3m
               load_type: memory
               scrape_kubelets: True
-            n10-p700-memory:
-              node_count: 10
-              max_pods: 70
-              repeats: 1
-              operation_timeout: 7m
-              load_type: memory
-              scrape_kubelets: True
-            n10-p1100-memory:
-              node_count: 10
-              max_pods: 110
-              repeats: 1
-              operation_timeout: 11m
-              load_type: memory
-              scrape_kubelets: True
+            # n10-p700-memory:
+            #   node_count: 10
+            #   max_pods: 70
+            #   repeats: 1
+            #   operation_timeout: 7m
+            #   load_type: memory
+            #   scrape_kubelets: True
+            # n10-p1100-memory:
+            #   node_count: 10
+            #   max_pods: 110
+            #   repeats: 1
+            #   operation_timeout: 11m
+            #   load_type: memory
+            #   scrape_kubelets: True
             # n10-p300-cpu:
             #   node_count: 10
             #   max_pods: 30

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -34,6 +34,7 @@ stages:
               load_type: memory
               kubernetes_version: "1.30"
               scrape_kubelets: True
+              k8s_machine_type: Standard_D16ds_v4
             n10-p700-memory-1-30:
               node_count: 10
               max_pods: 70
@@ -42,6 +43,7 @@ stages:
               load_type: memory
               kubernetes_version: "1.30"
               scrape_kubelets: True
+              k8s_machine_type: Standard_D16ds_v4
             n10-p1100-memory-1-30:
               node_count: 10
               max_pods: 110
@@ -50,6 +52,7 @@ stages:
               load_type: memory
               kubernetes_version: "1.30"
               scrape_kubelets: True
+              k8s_machine_type: Standard_D16ds_v4
             n10-p300-memory-1-31:
               node_count: 10
               max_pods: 30
@@ -58,6 +61,7 @@ stages:
               load_type: memory
               kubernetes_version: "1.31"
               scrape_kubelets: True
+              k8s_machine_type: Standard_D16ds_v4
             n10-p700-memory-1-31:
               node_count: 10
               max_pods: 70
@@ -66,6 +70,7 @@ stages:
               load_type: memory
               kubernetes_version: "1.31"
               scrape_kubelets: True
+              k8s_machine_type: Standard_D16ds_v4
             n10-p1100-memory-1-31:
               node_count: 10
               max_pods: 110
@@ -74,54 +79,61 @@ stages:
               load_type: memory
               kubernetes_version: "1.31"
               scrape_kubelets: True
-            n10-p300-cpu-1-30:
-              node_count: 10
-              max_pods: 30
-              repeats: 1
-              operation_timeout: 3m
-              load_type: cpu
-              kubernetes_version: "1.30"
-              scrape_kubelets: True
-            n10-p700-cpu-1-30:
-              node_count: 10
-              max_pods: 70
-              repeats: 1
-              operation_timeout: 7m
-              load_type: cpu
-              kubernetes_version: "1.30"
-              scrape_kubelets: True
-            n10-p1100-cpu-1-30:
-              node_count: 10
-              max_pods: 110
-              repeats: 1
-              operation_timeout: 11m
-              load_type: cpu
-              kubernetes_version: "1.30"
-              scrape_kubelets: True
-            n10-p300-cpu-1-31:
-              node_count: 10
-              max_pods: 30
-              repeats: 1
-              operation_timeout: 3m
-              load_type: cpu
-              kubernetes_version: "1.31"
-              scrape_kubelets: True
-            n10-p700-cpu-1-31:
-              node_count: 10
-              max_pods: 70
-              repeats: 1
-              operation_timeout: 7m
-              load_type: cpu
-              kubernetes_version: "1.31"
-              scrape_kubelets: True
-            n10-p1100-cpu-1-31:
-              node_count: 10
-              max_pods: 110
-              repeats: 1
-              operation_timeout: 11m
-              load_type: cpu
-              kubernetes_version: "1.31"
-              scrape_kubelets: True
+              k8s_machine_type: Standard_D16ds_v4
+            # n10-p300-memory-1-30-v5:
+            #   node_count: 10
+            #   max_pods: 30
+            #   repeats: 1
+            #   operation_timeout: 3m
+            #   load_type: memory
+            #   kubernetes_version: "1.30"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16s_v5
+            # n10-p700-memory-1-30-v5:
+            #   node_count: 10
+            #   max_pods: 70
+            #   repeats: 1
+            #   operation_timeout: 7m
+            #   load_type: memory
+            #   kubernetes_version: "1.30"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16s_v5
+            # n10-p1100-memory-1-30-v5:
+            #   node_count: 10
+            #   max_pods: 110
+            #   repeats: 1
+            #   operation_timeout: 11m
+            #   load_type: memory
+            #   kubernetes_version: "1.30"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16s_v5
+            # n10-p300-memory-1-31-v5:
+            #   node_count: 10
+            #   max_pods: 30
+            #   repeats: 1
+            #   operation_timeout: 3m
+            #   load_type: memory
+            #   kubernetes_version: "1.31"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16s_v5
+            # n10-p700-memory-1-31-v5:
+            #   node_count: 10
+            #   max_pods: 70
+            #   repeats: 1
+            #   operation_timeout: 7m
+            #   load_type: memory
+            #   kubernetes_version: "1.31"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16s_v5
+            # n10-p1100-memory-1-31-v5:
+            #   node_count: 10
+            #   max_pods: 110
+            #   repeats: 1
+            #   operation_timeout: 11m
+            #   load_type: memory
+            #   kubernetes_version: "1.31"
+            #   scrape_kubelets: True
+            #   k8s_machine_type: Standard_D16s_v5
           max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection
@@ -160,27 +172,27 @@ stages:
               operation_timeout: 11m
               load_type: memory
               scrape_kubelets: True
-            n10-p300-cpu:
-              node_count: 10
-              max_pods: 30
-              repeats: 1
-              operation_timeout: 3m
-              load_type: cpu
-              scrape_kubelets: True
-            n10-p700-cpu:
-              node_count: 10
-              max_pods: 70
-              repeats: 1
-              operation_timeout: 7m
-              load_type: cpu
-              scrape_kubelets: True
-            n10-p1100-cpu:
-              node_count: 10
-              max_pods: 110
-              repeats: 1
-              operation_timeout: 11m
-              load_type: cpu
-              scrape_kubelets: True
+            # n10-p300-cpu:
+            #   node_count: 10
+            #   max_pods: 30
+            #   repeats: 1
+            #   operation_timeout: 3m
+            #   load_type: cpu
+            #   scrape_kubelets: True
+            # n10-p700-cpu:
+            #   node_count: 10
+            #   max_pods: 70
+            #   repeats: 1
+            #   operation_timeout: 7m
+            #   load_type: cpu
+            #   scrape_kubelets: True
+            # n10-p1100-cpu:
+            #   node_count: 10
+            #   max_pods: 110
+            #   repeats: 1
+            #   operation_timeout: 11m
+            #   load_type: cpu
+            #   scrape_kubelets: True
           max_parallel: 3
           timeout_in_minutes: 120
           credential_type: service_connection

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/aws.tfvars
@@ -93,6 +93,11 @@ eks_config_list = [{
           key    = "cri-resource-consume"
           value  = "true"
           effect = "NO_SCHEDULE"
+        },
+        {
+          key    = "cri-resource-consume"
+          value  = "true"
+          effect = "NO_EXECUTE"
         }
       ]
       labels = {

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -38,7 +38,7 @@ aks_config_list = [
       name                         = "default"
       node_count                   = 3
       vm_size                      = "Standard_D16_v3"
-      os_disk_type                 = "Ephemeral"
+      os_disk_type                 = "Managed"
       only_critical_addons_enabled = true
       temporary_name_for_rotation  = "defaulttmp"
     }
@@ -48,7 +48,7 @@ aks_config_list = [
         node_count           = 1
         auto_scaling_enabled = false
         vm_size              = "Standard_D16_v3"
-        os_disk_type         = "Ephemeral"
+        os_disk_type         = "Managed"
         node_labels          = { "prometheus" = "true" }
       },
       {

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -38,7 +38,7 @@ aks_config_list = [
       name                         = "default"
       node_count                   = 3
       vm_size                      = "Standard_D16_v3"
-      os_disk_type                 = "Managed"
+      os_disk_type                 = "Ephemeral"
       only_critical_addons_enabled = true
       temporary_name_for_rotation  = "defaulttmp"
     }
@@ -48,6 +48,7 @@ aks_config_list = [
         node_count           = 1
         auto_scaling_enabled = false
         vm_size              = "Standard_D16_v3"
+        os_disk_type         = "Ephemeral"
         node_labels          = { "prometheus" = "true" }
       },
       {
@@ -55,6 +56,7 @@ aks_config_list = [
         node_count           = 10
         auto_scaling_enabled = false
         vm_size              = "Standard_D16_v3"
+        os_disk_type         = "Ephemeral"
         node_taints          = ["cri-resource-consume=true:NoSchedule"]
         node_labels          = { "cri-resource-consume" = "true" }
       }

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -57,7 +57,7 @@ aks_config_list = [
         auto_scaling_enabled = false
         vm_size              = "Standard_D16_v3"
         os_disk_type         = "Ephemeral"
-        node_taints          = ["cri-resource-consume=true:NoSchedule"]
+        node_taints          = ["cri-resource-consume=true:NoSchedule", "cri-resource-consume=true:NoExecute"]
         node_labels          = { "cri-resource-consume" = "true" }
       }
     ]

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -38,7 +38,7 @@ aks_config_list = [
       name                         = "default"
       node_count                   = 3
       vm_size                      = "Standard_D16_v3"
-      os_disk_type                 = "Ephemeral"
+      os_disk_type                 = "Managed"
       only_critical_addons_enabled = true
       temporary_name_for_rotation  = "defaulttmp"
     }
@@ -48,7 +48,7 @@ aks_config_list = [
         node_count           = 1
         auto_scaling_enabled = false
         vm_size              = "Standard_D16_v3"
-        os_disk_type         = "Ephemeral"
+        os_disk_type         = "Managed"
         node_labels          = { "prometheus" = "true" }
       },
       {
@@ -56,7 +56,7 @@ aks_config_list = [
         node_count           = 10
         auto_scaling_enabled = false
         vm_size              = "Standard_D16_v3"
-        os_disk_type         = "Ephemeral"
+        os_disk_type         = "Managed"
         node_taints          = ["cri-resource-consume=true:NoSchedule", "cri-resource-consume=true:NoExecute"]
         node_labels          = { "cri-resource-consume" = "true" }
       }

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -38,7 +38,7 @@ aks_config_list = [
       name                         = "default"
       node_count                   = 3
       vm_size                      = "Standard_D16_v3"
-      os_disk_type                 = "Managed"
+      os_disk_type                 = "Ephemeral"
       only_critical_addons_enabled = true
       temporary_name_for_rotation  = "defaulttmp"
     }
@@ -48,7 +48,7 @@ aks_config_list = [
         node_count           = 1
         auto_scaling_enabled = false
         vm_size              = "Standard_D16_v3"
-        os_disk_type         = "Managed"
+        os_disk_type         = "Ephemeral"
         node_labels          = { "prometheus" = "true" }
       },
       {

--- a/steps/cloud/azure/collect-cloud-info.yml
+++ b/steps/cloud/azure/collect-cloud-info.yml
@@ -19,6 +19,7 @@ steps:
       --arg subscription "$(az account show --query id --output tsv)" \
       --arg edge_zone "$(echo $aks_info | jq -r .extendedLocation.name)" \
       --arg network_profile "$(echo $aks_info | jq -r .networkProfile)" \
+      --arg agentpool_profile "$(echo $aks_info | jq -r .agentPoolProfiles)" \
       '{
         cloud: $cloud,
         region: $region,
@@ -27,7 +28,8 @@ steps:
         sku_tier: $sku_tier,
         subscription: $subscription,
         edge_zone: $edge_zone,
-        network_profile: $network_profile
+        network_profile: $network_profile,
+        agentpool_profile: $agentpool_profile
       }')
     cloud_info_str=$(echo $cloud_info | jq -c .)
     echo "Cloud info: $cloud_info_str"


### PR DESCRIPTION
- Add NoExecute taint to evict system pods landing on user pool (unsure while NoSchedule didn't prevent pods without tolerations from landing on the pool)
- Split pull image operation into a separate metrics
- Reduce scrape window for pull image operation to 5m since the operation is scarce and use avg_over_time() instead of rate() as histogram_quantile() won't work if rate() returns all 0 values for quick pull image
- Add jobs to run with ephemeral disk and remove cpu jobs to save some resources
- Add stage for parallel pull disabled