### PR TITLE
Remove type=eval from python scripts

### DIFF
--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -4,7 +4,7 @@ import argparse
 import math
 
 from datetime import datetime, timezone
-from utils import parse_xml_to_json, run_cl2_command, get_measurement
+from utils import parse_xml_to_json, run_cl2_command, get_measurement, str2bool
 from kubernetes_client import KubernetesClient, client as k8s_client
 
 DAEMONSETS_PER_NODE_MAP = {
@@ -211,11 +211,11 @@ def main():
     parser_override.add_argument("operation_timeout", type=str, default="2m", help="Operation timeout")
     parser_override.add_argument("load_type", type=str, choices=["memory", "cpu"],
                                  default="memory", help="Type of load to generate")
-    parser_override.add_argument("scale_enabled", type=eval, choices=[True, False], default=False,
+    parser_override.add_argument("scale_enabled", type=str2bool, choices=[True, False], default=False,
                                  help="Whether scale operation is enabled. Must be either True or False")
     parser_override.add_argument("pod_startup_latency_threshold", type=str, default="15s", help="Pod startup latency threshold")
     parser_override.add_argument("provider", type=str, help="Cloud provider name")
-    parser_override.add_argument("scrape_kubelets", type=eval, choices=[True, False], default=False,
+    parser_override.add_argument("scrape_kubelets", type=str2bool, choices=[True, False], default=False,
                                 help="Whether to scrape kubelets")
     parser_override.add_argument("cl2_override_file", type=str, help="Path to the overrides of CL2 config file")
 
@@ -226,7 +226,7 @@ def main():
     parser_execute.add_argument("cl2_report_dir", type=str, help="Path to the CL2 report directory")
     parser_execute.add_argument("kubeconfig", type=str, help="Path to the kubeconfig file")
     parser_execute.add_argument("provider", type=str, help="Cloud provider name")
-    parser_execute.add_argument("scrape_kubelets", type=eval, choices=[True, False], default=False,
+    parser_execute.add_argument("scrape_kubelets", type=str2bool, choices=[True, False], default=False,
                                 help="Whether to scrape kubelets")
 
     # Sub-command for collect_clusterloader2
@@ -241,7 +241,7 @@ def main():
     parser_collect.add_argument("run_id", type=str, help="Run ID")
     parser_collect.add_argument("run_url", type=str, help="Run URL")
     parser_collect.add_argument("result_file", type=str, help="Path to the result file")
-    parser_collect.add_argument("scrape_kubelets", type=eval, choices=[True, False], default=False,
+    parser_collect.add_argument("scrape_kubelets", type=str2bool, choices=[True, False], default=False,
                                 help="Whether to scrape kubelets")
 
     args = parser.parse_args()

--- a/modules/python/clusterloader2/slo/slo.py
+++ b/modules/python/clusterloader2/slo/slo.py
@@ -4,7 +4,7 @@ import argparse
 import time
 
 from datetime import datetime, timezone
-from utils import parse_xml_to_json, run_cl2_command, get_measurement
+from utils import parse_xml_to_json, run_cl2_command, get_measurement, str2bool
 from kubernetes_client import KubernetesClient
 
 DEFAULT_PODS_PER_NODE = 40
@@ -236,19 +236,19 @@ def main():
     parser_configure.add_argument("repeats", type=int, help="Number of times to repeat the deployment churn")
     parser_configure.add_argument("operation_timeout", type=str, help="Timeout before failing the scale up test")
     parser_configure.add_argument("provider", type=str, help="Cloud provider name")
-    parser_configure.add_argument("cilium_enabled", type=eval, choices=[True, False], default=False,
+    parser_configure.add_argument("cilium_enabled", type=str2bool, choices=[True, False], default=False,
                                   help="Whether cilium is enabled. Must be either True or False")
-    parser_configure.add_argument("scrape_containerd", type=eval, choices=[True, False], default=False,
+    parser_configure.add_argument("scrape_containerd", type=str2bool, choices=[True, False], default=False,
                                   help="Whether to scrape containerd metrics. Must be either True or False")
-    parser_configure.add_argument("service_test", type=eval, choices=[True, False], default=False,
+    parser_configure.add_argument("service_test", type=str2bool, choices=[True, False], default=False,
                                   help="Whether service test is running. Must be either True or False")
-    parser_configure.add_argument("cnp_test", type=eval, choices=[True, False], nargs='?', default=False,
+    parser_configure.add_argument("cnp_test", type=str2bool, choices=[True, False], nargs='?', default=False,
                                   help="Whether cnp test is running. Must be either True or False")
-    parser_configure.add_argument("ccnp_test", type=eval, choices=[True, False], nargs='?', default=False,
+    parser_configure.add_argument("ccnp_test", type=str2bool, choices=[True, False], nargs='?', default=False,
                                   help="Whether ccnp test is running. Must be either True or False")
     parser_configure.add_argument("num_cnps", type=int, nargs='?', default=0, help="Number of cnps")
     parser_configure.add_argument("num_ccnps", type=int, nargs='?', default=0, help="Number of ccnps")
-    parser_configure.add_argument("dualstack", type=eval, choices=[True, False], nargs='?', default=False,
+    parser_configure.add_argument("dualstack", type=str2bool, choices=[True, False], nargs='?', default=False,
                                   help="Whether cluster is dualstack. Must be either True or False")
     parser_configure.add_argument("cl2_override_file", type=str, help="Path to the overrides of CL2 config file")
 
@@ -265,7 +265,7 @@ def main():
     parser_execute.add_argument("cl2_config_file", type=str, help="Path to the CL2 config file")
     parser_execute.add_argument("kubeconfig", type=str, help="Path to the kubeconfig file")
     parser_execute.add_argument("provider", type=str, help="Cloud provider name")
-    parser_execute.add_argument("scrape_containerd", type=eval, choices=[True, False], default=False,
+    parser_execute.add_argument("scrape_containerd", type=str2bool, choices=[True, False], default=False,
                                 help="Whether to scrape containerd metrics. Must be either True or False")
 
     # Sub-command for collect_clusterloader2
@@ -278,11 +278,11 @@ def main():
     parser_collect.add_argument("cloud_info", type=str, help="Cloud information")
     parser_collect.add_argument("run_id", type=str, help="Run ID")
     parser_collect.add_argument("run_url", type=str, help="Run URL")
-    parser_collect.add_argument("service_test", type=eval, choices=[True, False], default=False,
+    parser_collect.add_argument("service_test", type=str2bool, choices=[True, False], default=False,
                                   help="Whether service test is running. Must be either True or False")
-    parser_collect.add_argument("cnp_test", type=eval, choices=[True, False], nargs='?', default=False,
+    parser_collect.add_argument("cnp_test", type=str2bool, choices=[True, False], nargs='?', default=False,
                                   help="Whether cnp test is running. Must be either True or False")
-    parser_collect.add_argument("ccnp_test", type=eval, choices=[True, False], nargs='?', default=False,
+    parser_collect.add_argument("ccnp_test", type=str2bool, choices=[True, False], nargs='?', default=False,
                                   help="Whether ccnp test is running. Must be either True or False")
     parser_collect.add_argument("result_file", type=str, help="Path to the result file")
     parser_collect.add_argument("test_type", type=str, nargs='?', default="default-config",

--- a/modules/python/clusterloader2/utils.py
+++ b/modules/python/clusterloader2/utils.py
@@ -1,6 +1,7 @@
 from xml.dom import minidom
 import json
 import os
+import argparse
 import docker
 
 from docker_client import DockerClient
@@ -124,3 +125,12 @@ def parse_xml_to_json(file_path, indent = 0):
     # Convert the result dictionary to JSON
     json_result = json.dumps(result, indent = indent)
     return json_result
+
+def str2bool(val):
+    if isinstance(val, bool):
+        return val
+    if val.lower() in ("true", "yes", "1"):
+        return True
+    if val.lower() in ("false", "no", "0"):
+        return False
+    raise argparse.ArgumentTypeError("Boolean value expected.")


### PR DESCRIPTION
The use of type=eval should be avoided per its known issues. This pull request removes the type=eval argument from the python scripts and replaces it with a custom function, str2bool, to ensure the correct type conversion.