### PR TITLE
enable azure policy add on for Karpenter

### DIFF
--- a/scenarios/perf-eval/nap-c2n200p200/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/nap-c2n200p200/terraform-inputs/azure.tfvars
@@ -35,7 +35,7 @@ aks_cli_config_list = [
         value = "CriticalAddonsOnly=true:NoSchedule"
       },
       {
-        name = "enable-addons"
+        name  = "enable-addons"
         value = "azure-policy"
       }
     ]

--- a/scenarios/perf-eval/nap-c2n200p200/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/nap-c2n200p200/terraform-inputs/azure.tfvars
@@ -33,6 +33,10 @@ aks_cli_config_list = [
       {
         name  = "node-init-taints"
         value = "CriticalAddonsOnly=true:NoSchedule"
+      },
+      {
+        name = "enable-addons"
+        value = "azure-policy"
       }
     ]
   }

--- a/scenarios/perf-eval/nap-c4n10p100/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/nap-c4n10p100/terraform-inputs/azure.tfvars
@@ -35,7 +35,7 @@ aks_cli_config_list = [
         value = "CriticalAddonsOnly=true:NoSchedule"
       },
       {
-        name = "enable-addons"
+        name  = "enable-addons"
         value = "azure-policy"
       }
     ]

--- a/scenarios/perf-eval/nap-c4n10p100/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/nap-c4n10p100/terraform-inputs/azure.tfvars
@@ -33,6 +33,10 @@ aks_cli_config_list = [
       {
         name  = "node-init-taints"
         value = "CriticalAddonsOnly=true:NoSchedule"
+      },
+      {
+        name = "enable-addons"
+        value = "azure-policy"
       }
     ]
   }


### PR DESCRIPTION
Create the cluster with the azure policy enabled to prevent it from being enabled later on. Enabling the cluster mid-test triggers a control plane restart that adds a lot of latency during the tests.