### PR TITLE
Skip terraform collect step if the resources are not provisioned

### DIFF
--- a/steps/cleanup-resources.yml
+++ b/steps/cleanup-resources.yml
@@ -32,8 +32,9 @@ steps:
   displayName: "Destroy Resource Group"
   condition: and(${{ eq(parameters.cloud, 'azure') }}, ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true'))
 
-- ${{ if and(ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true'), eq(variables['Build.SourceBranchName'], 'main')) }}:
+- ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
   - template: /steps/collect-terraform-operation-metadata.yml
     parameters:
       cloud: ${{ parameters.cloud }}
       credential_type: ${{ parameters.credential_type }}
+      condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')

--- a/steps/cleanup-resources.yml
+++ b/steps/cleanup-resources.yml
@@ -37,4 +37,4 @@ steps:
     parameters:
       cloud: ${{ parameters.cloud }}
       credential_type: ${{ parameters.credential_type }}
-      condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
+      condition: ${{ ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true') }}

--- a/steps/collect-terraform-operation-metadata.yml
+++ b/steps/collect-terraform-operation-metadata.yml
@@ -3,25 +3,29 @@ parameters:
   type: string
 - name: credential_type
   type: string
+- name: condition
+  type: boolean
+  default: true
 steps:
-- script: |
-    set -eo pipefail
+- ${{ if eq(parameters.condition, true) }}:
+  - script: |
+      set -eo pipefail
 
-    export RUN_ID=$RUN_ID
-    PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE \
-    $TERRAFORM_WORKING_DIRECTORY "$TEST_RESULTS_DIR/terraform_operation_metadata.json" "$SCENARIO_TYPE" "$SCENARIO_NAME"
-    echo "##vso[task.setvariable variable=TERRAFORM_OPERATION_METADATA_FILE]$TEST_RESULTS_DIR/terraform_operation_metadata.json"
-  displayName: "Collect Terraform Operation Metadata"
-  workingDirectory: modules/python/terraform
-  env:
-    PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/terraform/extract_terraform_operation_metadata.py
+      export RUN_ID=$RUN_ID
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE \
+      $TERRAFORM_WORKING_DIRECTORY "$TEST_RESULTS_DIR/terraform_operation_metadata.json" "$SCENARIO_TYPE" "$SCENARIO_NAME"
+      echo "##vso[task.setvariable variable=TERRAFORM_OPERATION_METADATA_FILE]$TEST_RESULTS_DIR/terraform_operation_metadata.json"
+    displayName: "Collect Terraform Operation Metadata"
+    workingDirectory: modules/python/terraform
+    env:
+      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/terraform/extract_terraform_operation_metadata.py
 
-- template: /steps/cloud/azure/upload-storage-account.yml
-  parameters:
-    source_file_name: $(TERRAFORM_OPERATION_METADATA_FILE)
-    destination_file_name: $(RUN_ID).json
-    subfolder: terraform-metadata/main
-    container_name: system
-    credential_type: ${{ parameters.credential_type }}
-    cloud: ${{ parameters.cloud }}
-    upload_type: "Terraform Operation Metadata"
+  - template: /steps/cloud/azure/upload-storage-account.yml
+    parameters:
+      source_file_name: $(TERRAFORM_OPERATION_METADATA_FILE)
+      destination_file_name: $(RUN_ID).json
+      subfolder: terraform-metadata/main
+      container_name: system
+      credential_type: ${{ parameters.credential_type }}
+      cloud: ${{ parameters.cloud }}
+      upload_type: "Terraform Operation Metadata"


### PR DESCRIPTION
This pull request refactors the resource cleanup logic in Azure pipelines by improving the handling of conditions for resource management. The changes simplify and centralize the condition checks to ensure better maintainability and readability.

### Improvements to condition handling:

* **`steps/cleanup-resources.yml`:** Refactored the condition for including the `collect-terraform-operation-metadata.yml` template to remove redundancy. The `condition` parameter is now passed explicitly to the template, ensuring that the `SKIP_RESOURCE_MANAGEMENT` variable is consistently evaluated.

* **`steps/collect-terraform-operation-metadata.yml`:** Added a new `condition` parameter (defaulting to `true`) to allow conditional execution of the steps within the template. This centralizes the condition logic and ensures steps are only executed when the condition evaluates to `true`.