### PR TITLE
Add KWOK implementations in python for reusability across Engines

### DIFF
--- a/modules/python/kwok/config/kwok-node.yaml
+++ b/modules/python/kwok/config/kwok-node.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-0
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-0
+spec:
+  taints: # Avoid scheduling actual running pods to fake Node
+  - effect: NoSchedule
+    key: kwok.x-k8s.io/node
+    value: fake
+status:
+  allocatable:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  capacity:
+    cpu: 32
+    memory: 256Gi
+    pods: 110
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running

--- a/modules/python/kwok/config/kwok-pod.yaml
+++ b/modules/python/kwok/config/kwok-pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-pod
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: fake-pod
+  template:
+    metadata:
+      labels:
+        app: fake-pod
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: In
+                values:
+                - kwok
+      # A taints was added to an automatically created Node.
+      # You can remove taints of Node or add this tolerations.
+      tolerations:
+      - key: "kwok.x-k8s.io/node"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: fake-container
+        image: fake-image

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -1,0 +1,161 @@
+import json
+import subprocess
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import requests
+import yaml
+
+
+@dataclass
+class KWOK(ABC):
+    kwok_repo: str = "kubernetes-sigs/kwok"
+    kwok_release: str = None
+    enable_metrics: bool = False
+
+    def fetch_latest_release(self):
+        response = requests.get(
+            f"https://api.github.com/repos/{self.kwok_repo}/releases/latest", timeout=10
+        )
+        response.raise_for_status()
+        return response.json().get("tag_name")
+
+    def apply_manifest(self, manifest):
+        with subprocess.Popen(
+            ["kubectl", "apply", "-f", "-"], stdin=subprocess.PIPE, text=True
+        ) as process:
+            process.communicate(input=json.dumps(manifest))
+            if process.returncode != 0:
+                raise RuntimeError("Failed to apply manifest")
+
+    # Setting up the KWOK environment and simulating the pod/node emulation
+    # If `enable_metrics` is True, it also applies an additional metrics usage YAML file
+    # to simulate resource usage for nodes, pods, and containers.
+    def apply_kwok_manifests(self, kwok_release, enable_metrics):
+        kwok_yaml_url = f"https://github.com/{self.kwok_repo}/releases/download/{kwok_release}/kwok.yaml"
+        stage_fast_yaml_url = f"https://github.com/{self.kwok_repo}/releases/download/{kwok_release}/stage-fast.yaml"
+        subprocess.run(["kubectl", "apply", "-f", kwok_yaml_url], check=True)
+        subprocess.run(["kubectl", "apply", "-f", stage_fast_yaml_url], check=True)
+
+        if enable_metrics:
+            metrics_usage_url = f"https://github.com/{self.kwok_repo}/releases/download/{kwok_release}/metrics-usage.yaml"
+            subprocess.run(["kubectl", "apply", "-f", metrics_usage_url], check=True)
+
+    @abstractmethod
+    def create(self):
+        pass
+
+    @abstractmethod
+    def validate(self):
+        pass
+
+    @abstractmethod
+    def tear_down(self):
+        pass
+
+
+@dataclass
+class Node(KWOK):
+    node_manifest_path: str = "config/kwok-node.yaml"
+    node_count: int = 1
+
+    def create(self):
+        try:
+            self.kwok_release = self.kwok_release or self.fetch_latest_release()
+            print(f"Using KWOK_RELEASE={self.kwok_release}")
+
+            self.apply_kwok_manifests(self.kwok_release, self.enable_metrics)
+
+            with open(self.node_manifest_path, "r", encoding="utf-8") as file:
+                base_node_manifest = yaml.safe_load(file)
+
+            for i in range(self.node_count):
+                node_manifest = base_node_manifest.copy()
+                node_manifest["metadata"]["name"] = f"kwok-node-{i}"
+                self.apply_manifest(node_manifest)
+
+            print(f"Successfully created {self.node_count} virtual nodes.")
+        except Exception as e:
+            raise RuntimeError(f"Failed to create nodes: {e}") from e
+
+    def validate(self):
+        for i in range(self.node_count):
+            node_name = f"kwok-node-{i}"
+            print(f"Validating node: {node_name}")
+            try:
+                node_info = self._get_node_info(node_name)
+                self._validate_node_status(node_name, node_info)
+                self._validate_node_annotations(node_name, node_info)
+                self._validate_node_resources(node_name, node_info)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Validation failed for node {node_name}: {e}"
+                ) from e
+
+        print(f"Validation completed for {self.node_count} nodes.")
+
+    def tear_down(self):
+        for i in range(self.node_count):
+            node_name = f"kwok-node-{i}"
+            print(f"Deleting node: {node_name}")
+            try:
+                subprocess.run(["kubectl", "delete", "node", node_name], check=True)
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(f"Failed to delete node {node_name}: {e}") from e
+
+        print(f"Successfully deleted {self.node_count} nodes.")
+
+    def _get_node_info(self, node_name):
+        result = subprocess.run(
+            ["kubectl", "get", "node", node_name, "-o", "json"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        return json.loads(result.stdout)
+
+    def _validate_node_status(self, node_name, node_info):
+        conditions = node_info.get("status", {}).get("conditions", [])
+        ready_condition = next((c for c in conditions if c["type"] == "Ready"), None)
+        if ready_condition and ready_condition["status"] == "True":
+            print(f"Node {node_name} is Ready.")
+        else:
+            raise RuntimeError(f"Node {node_name} is NOT Ready.")
+
+    def _validate_node_annotations(self, node_name, node_info):
+        annotations = node_info.get("metadata", {}).get("annotations", {})
+        if annotations.get("kwok.x-k8s.io/node") == "fake":
+            print(f"Node {node_name} is correctly annotated as a KWOK node.")
+        else:
+            raise RuntimeError(f"Node {node_name} is missing the KWOK annotation.")
+
+    def _validate_node_resources(self, node_name, node_info):
+        allocatable = node_info.get("status", {}).get("allocatable", {})
+        capacity = node_info.get("status", {}).get("capacity", {})
+        if not allocatable or not capacity:
+            raise RuntimeError(
+                f"Node {node_name} is missing resource information (allocatable or capacity)."
+            )
+        print(f"Node {node_name} Allocatable: {allocatable}")
+        print(f"Node {node_name} Capacity: {capacity}")
+
+
+# TODO: Implement the logic for KWOK pods
+@dataclass
+class Pod(KWOK):
+    def create(self):
+        pass
+
+    def validate(self):
+        pass
+
+    def tear_down(self):
+        pass
+
+
+if __name__ == "__main__":
+    # Example usage
+    kwok_node = Node(node_count=2, enable_metrics=True)
+    kwok_node.create()
+    kwok_node.validate()
+    kwok_node.tear_down()

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -151,11 +151,3 @@ class Pod(KWOK):
 
     def tear_down(self):
         pass
-
-
-if __name__ == "__main__":
-    # Example usage
-    kwok_node = Node(node_count=2, enable_metrics=True)
-    kwok_node.create()
-    kwok_node.validate()
-    kwok_node.tear_down()

--- a/modules/python/tests/kwok/test_kwok_node.py
+++ b/modules/python/tests/kwok/test_kwok_node.py
@@ -1,0 +1,1 @@
+# TODO: implement kwok node tests


### PR DESCRIPTION
This update integrates KWOK functionality into [python](vscode-file://vscode-app/c:/Users/vsalim/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), making it reusable and callable by different engines. 
- ClusterLoader2 + KWOK
- KPerf + KWOK
- FIO + KWOK
- Attach + KWOK

Test Results: Creating, Validating, and Deleting KWOK Virtual Nodes

```
Using KWOK_RELEASE=v0.6.1
customresourcedefinition.apiextensions.k8s.io/attaches.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterattaches.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterexecs.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterlogs.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterportforwards.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/clusterresourceusages.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/execs.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/logs.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/metrics.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/portforwards.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/resourceusages.kwok.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/stages.kwok.x-k8s.io unchanged
serviceaccount/kwok-controller unchanged
clusterrole.rbac.authorization.k8s.io/kwok-controller unchanged
clusterrolebinding.rbac.authorization.k8s.io/kwok-controller unchanged
service/kwok-controller unchanged
deployment.apps/kwok-controller unchanged
stage.kwok.x-k8s.io/node-heartbeat-with-lease unchanged
stage.kwok.x-k8s.io/node-initialize unchanged
stage.kwok.x-k8s.io/pod-complete unchanged
stage.kwok.x-k8s.io/pod-delete unchanged
stage.kwok.x-k8s.io/pod-ready unchanged
node/kwok-node-0 created
node/kwok-node-1 created
node/kwok-node-2 created
node/kwok-node-3 created
node/kwok-node-4 created
Successfully created 5 virtual nodes.
Validating node: kwok-node-0
Node kwok-node-0 is Ready.
Node kwok-node-0 is correctly annotated as a KWOK node.
Node kwok-node-0 Allocatable: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Node kwok-node-0 Capacity: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Validating node: kwok-node-1
Node kwok-node-1 is Ready.
Node kwok-node-1 is correctly annotated as a KWOK node.
Node kwok-node-1 Allocatable: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Node kwok-node-1 Capacity: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Validating node: kwok-node-2
Node kwok-node-2 is Ready.
Node kwok-node-2 is correctly annotated as a KWOK node.
Node kwok-node-2 Allocatable: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Node kwok-node-2 Capacity: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Validating node: kwok-node-3
Node kwok-node-3 is Ready.
Node kwok-node-3 is correctly annotated as a KWOK node.
Node kwok-node-3 Allocatable: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Node kwok-node-3 Capacity: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Validating node: kwok-node-4
Node kwok-node-4 is Ready.
Node kwok-node-4 is correctly annotated as a KWOK node.
Node kwok-node-4 Allocatable: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Node kwok-node-4 Capacity: {'cpu': '32', 'memory': '256Gi', 'pods': '110'}
Validation completed for 5 nodes.
Deleting node: kwok-node-0
node "kwok-node-0" deleted
Deleting node: kwok-node-1
node "kwok-node-1" deleted
Deleting node: kwok-node-2
node "kwok-node-2" deleted
Deleting node: kwok-node-3
node "kwok-node-3" deleted
Deleting node: kwok-node-4
node "kwok-node-4" deleted
Successfully deleted 5 nodes.
```