### PR TITLE
Add ena_express support to EKS node groups

### DIFF
--- a/modules/terraform/aws/aws_input_schema.json
+++ b/modules/terraform/aws/aws_input_schema.json
@@ -15,6 +15,9 @@
     },
     "user_data_path": {
       "type": "string"
+    },
+    "ena_express" : {
+      "type": "boolean"
     }
   },
   "required": [

--- a/modules/terraform/aws/eks/README.md
+++ b/modules/terraform/aws/eks/README.md
@@ -10,7 +10,7 @@ To use the EKS module, follow these steps:
 
   Include the configuration in your input tfvars file:
 
-  ```hcl
+```hcl
   eks_config_list = [{
   eks_name                = "sumanth-test"
   vpc_name                = "client-vpc"
@@ -24,6 +24,7 @@ To use the EKS module, follow these steps:
       max_size       = 3
       desired_size   = 2
       capacity_type = "ON_DEMAND" # Optional input
+      ena_express    = true # Optional (default: false)
       labels         = { terraform = "true", k8s = "true", role = "perf-eval" } # Optional input
       taints         = [{
         key = "dedicated"
@@ -33,17 +34,17 @@ To use the EKS module, follow these steps:
     }
   ]
   }]
-  ```
-	
-   - This configuration creates EKS cluster using specified VPC.
-	 - You need to have at least 2 subnets in different zones with public ip enabled for each subnet to be able to successfully create the cluster.
-	 - We need few IAM permission in order to create Node Group. Please refer [here](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html)
-	 - Recommended to have these polices added to your tfvars. ["AmazonEKSClusterPolicy", "AmazonEKSVPCResourceController", "AmazonEKSWorkerNodePolicy", "AmazonEC2ContainerRegistryReadOnly", "AmazonEKS_CNI_Policy"] 
-   - It also creates an IAM role and attachs the polices listed in the tfvars config.
-   - It creates one node group for the cluster with our desired configuration.
-   - policy_arns is the list of suffix strings of policy we want to attach to a IAM role.
-   - For Example: Policy ARN : arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
-     In the given example policy arn is "service-role/AmazonEBSCSIDriverPolicy"
+```
+
+- This configuration creates EKS cluster using specified VPC.
+  - You need to have at least 2 subnets in different zones with public ip enabled for each subnet to be able to successfully create the cluster.
+  - We need few IAM permission in order to create Node Group. Please refer [here](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html)
+  - Recommended to have these polices added to your tfvars. ["AmazonEKSClusterPolicy", "AmazonEKSVPCResourceController", "AmazonEKSWorkerNodePolicy", "AmazonEC2ContainerRegistryReadOnly", "AmazonEKS_CNI_Policy"]
+- It also creates an IAM role and attachs the polices listed in the tfvars config.
+- It creates one node group for the cluster with our desired configuration.
+- policy_arns is the list of suffix strings of policy we want to attach to a IAM role.
+- For Example: Policy ARN : arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+  In the given example policy arn is "service-role/AmazonEBSCSIDriverPolicy"
 
 2. **Create EKS Addon:**
 
@@ -66,23 +67,24 @@ To use the EKS module, follow these steps:
    ]
    ```
 
-  - **Description:** A list of maps of EKS addons to deploy.
-   - **Type:** Map of objects
-    - `name`: Name of the addon
-    - `version`: Version of the addon (optional)
-    - `service_account`: Service account associated with the addon (optional)
-    - `policy_arns`: Policy ARNs required for the addon (optional)
-    - `before_compute`: Create addon before creating the managed node groups (default = false)
+- **Description:** A list of maps of EKS addons to deploy.
+- **Type:** Map of objects
+  - `name`: Name of the addon
+  - `version`: Version of the addon (optional)
+  - `service_account`: Service account associated with the addon (optional)
+  - `policy_arns`: Policy ARNs required for the addon (optional)
+  - `before_compute`: Create addon before creating the managed node groups (default = false)
+- For EKS addon's we have to create OIDC provider for the cluster and attach policy arns.[Refer here](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html)
+- This configuration creates two addons related to storage.
+- service_account and policy_attachment_names are optional in general but some addons are required to have IAM permisson values. [Refer here](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html)
+- We can also provide the version of an addon we are created which is an optional input here.
+- For VPC-CNI, a default configuration is used (see [main.tf](./main.tf)). Use vpc_cni_warm_prefix_target to set WARM_PREFIX_TARGET (default: 1)
 
-   - For EKS addon's we have to create OIDC provider for the cluster and attach policy arns.[Refer here](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html)
-   - This configuration creates two addons related to storage.
-   - service_account and policy_attachment_names are optional in general but some addons are required to have IAM permisson values. [Refer here](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html)
-   - We can also provide the version of an addon we are created which is an optional input here.
-   - For VPC-CNI, a default configuration is used (see [main.tf](./main.tf)). Use vpc_cni_warm_prefix_target to set WARM_PREFIX_TARGET (default: 1)
-   
 3. **Config override**
 
 The optional field `k8s_machine_type` overrides, when set, the `instance_types` value of all EKS nodes defined in `eks_managed_node_groups`. This is useful to define scenarios with different instance types using the same base config. Valid values can be found in the [AWS EC2 instance types documentation](https://aws.amazon.com/ec2/instance-types/).
+
+The optional field `ena_express` overrides the `ena_express` value of all EKS nodes defined in `eks_managed_node_groups`. See more about ENA (Enhanced Networking Experience) express in [AWS ENA Express documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ena-express.html).
 
 ## Terraform Provider References
 

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -186,9 +186,9 @@ resource "aws_launch_template" "launch_template" {
 
   network_interfaces {
     ena_srd_specification {
-      ena_srd_enabled = each.value.ena_express
+      ena_srd_enabled = var.ena_express != null ? var.ena_express : each.value.ena_express
       ena_srd_udp_specification {
-        ena_srd_udp_enabled = each.value.ena_express
+        ena_srd_udp_enabled = var.ena_express != null ? var.ena_express : each.value.ena_express
       }
     }
   }

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -184,6 +184,15 @@ resource "aws_launch_template" "launch_template" {
 
   user_data = var.user_data_path != "" ? filebase64("${var.user_data_path}/${local.role}-userdata.sh") : null
 
+  network_interfaces {
+    ena_srd_specification {
+      ena_srd_enabled = each.value.ena_express
+      ena_srd_udp_specification {
+        ena_srd_udp_enabled = each.value.ena_express
+      }
+    }
+  }
+
   tags = var.tags
 }
 

--- a/modules/terraform/aws/eks/variables.tf
+++ b/modules/terraform/aws/eks/variables.tf
@@ -26,6 +26,12 @@ variable "k8s_machine_type" {
   default     = null
 }
 
+variable "ena_express" {
+  description = "Whether to enable ENA Express. This replaces the value under eks_managed_node_groups"
+  type        = bool
+  default     = null
+}
+
 variable "eks_config" {
   type = object({
     role                      = string

--- a/modules/terraform/aws/eks/variables.tf
+++ b/modules/terraform/aws/eks/variables.tf
@@ -44,6 +44,7 @@ variable "eks_config" {
       capacity_type  = optional(string, "ON_DEMAND")
       labels         = optional(map(string), {})
       subnet_names   = optional(list(string), null)
+      ena_express    = optional(bool, false)
       taints = optional(list(object({
         key    = string
         value  = string

--- a/modules/terraform/aws/main.tf
+++ b/modules/terraform/aws/main.tf
@@ -4,6 +4,7 @@ locals {
   user_data_path   = lookup(var.json_input, "user_data_path", "")
   creation_time    = var.json_input["creation_time"]
   k8s_machine_type = lookup(var.json_input, "k8s_machine_type", null)
+  ena_express      = lookup(var.json_input, "ena_express", null)
 
   non_computed_tags = {
     # Note: Define only non computed values (i.e. values that do not change for each resource). This is required due to a limitation at "aws" provider default_tags.
@@ -56,6 +57,7 @@ module "eks" {
   eks_config       = each.value
   tags             = local.tags
   k8s_machine_type = local.k8s_machine_type
+  ena_express      = local.ena_express
   user_data_path   = local.user_data_path
   depends_on       = [module.virtual_network]
 }

--- a/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
@@ -55,14 +55,21 @@ variables {
     eks_name    = "eks_name"
     vpc_name    = "nap-vpc"
     policy_arns = ["AmazonEKS_CNI_Policy"]
-    eks_managed_node_groups = [
-      {
+    eks_managed_node_groups = [{
         name           = "my_scenario-ng"
         ami_type       = "AL2_x86_64"
         instance_types = ["m4.large"]
         min_size       = 5
         max_size       = 5
         desired_size   = 5
+    },{
+        name           = "my_scenario-ng-2"
+        ami_type       = "AL2_x86_64"
+        instance_types = ["m4.large"]
+        min_size       = 5
+        max_size       = 5
+        desired_size   = 5
+        ena_express    = true
     }]
     eks_addons = []
   }]
@@ -92,6 +99,30 @@ run "valid_launch_template_name" {
   assert {
     condition     = strcontains(module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng"].name, var.json_input.run_id)
     error_message = "Error. Launch tempalte name must be unique (expected to contain run id: ${var.json_input.run_id})"
+  }
+
+  expect_failures = [check.deletion_due_time]
+}
+
+run "valid_launch_template_ena_express" {
+
+  command = plan
+
+  # ena express disabled
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng"].network_interfaces[0].ena_srd_specification[0].ena_srd_enabled == false
+    error_message = "Error. Expected ena_srd_enabled false in the launch template ena srd specification"
+  }
+
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng"].network_interfaces[0].ena_srd_specification[0].ena_srd_udp_specification[0].ena_srd_udp_enabled == false
+    error_message = "Error. Expected ena_srd_udp_enabled false in the launch template ena srd specification"
+  }
+
+  # ena express enabled
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng-2"].network_interfaces[0].ena_srd_specification[0].ena_srd_enabled == true
+    error_message = "Error. Expected ena_srd_enabled true in the launch template ena srd specification"
   }
 
   expect_failures = [check.deletion_due_time]

--- a/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
@@ -125,6 +125,11 @@ run "valid_launch_template_ena_express" {
     error_message = "Error. Expected ena_srd_enabled true in the launch template ena srd specification"
   }
 
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng-2"].network_interfaces[0].ena_srd_specification[0].ena_srd_udp_specification[0].ena_srd_udp_enabled == true
+    error_message = "Error. Expected ena_srd_udp_enabled true in the launch template ena srd specification"
+  }
+
   expect_failures = [check.deletion_due_time]
 }
 
@@ -141,7 +146,7 @@ run "valid_launch_template_ena_express_override" {
     }
   }
 
-  # ena express disabled
+  # ena express enabled
   assert {
     condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng"].network_interfaces[0].ena_srd_specification[0].ena_srd_enabled == true
     error_message = "Error. Expected ena_srd_enabled true in the launch template ena srd specification"
@@ -152,10 +157,14 @@ run "valid_launch_template_ena_express_override" {
     error_message = "Error. Expected ena_srd_udp_enabled true in the launch template ena srd specification"
   }
 
-  # ena express enabled
   assert {
     condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng-2"].network_interfaces[0].ena_srd_specification[0].ena_srd_enabled == true
     error_message = "Error. Expected ena_srd_enabled true in the launch template ena srd specification"
+  }
+
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng-2"].network_interfaces[0].ena_srd_specification[0].ena_srd_udp_specification[0].ena_srd_udp_enabled == true
+    error_message = "Error. Expected ena_srd_udp_enabled true in the launch template ena srd specification"
   }
 
   expect_failures = [check.deletion_due_time]

--- a/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
@@ -127,3 +127,36 @@ run "valid_launch_template_ena_express" {
 
   expect_failures = [check.deletion_due_time]
 }
+
+run "valid_launch_template_ena_express_override" {
+
+  command = plan
+
+  variables {
+    json_input = {
+      "run_id" : "123456789",
+      "region" : "us-east-1",
+      "creation_time" : "2024-11-12T16:39:54Z"
+      "ena_express" : true
+    }
+  }
+
+  # ena express disabled
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng"].network_interfaces[0].ena_srd_specification[0].ena_srd_enabled == true
+    error_message = "Error. Expected ena_srd_enabled true in the launch template ena srd specification"
+  }
+
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng"].network_interfaces[0].ena_srd_specification[0].ena_srd_udp_specification[0].ena_srd_udp_enabled == true
+    error_message = "Error. Expected ena_srd_udp_enabled true in the launch template ena srd specification"
+  }
+
+  # ena express enabled
+  assert {
+    condition     = module.eks["eks_name"].eks_node_groups_launch_template["my_scenario-ng-2"].network_interfaces[0].ena_srd_specification[0].ena_srd_enabled == true
+    error_message = "Error. Expected ena_srd_enabled true in the launch template ena srd specification"
+  }
+
+  expect_failures = [check.deletion_due_time]
+}

--- a/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
@@ -56,20 +56,20 @@ variables {
     vpc_name    = "nap-vpc"
     policy_arns = ["AmazonEKS_CNI_Policy"]
     eks_managed_node_groups = [{
-        name           = "my_scenario-ng"
-        ami_type       = "AL2_x86_64"
-        instance_types = ["m4.large"]
-        min_size       = 5
-        max_size       = 5
-        desired_size   = 5
-    },{
-        name           = "my_scenario-ng-2"
-        ami_type       = "AL2_x86_64"
-        instance_types = ["m4.large"]
-        min_size       = 5
-        max_size       = 5
-        desired_size   = 5
-        ena_express    = true
+      name           = "my_scenario-ng"
+      ami_type       = "AL2_x86_64"
+      instance_types = ["m4.large"]
+      min_size       = 5
+      max_size       = 5
+      desired_size   = 5
+      }, {
+      name           = "my_scenario-ng-2"
+      ami_type       = "AL2_x86_64"
+      instance_types = ["m4.large"]
+      min_size       = 5
+      max_size       = 5
+      desired_size   = 5
+      ena_express    = true
     }]
     eks_addons = []
   }]

--- a/modules/terraform/aws/variables.tf
+++ b/modules/terraform/aws/variables.tf
@@ -6,6 +6,7 @@ variable "json_input" {
     creation_time    = string
     user_data_path   = optional(string, "")
     k8s_machine_type = optional(string, null)
+    ena_express      = optional(bool, null)
   })
 
   validation {

--- a/modules/terraform/aws/variables.tf
+++ b/modules/terraform/aws/variables.tf
@@ -118,6 +118,7 @@ variable "eks_config_list" {
       capacity_type  = optional(string, "ON_DEMAND")
       labels         = optional(map(string), {})
       subnet_names   = optional(list(string), null)
+      ena_express    = optional(bool, false)
       taints = optional(list(object({
         key    = string
         value  = string

--- a/steps/terraform/set-input-variables-aws.yml
+++ b/steps/terraform/set-input-variables-aws.yml
@@ -25,12 +25,14 @@ steps:
                 --arg region $REGION \
                 --arg creation_time $CREATION_TIME \
                 --arg k8s_machine_type "$K8S_MACHINE_TYPE" \
+                --arg ena_express "$ENA_EXPRESS" \
                 --arg user_data_path "$TERRAFORM_USER_DATA_PATH" \
                 '{
                 run_id: $run_id,
                 region: $region,
                 creation_time: $creation_time,
                 k8s_machine_type: $k8s_machine_type,
+                ena_express: $ena_express,
                 user_data_path: $user_data_path,
                 }' | jq 'with_entries(select(.value != null and .value != ""))')
         fi


### PR DESCRIPTION
This pull request introduces support for enabling ENA Express in the AWS EKS Terraform module. The changes span multiple files and include updates to variables, configurations, and tests to accommodate this new feature.

### Support for ENA Express:

* Added `ena_express` variable to the `aws_input_schema.json` to define the type as boolean.
* Updated `eks_config` and `eks_config_list` variables to include `ena_express` as an optional boolean. [[1]](diffhunk://#diff-8abbc84758137371997b88238369c9fd9f08384fc96dc0932a3841a66cdf83abR53) [[2]](diffhunk://#diff-9bd8d786978d8f7797b6b7bb3cf1d957ceab3be62c9fb17ec3ad6a3ee53f22caR122)
* Modified `main.tf` to include `ena_express` in the local variables and pass it to the EKS module. [[1]](diffhunk://#diff-4fa7e1512b9b19b6cf0ec7166bff84df309a63560e72e26b07a28e5f3fc0a086R7) [[2]](diffhunk://#diff-4fa7e1512b9b19b6cf0ec7166bff84df309a63560e72e26b07a28e5f3fc0a086R60)
* Added `ena_express` variable to the `variables.tf` file and updated `json_input` validation. [[1]](diffhunk://#diff-8abbc84758137371997b88238369c9fd9f08384fc96dc0932a3841a66cdf83abR29-R34) [[2]](diffhunk://#diff-9bd8d786978d8f7797b6b7bb3cf1d957ceab3be62c9fb17ec3ad6a3ee53f22caR9)
* Updated `aws_launch_template` to configure `ena_srd_specification` and `ena_srd_udp_specification` based on `ena_express`.

### Testing Enhancements:

* Enhanced test configurations in `test_eks_node_groups.tftest.hcl` to validate the behavior of `ena_express` in different scenarios. [[1]](diffhunk://#diff-d510eb2a3a55b7e7d3c553c9fca75fc15dd64d3e9be6c8497c06db64aefca94dL58-R72) [[2]](diffhunk://#diff-d510eb2a3a55b7e7d3c553c9fca75fc15dd64d3e9be6c8497c06db64aefca94dR106-R162)

### CI/CD Integration:

* Updated `set-input-variables-aws.yml` to pass `ena_express` as an argument in the Terraform input variables.This pull request introduces support for enabling ENA Express in AWS EKS node groups. The key changes include updates to the Terraform configuration and the addition of new test cases.

### Terraform Configuration Updates:

* [`modules/terraform/aws/eks/main.tf`](diffhunk://#diff-fd5dd7320a4e52fded4d41f24c016f50020f4b1ce1578d83fec5442c437e09ebR187-R195): Added `network_interfaces` block with `ena_srd_specification` to support ENA Express.
* [`modules/terraform/aws/eks/variables.tf`](diffhunk://#diff-8abbc84758137371997b88238369c9fd9f08384fc96dc0932a3841a66cdf83abR47): Added `ena_express` as an optional variable in `eks_config`.
* [`modules/terraform/aws/variables.tf`](diffhunk://#diff-9bd8d786978d8f7797b6b7bb3cf1d957ceab3be62c9fb17ec3ad6a3ee53f22caR121): Added `ena_express` as an optional variable in `eks_config_list`.

### Test Case Updates:

* [`modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl`](diffhunk://#diff-d510eb2a3a55b7e7d3c553c9fca75fc15dd64d3e9be6c8497c06db64aefca94dL58-R72): Updated `eks_managed_node_groups` to include a new node group with `ena_express` enabled and added a new test run `valid_launch_template_ena_express` to validate the ENA Express settings. [[1]](diffhunk://#diff-d510eb2a3a55b7e7d3c553c9fca75fc15dd64d3e9be6c8497c06db64aefca94dL58-R72) [[2]](diffhunk://#diff-d510eb2a3a55b7e7d3c553c9fca75fc15dd64d3e9be6c8497c06db64aefca94dR106-R129)