### PR TITLE
Update NAP node pool config

### DIFF
--- a/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.aws.yml
+++ b/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.aws.yml
@@ -15,9 +15,6 @@ spec:
         kind: EC2NodeClass
         name: default
       requirements:
-        - key: kubernetes.io/arch
-          operator: In
-          values: ["amd64"]
         - key: kubernetes.io/os
           operator: In
           values: ["linux"]

--- a/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml
@@ -22,10 +22,6 @@ spec:
           effect: NoExecute
           value: "true"
       requirements:
-        - key: kubernetes.io/arch
-          operator: In
-          values:
-            - amd64
         - key: kubernetes.io/os
           operator: In
           values:

--- a/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.aws.yml
+++ b/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.aws.yml
@@ -15,9 +15,6 @@ spec:
         kind: EC2NodeClass
         name: default
       requirements:
-        - key: kubernetes.io/arch
-          operator: In
-          values: ["amd64"]
         - key: kubernetes.io/os
           operator: In
           values: ["linux"]

--- a/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
@@ -22,10 +22,6 @@ spec:
           effect: NoExecute
           value: "true"
       requirements:
-        - key: kubernetes.io/arch
-          operator: In
-          values:
-            - amd64
         - key: kubernetes.io/os
           operator: In
           values:


### PR DESCRIPTION
This pull request includes changes to the Kubernetes node pool configuration files for performance evaluation scenarios. The most important changes involve the removal of architecture-specific requirements.

Changes to Kubernetes node pool configuration:

* [`scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.aws.yml`](diffhunk://#diff-4e361d0ecb1ef1fa3fb63c07685c8c3a72f19b446849a10c7772051cfbeabdc0L18-L20): Removed the requirement specifying the architecture key `kubernetes.io/arch` with value `amd64`.
* [`scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml`](diffhunk://#diff-b3a1db895732ad4944cb82e8ff930d3ac2aebbb71f38b10d7223f46b50757debL25-L28): Removed the requirement specifying the architecture key `kubernetes.io/arch` with value `amd64`.