### PR TITLE
Fixing the terraform input quotes

### DIFF
--- a/steps/terraform/run-command.yml
+++ b/steps/terraform/run-command.yml
@@ -34,7 +34,7 @@ steps:
         terraform_input_variables=$(echo $TERRAFORM_REGIONAL_CONFIG | jq -r --arg region "$region" '.[$region].TERRAFORM_INPUT_VARIABLES')
 
         set +e
-        terraform ${{ parameters.command }} --auto-approve ${{ parameters.arguments }} -var-file $terraform_input_file -var json_input=$terraform_input_variables
+        terraform ${{ parameters.command }} --auto-approve ${{ parameters.arguments }} -var-file $terraform_input_file -var json_input="$terraform_input_variables"
 
         if [[ $? -ne 0 ]]; then
           if [[ ${{ parameters.command }} == "apply" && "$CLOUD" == "azure" ]]; then


### PR DESCRIPTION
The json input needs to be properly quoted before enter into terraform. Without this quote, the space seperated the argument cannot be processed in terraform property.

