### PR TITLE
Update Karpenter node pool config

### DIFF
--- a/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.aws.yml
+++ b/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.aws.yml
@@ -21,15 +21,6 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values: ["on-demand"]
-        - key: karpenter.k8s.aws/instance-category
+        - key: node.kubernetes.io/instance-type
           operator: In
-          values: ["m"]
-        - key: karpenter.k8s.aws/instance-family
-          operator: In
-          values: ["m6i"]
-        - key: karpenter.k8s.aws/instance-generation
-          operator: Gt
-          values: ["5"]
-        - key: karpenter.k8s.aws/instance-cpu
-          operator: In
-          values: ["2"]
+          values: ["m6i.large"]

--- a/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml
@@ -21,15 +21,7 @@ spec:
           operator: In
           values:
             - on-demand
-        - key: karpenter.azure.com/sku-family
+        - key: karpenter.azure.com/sku-name
           operator: In
           values:
-            - D
-        - key: karpenter.azure.com/sku-cpu
-          operator: In
-          values:
-            - "2"
-        - key: karpenter.azure.com/sku-version
-          operator: In
-          values:
-            - "5"
+            - Standard_D2_v5

--- a/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.aws.yml
+++ b/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.aws.yml
@@ -21,12 +21,6 @@ spec:
         - key: karpenter.sh/capacity-type
           operator: In
           values: ["on-demand"]
-        - key: karpenter.k8s.aws/instance-category
+        - key: node.kubernetes.io/instance-type
           operator: In
-          values: ["m"]
-        - key: karpenter.k8s.aws/instance-generation
-          operator: Gt
-          values: ["2"]
-        - key: karpenter.k8s.aws/instance-cpu
-          operator: In
-          values: ["4"]
+          values: ["m5.xlarge"]

--- a/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
+++ b/scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml
@@ -21,11 +21,7 @@ spec:
           operator: In
           values:
             - on-demand
-        - key: karpenter.azure.com/sku-family
+        - key: karpenter.azure.com/sku-name
           operator: In
           values:
-            - D
-        - key: karpenter.azure.com/sku-cpu
-          operator: In
-          values:
-            - "4"
+            - Standard_D4_v5


### PR DESCRIPTION
This pull request includes changes to the Kubernetes node pool configurations for both AWS and Azure in the performance evaluation scenarios. The main focus is on updating the instance type and SKU naming conventions.

Changes to AWS configurations:

* [`scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.aws.yml`](diffhunk://#diff-dd68e8ab71662c232334ebe9d2807371acc45d46cb332045af75a80e76e2b60bL24-R26): Updated the key from `karpenter.k8s.aws/instance-category` to `node.kubernetes.io/instance-type` and changed the instance type values to `m6i.large`. Removed several other instance specifications.
* [`scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.aws.yml`](diffhunk://#diff-4e361d0ecb1ef1fa3fb63c07685c8c3a72f19b446849a10c7772051cfbeabdc0L24-R26): Updated the key from `karpenter.k8s.aws/instance-category` to `node.kubernetes.io/instance-type` and changed the instance type values to `m5.xlarge`. Removed several other instance specifications.

Changes to Azure configurations:

* [`scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml`](diffhunk://#diff-fcd8ffee3e58f9d34e944ac4517ff249f60dd89facf63693d256a0baaa7c04e9L24-R27): Updated the key from `karpenter.azure.com/sku-family` to `karpenter.azure.com/sku-name` and changed the SKU values to `Standard_D2_v5`. Removed several other SKU specifications.
* [`scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml`](diffhunk://#diff-b3a1db895732ad4944cb82e8ff930d3ac2aebbb71f38b10d7223f46b50757debL24-R27): Updated the key from `karpenter.azure.com/sku-family` to `karpenter.azure.com/sku-name` and changed the SKU values to `Standard_D4_v5`. Removed several other SKU specifications.This pull request includes updates to the Kubernetes configuration files for Karpenter node pools in two different performance evaluation scenarios. The changes ensure that the node pools are configured with specific SKU names instead of SKU families and other individual attributes.

Configuration updates:

* [`scenarios/perf-eval/nap-c2n200p200/kubernetes/karpenter_nodepool.azure.yml`](diffhunk://#diff-fcd8ffee3e58f9d34e944ac4517ff249f60dd89facf63693d256a0baaa7c04e9L24-R27): Replaced `karpenter.azure.com/sku-family` with `karpenter.azure.com/sku-name` and specified `Standard_D2_v5` as the SKU name. Removed the `sku-cpu` and `sku-version` keys.
* [`scenarios/perf-eval/nap-c4n10p100/kubernetes/karpenter_nodepool.azure.yml`](diffhunk://#diff-b3a1db895732ad4944cb82e8ff930d3ac2aebbb71f38b10d7223f46b50757debL24-R27): Replaced `karpenter.azure.com/sku-family` with `karpenter.azure.com/sku-name` and specified `Standard_D4_v5` as the SKU name. Removed the `sku-cpu` key.