### PR TITLE
bump CNI pipelines k8s ver to 1.32

### DIFF
--- a/scenarios/perf-eval/cilium-cluster-churn-n1000p50k/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cilium-cluster-churn-n1000p50k/terraform-inputs/aws.tfvars
@@ -96,5 +96,5 @@ eks_config_list = [{
   ]
 
   eks_addons         = []
-  kubernetes_version = "1.30"
+  kubernetes_version = "1.32"
 }]

--- a/scenarios/perf-eval/cilium-cluster-churn-n1000p50k/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cilium-cluster-churn-n1000p50k/terraform-inputs/azure.tfvars
@@ -75,6 +75,6 @@ aks_config_list = [
         node_labels          = { "slo" = "true" }
       }
     ]
-    kubernetes_version = "1.30"
+    kubernetes_version = "1.32"
   }
 ]

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
@@ -203,5 +203,5 @@ eks_config_list = [{
     { name = "kube-proxy" },
     { name = "coredns" }
   ]
-  kubernetes_version = "1.30"
+  kubernetes_version = "1.32"
 }]

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/azure.tfvars
@@ -80,6 +80,6 @@ aks_config_list = [
         node_labels          = { "slo" = "true" }
       }
     ]
-    kubernetes_version = "1.30"
+    kubernetes_version = "1.32"
   }
 ]


### PR DESCRIPTION
Pipelines need to be bumped to K8S v1.32 to get accurate data about up-to-date cluster behavior.