### PR TITLE
Add CRI test for Ubuntu2404 with k8s 1.32 version and allow aks preview private build

### DIFF
--- a/modules/terraform/azure/aks-cli/README.md
+++ b/modules/terraform/azure/aks-cli/README.md
@@ -34,6 +34,7 @@ configuration, like `--aks-custom-headers" flags. It also supports to use aks-pr
   - `kubernetes_version`: The kubernetes version of the AKS cluster
   - `aks_custom_headers`: Custom headers for AKS.
   - `use_aks_preview_cli_extension`: using aks-preview cli extension
+  - `use_aks_preview_private_build`: using aks-preview private build
   - `default_node_pool`: Configuration for the default node pool
   - `extra_node_pool`: Additional node pools for the AKS cluster
     - `name`: Name of the node pool
@@ -63,6 +64,7 @@ module "aks" {
     kubernetes_version = "1.31"
 
     use_aks_preview_cli_extension = true
+    use_aks_preview_private_build = true
 
     aks_custom_headers = [
       "WindowsContainerRuntime=containerd",

--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -74,15 +74,18 @@ resource "terraform_data" "enable_aks_cli_preview_extension" {
 
   # Todo - Update aks-preview extension for newer features
   provisioner "local-exec" {
-    command = join(" ", [
-      "az",
-      "extension",
-      "add",
-      "-n",
-      "aks-preview",
-      "--version",
-      "14.0.0b2",
-    ])
+    command = var.private_build == true ? (
+      <<EOT
+			wget https://telescopetools.z13.web.core.windows.net/packages/az-cli/aks_preview-14.0.0b6-py2.py3-none-any.whl
+			az extension add --source ./aks_preview-14.0.0b1-py2.py3-none-any.whl -y
+			az version
+    EOT
+    ) : (
+      <<EOT
+      az extension add -n aks-preview --version 14.0.0b2
+      az version
+    EOT
+    )
   }
 
   provisioner "local-exec" {

--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -74,10 +74,10 @@ resource "terraform_data" "enable_aks_cli_preview_extension" {
 
   # Todo - Update aks-preview extension for newer features
   provisioner "local-exec" {
-    command = var.private_build == true ? (
+    command = var.aks_cli_config.use_aks_preview_private_build == true ? (
       <<EOT
 			wget https://telescopetools.z13.web.core.windows.net/packages/az-cli/aks_preview-14.0.0b6-py2.py3-none-any.whl
-			az extension add --source ./aks_preview-14.0.0b1-py2.py3-none-any.whl -y
+			az extension add --source ./aks_preview-14.0.0b6-py2.py3-none-any.whl -y
 			az version
     EOT
     ) : (

--- a/modules/terraform/azure/aks-cli/variables.tf
+++ b/modules/terraform/azure/aks-cli/variables.tf
@@ -32,6 +32,7 @@ variable "aks_cli_config" {
     kubernetes_version            = optional(string, null)
     aks_custom_headers            = optional(list(string), [])
     use_aks_preview_cli_extension = optional(bool, true)
+    use_aks_preview_private_build = optional(bool, false)
     default_node_pool = object({
       name        = string
       node_count  = number
@@ -54,10 +55,4 @@ variable "aks_cli_config" {
       value = string
     })), [])
   })
-}
-
-variable "private_build" {
-  description = "Whether to install private build of aks cli extension"
-  type        = string
-  default     = false
 }

--- a/modules/terraform/azure/aks-cli/variables.tf
+++ b/modules/terraform/azure/aks-cli/variables.tf
@@ -55,3 +55,9 @@ variable "aks_cli_config" {
     })), [])
   })
 }
+
+variable "private_build" {
+  description = "Whether to install private build of aks cli extension"
+  type        = string
+  default     = false
+}

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -103,7 +103,6 @@ module "aks-cli" {
   location            = local.region
   aks_cli_config      = each.value
   tags                = local.tags
-  private_build       = var.aks_cli_private_build
 }
 
 module "aks-arm-deployment" {

--- a/modules/terraform/azure/main.tf
+++ b/modules/terraform/azure/main.tf
@@ -103,6 +103,7 @@ module "aks-cli" {
   location            = local.region
   aks_cli_config      = each.value
   tags                = local.tags
+  private_build       = var.aks_cli_private_build
 }
 
 module "aks-arm-deployment" {

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -220,6 +220,7 @@ variable "aks_cli_config_list" {
     kubernetes_version            = optional(string, null)
     aks_custom_headers            = optional(list(string), [])
     use_aks_preview_cli_extension = optional(bool, true)
+    use_aks_preview_private_build = optional(bool, false)
 
     default_node_pool = object({
       name        = string
@@ -244,12 +245,6 @@ variable "aks_cli_config_list" {
     })), [])
   }))
   default = []
-}
-
-variable "aks_cli_private_build" {
-  description = "Whether to install private build of aks cli extension"
-  type        = bool
-  default     = false
 }
 
 variable "aks_arm_deployment_config_list" {

--- a/modules/terraform/azure/variables.tf
+++ b/modules/terraform/azure/variables.tf
@@ -246,6 +246,12 @@ variable "aks_cli_config_list" {
   default = []
 }
 
+variable "aks_cli_private_build" {
+  description = "Whether to install private build of aks cli extension"
+  type        = bool
+  default     = false
+}
+
 variable "aks_arm_deployment_config_list" {
   description = "AKS ARM deployment configuration"
   type = list(object({

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -216,6 +216,47 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
 
+  - stage: azure_swedencentral_ubuntu2404
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - swedencentral
+          terraform_input_file_mapping:
+            - swedencentral: "scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure-ubuntu2404.tfvars"
+          engine: clusterloader2
+          engine_input:
+            image: "ghcr.io/azure/clusterloader2:v20241016"
+          topology: cri-resource-consume
+          matrix:
+            n10-p300-memory-1-32:
+              node_count: 10
+              max_pods: 30
+              repeats: 1
+              operation_timeout: 3m
+              load_type: memory
+              scrape_kubelets: True
+            n10-p700-memory-1-32:
+              node_count: 10
+              max_pods: 70
+              repeats: 1
+              operation_timeout: 7m
+              load_type: memory
+              scrape_kubelets: True
+            n10-p1100-memory-1-32:
+              node_count: 10
+              max_pods: 110
+              repeats: 1
+              operation_timeout: 11m
+              load_type: memory
+              scrape_kubelets: True
+          max_parallel: 1
+          timeout_in_minutes: 120
+          credential_type: service_connection
+          ssh_key_enabled: false
+
   - stage: aws_westeurope
     dependsOn: []
     jobs:

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure-ubuntu2404.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure-ubuntu2404.tfvars
@@ -1,0 +1,62 @@
+scenario_type  = "perf-eval"
+scenario_name  = "cri-resource-consume"
+deletion_delay = "2h"
+owner          = "aks"
+
+aks_config_list = []
+
+aks_cli_config_list = [
+  {
+    role               = "client"
+    aks_name           = "cri-resource-consume"
+    sku_tier           = "standard"
+    kubernetes_version = "1.32"
+    default_node_pool = {
+      name       = "default"
+      node_count = 3
+      vm_size    = "Standard_D16_v5"
+    }
+    extra_node_pool = [
+      {
+        name       = "prompool",
+        node_count = 1,
+        vm_size    = "Standard_D16_v5",
+      },
+      {
+        name             = "userpool0",
+        node_count       = 10,
+        vm_size          = "Standard_D16ds_v5",
+        node_osdisk_type = "Ephemeral",
+        os_sku           = "Ubuntu2404",
+      }
+    ]
+    optional_parameters = [
+      {
+        name  = "network-plugin"
+        value = "azure"
+      },
+      {
+        name  = "network-plugin-mode"
+        value = "overlay"
+      },
+      {
+        name  = "node-init-taints"
+        value = "CriticalAddonsOnly=true:NoSchedule"
+      },
+      {
+        name  = "pod-cidr"
+        value = "10.0.0.0/9"
+      },
+      {
+        name  = "service-cidr"
+        value = "192.168.0.0/16"
+      },
+      {
+        name  = "dns-service-ip"
+        value = "192.168.0.10"
+      }
+    ]
+  }
+]
+
+aks_cli_private_build = true

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure-ubuntu2404.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure-ubuntu2404.tfvars
@@ -7,10 +7,11 @@ aks_config_list = []
 
 aks_cli_config_list = [
   {
-    role               = "client"
-    aks_name           = "cri-resource-consume"
-    sku_tier           = "standard"
-    kubernetes_version = "1.32"
+    role                          = "client"
+    aks_name                      = "cri-resource-consume"
+    sku_tier                      = "standard"
+    kubernetes_version            = "1.32"
+    use_aks_preview_private_build = true
     default_node_pool = {
       name       = "default"
       node_count = 3
@@ -21,13 +22,35 @@ aks_cli_config_list = [
         name       = "prompool",
         node_count = 1,
         vm_size    = "Standard_D16_v5",
+        optional_parameters = [
+          {
+            name  = "labels"
+            value = "prometheus=true"
+          }
+        ]
       },
       {
-        name             = "userpool0",
-        node_count       = 10,
-        vm_size          = "Standard_D16ds_v5",
-        node_osdisk_type = "Ephemeral",
-        os_sku           = "Ubuntu2404",
+        name       = "userpool0",
+        node_count = 10,
+        vm_size    = "Standard_D16ds_v5",
+        optional_parameters = [
+          {
+            name  = "node-osdisk-type"
+            value = "Ephemeral"
+          },
+          {
+            name  = "os-sku"
+            value = "Ubuntu2404"
+          },
+          {
+            name  = "node-taints"
+            value = "cri-resource-consume=true:NoSchedule,cri-resource-consume=true:NoExecute"
+          },
+          {
+            name  = "labels"
+            value = "cri-resource-consume=true"
+          }
+        ]
       }
     ]
     optional_parameters = [
@@ -58,5 +81,3 @@ aks_cli_config_list = [
     ]
   }
 ]
-
-aks_cli_private_build = true


### PR DESCRIPTION
- Add a variable to allow the use of aks preview private build
- Add a test for Ubuntu2404 with k8s version 1.32 and Ephemeral disk