### PR TITLE
Add variable to customize AKS os disk type for all node pools

### DIFF
--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -14,6 +14,9 @@ env:
   AWS_REGION: us-east-1
 jobs:
   terraform-validation:
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
@@ -66,6 +69,18 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_MI }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Terraform Azure Test
+        working-directory: ${{ env.TERRAFORM_AZURE_MODULES_DIR }}
+        run: terraform test
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   setup-matrix:
     runs-on: ubuntu-latest

--- a/modules/terraform/azure/aks/main.tf
+++ b/modules/terraform/azure/aks/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     vm_size                      = coalesce(var.k8s_machine_type, var.aks_config.default_node_pool.vm_size)
     vnet_subnet_id               = try(local.subnets[var.aks_config.default_node_pool.subnet_name], try(var.subnet_id, null))
     os_sku                       = var.aks_config.default_node_pool.os_sku
-    os_disk_type                 = var.aks_config.default_node_pool.os_disk_type
+    os_disk_type                 = coalesce(var.k8s_os_disk_type, var.aks_config.default_node_pool.os_disk_type)
     only_critical_addons_enabled = var.aks_config.default_node_pool.only_critical_addons_enabled
     temporary_name_for_rotation  = var.aks_config.default_node_pool.temporary_name_for_rotation
     max_pods                     = var.aks_config.default_node_pool.max_pods
