### PR TITLE
Collect Pipeline Metadata

### DIFF
--- a/steps/collect-telescope-metadata.yml
+++ b/steps/collect-telescope-metadata.yml
@@ -42,6 +42,8 @@ steps:
       --arg cloud_info "$CLOUD_INFO" \
       --arg pipeline_id "$(System.DefinitionId)" \
       --arg pipeline_name "$(Build.DefinitionName)" \
+      --arg job_name "$(System.JobDisplayName)" \
+      --arg stage_name "$(System.StageDisplayName)" \
       --arg cron_schedule_display_name "$BUILD_CRONSCHEDULE_DISPLAYNAME" \
       --arg project_name "$(System.TeamProject)" \
       --arg byo_resources "$SKIP_RESOURCE_MANAGEMENT" \
@@ -55,6 +57,8 @@ steps:
             requester: $requester,
             pipeline_id: $pipeline_id,
             pipeline_name: $pipeline_name,
+            job_name: $job_name,
+            stage_name: $stage_name,
             cron_schedule_display_name: $cron_schedule_display_name,
             project_name: $project_name,
             code_url: $code_url,


### PR DESCRIPTION
This pull request updates the `steps/collect-telescope-metadata.yml` file to include additional metadata about the job and stage in the pipeline. These changes enhance the metadata collection process by adding more context about the pipeline execution.

### Metadata collection improvements:
* Added `job_name` and `stage_name` arguments to the metadata collection script to capture the display names of the current job and stage. (`[steps/collect-telescope-metadata.ymlR45-R46](diffhunk://#diff-ae1c8a2df49c63c2b3b1b2a3916f310268251b6996f471854d00689775684ae1R45-R46)`)
* Included `job_name` and `stage_name` in the JSON payload sent to the metadata collector, ensuring this information is recorded. (`[steps/collect-telescope-metadata.ymlR60-R61](diffhunk://#diff-ae1c8a2df49c63c2b3b1b2a3916f310268251b6996f471854d00689775684ae1R60-R61)`)