### PR TITLE
Update Node count for CAS 1k test

### DIFF
--- a/scenarios/perf-eval/cluster-autoscaler/terraform-inputs/azure-1000nodes.tfvars
+++ b/scenarios/perf-eval/cluster-autoscaler/terraform-inputs/azure-1000nodes.tfvars
@@ -47,8 +47,8 @@ aks_config_list = [
       },
       {
         name                 = "userpool3"
-        node_count           = 1
-        min_count            = 1
+        node_count           = 0
+        min_count            = 0
         max_count            = 250
         auto_scaling_enabled = true
         vm_size              = "Standard_D2ds_v4"


### PR DESCRIPTION
This pull request updates the cluster configuration in the Terraform input file for the Azure 1000-nodes performance evaluation scenario. The most important change is the adjustment of the initial and minimum node counts for the `userpool3` node pool.

Cluster configuration updates:

* [`scenarios/perf-eval/cluster-autoscaler/terraform-inputs/azure-1000nodes.tfvars`](diffhunk://#diff-953093106ccceda193730e9c4e1ef68fa9cd5c0cf4f1aece3f20802c18f924b1L50-R51): Updated the `userpool3` node pool configuration by setting `node_count` and `min_count` to `0` (previously `1`). This change likely reflects a decision to start with no nodes in this pool, relying on autoscaling to add nodes as needed.