### PR TITLE
chore: run cilium nodesubnet runs more frequently

### DIFF
--- a/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cilium-cluster-churn-nodes-cilium-nodesubnet.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
-  - cron: "0 10,22 * * *"
-    displayName: "10:00 AM & PM Daily"
+  - cron: "0 2,10,18 * * *"
+    displayName: "2:00 AM, 10:00 AM & 6:00 PM Daily"
     branches:
       include:
         - main

--- a/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
+++ b/pipelines/perf-eval/CNI Benchmark/slo-servicediscovery-cilium-nodesubnet.yml
@@ -1,7 +1,7 @@
 trigger: none
 schedules:
-  - cron: "0 4,16 * * *"
-    displayName: "4:00 AM & PM Daily"
+  - cron: "0 4,12,20 * * *"
+    displayName: "4:00 AM, 12:00pm & 8:00PM Daily"
     branches:
       include:
         - main


### PR DESCRIPTION
Currently cilium nodesubnet recurring pipelines run twice a day. This PR changes that to thrice a day, equally spaced.