@@ -91,7 +91,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "pools" {
   vm_size               = coalesce(var.k8s_machine_type, each.value.vm_size)
   vnet_subnet_id        = try(local.subnets[each.value.subnet_name], null)
   os_sku                = each.value.os_sku
-  os_disk_type          = each.value.os_disk_type
+  os_disk_type          = coalesce(var.k8s_os_disk_type, each.value.os_disk_type)
   max_pods              = each.value.max_pods
   ultra_ssd_enabled     = try(each.value.ultra_ssd_enabled, false)
   zones                 = try(each.value.zones, [])

--- a/modules/terraform/azure/aks/variables.tf
+++ b/modules/terraform/azure/aks/variables.tf
@@ -36,6 +36,12 @@ variable "k8s_machine_type" {
   default     = null
 }
 
+variable "k8s_os_disk_type" {
+  description = "Value to replace AKS nodes os_disk_type"
+  type        = string
+  default     = null
+}
+
 variable "network_policy" {
   description = "Value to replace the AKS network_policy. If network_policy is 'azure' or 'cilium', network_dataplane must match or be null."
   type        = string

--- a/modules/terraform/azure/azure_input_schema.json
+++ b/modules/terraform/azure/azure_input_schema.json
@@ -25,7 +25,10 @@
     "aks_cli_user_node_pool": {
       "type": "array"
     },
-    "k8s_machine_type" : {
+    "k8s_machine_type": {
+      "type": "string"
+    },
+    "k8s_os_disk_type": {
       "type": "string"
     }
   },

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -9,6 +9,7 @@ locals {
   aks_cli_user_node_pool   = lookup(var.json_input, "aks_cli_user_node_pool", null)
   aks_custom_headers       = lookup(var.json_input, "aks_custom_headers", [])
   k8s_machine_type         = lookup(var.json_input, "k8s_machine_type", null)
+  k8s_os_disk_type         = lookup(var.json_input, "k8s_os_disk_type", null)
 
   tags = {
     "owner"             = var.owner
@@ -85,6 +86,7 @@ module "aks" {
   vnet_id             = try(module.virtual_network[each.value.role].vnet_id, null)
   subnets             = try(local.all_subnets, null)
   k8s_machine_type    = local.k8s_machine_type
+  k8s_os_disk_type    = local.k8s_os_disk_type
   network_dataplane   = local.aks_network_dataplane
   network_policy      = local.aks_network_policy
 }

--- a/modules/terraform/azure/tests/test_aks_machine_type.tftest.hcl
+++ b/modules/terraform/azure/tests/test_aks_machine_type.tftest.hcl
@@ -7,7 +7,8 @@ variables {
     "run_id" : "123456789",
     "region" : "eastus",
     "public_key_path" : "public_key_path",
-    "k8s_machine_type" : "Standard_D32s_v4"
+    "k8s_machine_type" : "Standard_D32s_v4",
+    "k8s_os_disk_type" : "Ephemeral",
   }
 
 
@@ -32,16 +33,18 @@ variables {
       }
       extra_node_pool = [
         {
-          name       = "server"
-          node_count = 1
-          vm_size    = "Standard_D32s_v3"
-          zones      = ["1"]
+          name         = "server"
+          node_count   = 1
+          os_disk_type = "Ephemeral"
+          vm_size      = "Standard_D32s_v3"
+          zones        = ["1"]
         },
         {
-          name       = "client"
-          node_count = 1
-          vm_size    = "Standard_L8s_v3"
-          zones      = ["1"]
+          name         = "client"
+          node_count   = 1
+          os_disk_type = "Managed"
+          vm_size      = "Standard_L8s_v3"
+          zones        = ["1"]
         }
       ]
     }
@@ -96,5 +99,50 @@ run "valid_aks_machine_type_no_override" {
   }
 }
 
+run "valid_aks_os_disk_type_override_all" {
 
+  command = plan
 
+  assert {
+    condition     = module.aks["test"].aks_cluster.default_node_pool[0].os_disk_type == var.json_input["k8s_os_disk_type"]
+    error_message = "Expected: ${var.json_input["k8s_os_disk_type"]} \n Actual:  ${module.aks["test"].aks_cluster.default_node_pool[0].os_disk_type}"
+  }
+
+  assert {
+    condition     = module.aks["test"].aks_cluster_nood_pools["server"].os_disk_type == var.json_input["k8s_os_disk_type"]
+    error_message = "Expected: ${var.json_input["k8s_os_disk_type"]} \n Actual:  ${module.aks["test"].aks_cluster_nood_pools["server"].os_disk_type}"
+  }
+
+  assert {
+    condition     = module.aks["test"].aks_cluster_nood_pools["client"].os_disk_type == var.json_input["k8s_os_disk_type"]
+    error_message = "Expected: ${var.json_input["k8s_os_disk_type"]} \n Actual:  ${module.aks["test"].aks_cluster_nood_pools["client"].os_disk_type}"
+  }
+}
+
+run "valid_aks_os_disk_type_no_override" {
+
+  command = plan
+
+  variables {
+    json_input = {
+      "run_id" : "123456789",
+      "region" : "eastus",
+      "public_key_path" : "public_key_path",
+    }
+  }
+
+  assert {
+    condition     = module.aks["test"].aks_cluster.default_node_pool[0].os_disk_type == var.aks_config_list[0].default_node_pool.os_disk_type
+    error_message = "Expected: ${var.aks_config_list[0].default_node_pool.os_disk_type} \n Actual: ${module.aks["test"].aks_cluster.default_node_pool[0].os_disk_type}"
+  }
+
+  assert {
+    condition     = module.aks["test"].aks_cluster_nood_pools["server"].os_disk_type == var.aks_config_list[0].extra_node_pool[0].os_disk_type
+    error_message = "Expected: ${var.aks_config_list[0].extra_node_pool[0].os_disk_type} \n Actual:  ${module.aks["test"].aks_cluster_nood_pools["server"].os_disk_type}"
+  }
+
+  assert {
+    condition     = module.aks["test"].aks_cluster_nood_pools["client"].os_disk_type == var.aks_config_list[0].extra_node_pool[1].os_disk_type
+    error_message = "Expected: ${var.aks_config_list[0].extra_node_pool[1].os_disk_type} \n Actual:  ${module.aks["test"].aks_cluster_nood_pools["client"].os_disk_type}"
+  }
+}

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -9,6 +9,7 @@ variable "json_input" {
     aks_network_dataplane  = optional(string, null)
     aks_custom_headers     = optional(list(string), [])
     k8s_machine_type       = optional(string, null)
+    k8s_os_disk_type       = optional(string, null)
     aks_cli_system_node_pool = optional(object({
       name        = string
       node_count  = number

--- a/steps/terraform/set-input-variables-azure.yml
+++ b/steps/terraform/set-input-variables-azure.yml
@@ -38,6 +38,7 @@ steps:
                 --arg aks_network_policy "$NETWORK_POLICY" \
                 --arg aks_network_dataplane "$NETWORK_DATAPLANE" \
                 --arg k8s_machine_type "$K8S_MACHINE_TYPE" \
+                --arg k8s_os_disk_type "$K8S_OS_DISK_TYPE" \
                 --argjson aks_custom_headers "$AKS_CUSTOM_HEADERS" \
                 --argjson aks_cli_system_node_pool "$SYSTEM_NODE_POOL" \
                 --argjson aks_cli_user_node_pool "$USER_NODE_POOL" \
@@ -49,6 +50,7 @@ steps:
                   aks_network_policy: $aks_network_policy,
                   aks_network_dataplane: $aks_network_dataplane,
                   k8s_machine_type: $k8s_machine_type,
+                  k8s_os_disk_type: $k8s_os_disk_type,
                   aks_custom_headers: $aks_custom_headers,
                   aks_cli_system_node_pool: $aks_cli_system_node_pool,
                   aks_cli_user_node_pool: $aks_cli_user_node_pool


### PR DESCRIPTION
- Add variable to customize AKS os disk type for all node pools so we can test against different disk types
- Run test for Azure in terraform validation