### PR TITLE
Update AKS CLI module to use fixed version

### DIFF
--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -79,6 +79,8 @@ resource "terraform_data" "enable_aks_cli_preview_extension" {
       "add",
       "-n",
       "aks-preview",
+      "--version",
+      "14.0.0b2",
     ])
   }
 

--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -72,6 +72,7 @@ resource "azurerm_role_assignment" "network_contributor" {
 resource "terraform_data" "enable_aks_cli_preview_extension" {
   count = var.aks_cli_config.use_aks_preview_cli_extension == true ? 1 : 0
 
+  # Todo - Update aks-preview extension for newer features
   provisioner "local-exec" {
     command = join(" ", [
       "az",


### PR DESCRIPTION
This pull request updates the Azure AKS CLI preview extension configuration in the Terraform module to specify a version for the extension.

* [`modules/terraform/azure/aks-cli/main.tf`](diffhunk://#diff-1c09e32cd63aa3f4a6cfae577b3db448daedf498df32bd8834fd4344f6b86ab4R82-R83): Added the `--version` flag with a value of `14.0.0b2` to ensure a specific version of the `aks-preview` extension is used.