### PR TITLE
Update Azure NAP test without Cilium

### DIFF
--- a/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml
@@ -9,18 +9,9 @@ spec:
     budgets:
       - nodes: "100%"
   template:
-    metadata:
-      labels:
-        # required for Karpenter to predict overhead from cilium DaemonSet
-        kubernetes.azure.com/ebpf-dataplane: cilium
     spec:
       nodeClassRef:
         name: default
-      startupTaints:
-        # https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
-        - key: node.cilium.io/agent-not-ready
-          effect: NoExecute
-          value: "true"
       requirements:
         - key: kubernetes.io/os
           operator: In

--- a/scenarios/perf-eval/nap-c2n200p200/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/nap-c2n200p200/terraform-inputs/azure.tfvars
@@ -31,10 +31,6 @@ aks_cli_config_list = [
         value = "overlay"
       },
       {
-        name  = "network-dataplane"
-        value = "cilium"
-      },
-      {
         name  = "node-init-taints"
         value = "CriticalAddonsOnly=true:NoSchedule"
       }

--- a/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
@@ -9,18 +9,9 @@ spec:
     budgets:
       - nodes: "100%"
   template:
-    metadata:
-      labels:
-        # required for Karpenter to predict overhead from cilium DaemonSet
-        kubernetes.azure.com/ebpf-dataplane: cilium
     spec:
       nodeClassRef:
         name: default
-      startupTaints:
-        # https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
-        - key: node.cilium.io/agent-not-ready
-          effect: NoExecute
-          value: "true"
       requirements:
         - key: kubernetes.io/os
           operator: In

--- a/scenarios/perf-eval/nap-c4n10p100/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/nap-c4n10p100/terraform-inputs/azure.tfvars
@@ -31,10 +31,6 @@ aks_cli_config_list = [
         value = "overlay"
       },
       {
-        name  = "network-dataplane"
-        value = "cilium"
-      },
-      {
         name  = "node-init-taints"
         value = "CriticalAddonsOnly=true:NoSchedule"
       }


### PR DESCRIPTION
This pull request includes changes to the configuration files for Karpenter node pools in the performance evaluation scenarios. The main changes involve removing metadata labels and startup taints related to the cilium DaemonSet.

Configuration updates for Karpenter node pools:

* [`scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml`](diffhunk://#diff-fcd8ffee3e58f9d34e944ac4517ff249f60dd89facf63693d256a0baaa7c04e9L12-L23): Removed metadata labels and startup taints for the cilium DaemonSet.
* [`scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml`](diffhunk://#diff-b3a1db895732ad4944cb82e8ff930d3ac2aebbb71f38b10d7223f46b50757debL12-L23): Removed metadata labels and startup taints for the cilium DaemonSet.