### PR TITLE
Reduce AWS test frequency for Autoscaler tests

### DIFF
--- a/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes10-pods100.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes10-pods100.yml
@@ -7,12 +7,24 @@ schedules:
         - main
     always: true
 
+  - cron: "0 13 * * 1,5"
+    displayName: "1:00 PM on Monday and Friday"
+    branches:
+      include:
+        - main
+    always: true
+
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: cas-c4n10p100
 
 stages:
   - stage: aws_eastus1
+    condition: |
+        or(
+          eq(variables['Build.CronSchedule.DisplayName'], '1:00 PM on Monday and Friday'),
+          eq(variables['Build.Reason'], 'Manual')
+        )
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
@@ -39,6 +51,11 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
   - stage: azure_eastus2
+    condition: |
+        or(
+          eq(variables['Build.CronSchedule.DisplayName'], '1:00 AM & PM Daily'),
+          eq(variables['Build.Reason'], 'Manual')
+        )
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml

--- a/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes10-pods100.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes10-pods100.yml
@@ -7,8 +7,8 @@ schedules:
         - main
     always: true
 
-  - cron: "0 13 * * 1,5"
-    displayName: "1:00 PM on Monday and Friday"
+  - cron: "0 13 * * 2,4,6"
+    displayName: "1:00 PM on Tuesday, Thursday, and Saturday"
     branches:
       include:
         - main
@@ -22,7 +22,7 @@ stages:
   - stage: aws_eastus1
     condition: |
         or(
-          eq(variables['Build.CronSchedule.DisplayName'], '1:00 PM on Monday and Friday'),
+          eq(variables['Build.CronSchedule.DisplayName'], '1:00 PM on Tuesday, Thursday, and Saturday'),
           eq(variables['Build.Reason'], 'Manual')
         )
     dependsOn: []

--- a/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes200-pods200.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes200-pods200.yml
@@ -7,12 +7,24 @@ schedules:
         - main
     always: true
 
+  - cron: "0 16 * * 1,5"
+    displayName: "4:00 PM on Monday and Friday"
+    branches:
+      include:
+        - main
+    always: true
+
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: cas-c2n200p200
 
 stages:
   - stage: azure_eastus2
+    condition: |
+        or(
+          eq(variables['Build.CronSchedule.DisplayName'], 'Every day at 4:00 PM'),
+          eq(variables['Build.Reason'], 'Manual')
+        )
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
@@ -39,6 +51,11 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
   - stage: aws_eastus2
+    condition: |
+      or(
+        eq(variables['Build.CronSchedule.DisplayName'], '4:00 PM on Monday and Friday'),
+        eq(variables['Build.Reason'], 'Manual')
+      )
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml

--- a/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes10-pods100.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes10-pods100.yml
@@ -7,12 +7,24 @@ schedules:
         - main
     always: true
 
+  - cron: "0 13 * * 2,4,6"
+    displayName: "1:00 PM on Tuesday, Thursday, and Saturday"
+    branches:
+      include:
+        - main
+    always: true
+
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: nap-c4n10p100
 
 stages:
   - stage: aws_eastus2
+    condition: |
+      or(
+        eq(variables['Build.CronSchedule.DisplayName'], '1:00 PM on Tuesday, Thursday, and Saturday'),
+        eq(variables['Build.Reason'], 'Manual')
+      )
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
@@ -40,6 +52,11 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
   - stage: azure_eastus2
+    condition: |
+        or(
+          eq(variables['Build.CronSchedule.DisplayName'], '1:00 AM & PM Daily'),
+          eq(variables['Build.Reason'], 'Manual')
+        )
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml

--- a/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes200-pods200.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes200-pods200.yml
@@ -7,8 +7,8 @@ schedules:
         - main
     always: true
 
-  - cron: "0 18 * * 2,4,6"
-    displayName: "6:00 PM on Tuesday, Thursday, and Saturday"
+  - cron: "0 18 * * 1,5"
+    displayName: "6:00 PM on Monday and Friday"
     branches:
       include:
         - main
@@ -20,6 +20,11 @@ variables:
 
 stages:
   - stage: aws_westus2
+    condition: |
+        or(
+          eq(variables['Build.CronSchedule.DisplayName'], '6:00 PM on Monday and Friday'),
+          eq(variables['Build.Reason'], 'Manual')
+        )
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
@@ -47,6 +52,11 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
   - stage: azure_westus2
+    condition: |
+        or(
+          eq(variables['Build.CronSchedule.DisplayName'], 'Every day at 6:00 PM'),
+          eq(variables['Build.Reason'], 'Manual')
+        )
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml

--- a/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes200-pods200.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-nodes200-pods200.yml
@@ -7,6 +7,13 @@ schedules:
         - main
     always: true
 
+  - cron: "0 18 * * 2,4,6"
+    displayName: "6:00 PM on Tuesday, Thursday, and Saturday"
+    branches:
+      include:
+        - main
+    always: true
+
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: nap-c2n200p200


### PR DESCRIPTION
This pull request includes changes to the scheduling and conditions for various performance evaluation pipelines in the `pipelines/perf-eval/Autoscale Benchmark` directory. The primary changes involve adding new cron schedules and updating the conditions for different stages within the YAML files.

Here are the most important changes:

### Scheduling changes:
* Added a new cron schedule for running the pipeline at 1:00 PM on Monday and Friday in `cluster-autoscaler-benchmark-nodes10-pods100.yml`.
* Added a new cron schedule for running the pipeline at 4:00 PM on Monday and Friday in `cluster-autoscaler-benchmark-nodes200-pods200.yml`.
* Added a new cron schedule for running the pipeline at 1:00 PM on Tuesday, Thursday, and Saturday in `node-auto-provisioning-benchmark-nodes10-pods100.yml`.
* Added a new cron schedule for running the pipeline at 6:00 PM on Tuesday, Thursday, and Saturday in `node-auto-provisioning-benchmark-nodes200-pods200.yml`.

### Condition updates:
* Updated the condition for the `aws_eastus1` stage to include the new cron schedule in `cluster-autoscaler-benchmark-nodes10-pods100.yml`.
* Updated the condition for the `azure_eastus2` stage to include the new cron schedule in `cluster-autoscaler-benchmark-nodes200-pods200.yml`.
* Updated the condition for the `aws_eastus2` stage to include the new cron schedule in `node-auto-provisioning-benchmark-nodes10-pods100.yml`.