### PR TITLE
fix variable naming to not use library keywords

### DIFF
--- a/pypeline/pipeline.py
+++ b/pypeline/pipeline.py
@@ -82,9 +82,9 @@ def literal_block_representer(dumper: yaml.Dumper, data: str):
 
 def custom_name_representer(dumper, data):
     data_dict = {}
-    for field in fields(data):
-        yaml_name = field.metadata.get("yaml", field.name)
-        value = getattr(data, field.name)
+    for data_field in fields(data):
+        yaml_name = data_field.metadata.get("yaml", data_field.name)
+        value = getattr(data, data_field.name)
         if value is not None:
             data_dict[yaml_name] = value
     return dumper.represent_dict(data_dict)

--- a/pypeline/pipelines/controller/job_scheduling.py
+++ b/pypeline/pipelines/controller/job_scheduling.py
@@ -17,7 +17,7 @@ def main():
                 display_name="eastus",
                 setup=Setup(run_id=os.getenv("RUN_ID")),
                 cloud=Azure(),
-                resouces=[
+                resources=[
                     Python3(),
                     SSH(cloud="azure"),
                 ],


### PR DESCRIPTION
- Eliminate warning by not using library keywords 

We are importing **field** from dataclass and using **field** as a variable at custom_name_representer cause warning
from dataclasses import dataclass, field, fields