### PR TITLE
Move resource group from terraform to cloud class 

### DIFF
--- a/pypeline/benchmark.py
+++ b/pypeline/benchmark.py
@@ -53,7 +53,7 @@ class Cloud(ABC):
         pass
 
     @abstractmethod
-    def create_resource_group(self) -> Script:
+    def create_resource_group(self) -> str:
         pass
 
 

--- a/pypeline/benchmark.py
+++ b/pypeline/benchmark.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 import yaml
 
-from pipeline import Job, Pipeline, Stage, Step, customize_yaml
+from pipeline import Job, Pipeline, Script, Stage, Step, customize_yaml
 
 
 class CloudProvider(Enum):
@@ -46,6 +46,10 @@ class Cloud(ABC):
 
     @abstractmethod
     def generate_input_variables(self, region: str, input_variables: dict) -> dict:
+        pass
+
+    @abstractmethod
+    def create_resource_group(self, region: str) -> Script:
         pass
 
 

--- a/pypeline/benchmark.py
+++ b/pypeline/benchmark.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 import yaml
 
-from pipeline import Job, Pipeline, Script, Stage, Step, customize_yaml
+from pipeline import Job, Pipeline, Stage, Step, customize_yaml
 
 
 class CloudProvider(Enum):

--- a/pypeline/cloud/azure.py
+++ b/pypeline/cloud/azure.py
@@ -131,7 +131,7 @@ class Azure(Cloud):
             ),
         }
 
-    def create_resource_group(self, region: str) -> Script:
+    def create_resource_group(self, region: str) -> str:
         return dedent(
             f"""
             set -eu

--- a/pypeline/cloud/azure.py
+++ b/pypeline/cloud/azure.py
@@ -132,18 +132,14 @@ class Azure(Cloud):
         }
 
     def create_resource_group(self, region: str) -> Script:
-        return Script(
-            display_name="Create Resource Group",
-            script=dedent(
-                f"""
-                set -eu
-                echo "Create resource group $RUN_ID in region {region}"
-                az group create --name $RUN_ID --location {region} \\
-                --tags "run_id=$RUN_ID" "scenario=${{SCENARIO_TYPE}}-${{SCENARIO_NAME}}" "owner=${{OWNER}}" "creation_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "deletion_due_time=${{DELETION_DUE_TIME}}" "SkipAKSCluster=1"
-                """
-            ).strip(),
-            condition="ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')",
-        )
+        return dedent(
+            f"""
+            set -eu
+            echo "Create resource group $RUN_ID in region {region}"
+            az group create --name $RUN_ID --location {region} \\
+            --tags "run_id=$RUN_ID" "scenario=${{SCENARIO_TYPE}}-${{SCENARIO_NAME}}" "owner=${{OWNER}}" "creation_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "deletion_due_time=${{DELETION_DUE_TIME}}" "SkipAKSCluster=1"
+            """
+        ).strip()
 
     def delete_resource_group(self) -> str:
         return dedent(

--- a/pypeline/cloud/azure.py
+++ b/pypeline/cloud/azure.py
@@ -130,3 +130,17 @@ class Azure(Cloud):
                 "user_node_pool", "$USER_NODE_POOL"
             ),
         }
+
+    def create_resource_group(self, region: str) -> Script:
+        return Script(
+            display_name="Create Resource Group",
+            script=dedent(
+                f"""
+                set -eu
+                echo "Create resource group $RUN_ID in region {region}"
+                az group create --name $RUN_ID --location {region} \
+                --tags "run_id=$RUN_ID" "scenario=${{SCENARIO_TYPE}}-${{SCENARIO_NAME}}" "owner=${{OWNER}}" "creation_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "deletion_due_time=${{DELETION_DUE_TIME}}" "SkipAKSCluster=1"
+                """
+            ).strip(),
+            condition="ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')",
+        )

--- a/pypeline/terraform/terraform.py
+++ b/pypeline/terraform/terraform.py
@@ -129,6 +129,7 @@ def get_deletion_info(region: str) -> Script:
         condition="ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')",
     )
 
+
 def set_input_variables(
     cloud: Cloud, regions: list[str], input_variables: dict
 ) -> Script:
@@ -231,6 +232,14 @@ def generate_apply_or_destroy_script(
     ).strip()
 
 
+def create_resource_group(cloud: Cloud, region: str) -> Script:
+    return Script(
+        display_name="Create Resource Group",
+        script=cloud.create_resource_group(region),
+        condition="ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')",
+    )
+
+
 # TODO: Add delete_resource_group function and validate_resource_group function
 @dataclass
 class Terraform(Resource):
@@ -253,7 +262,7 @@ class Terraform(Resource):
             set_user_data_path(self.user_data_path),
             set_input_variables(self.cloud, self.regions, self.input_variables),
             get_deletion_info(self.regions[0]),
-            self.cloud.create_resource_group(self.regions[0]),
+            create_resource_group(self.cloud, self.regions[0]),
             self.run_command(TerraformCommand.VERSION),
             self.run_command(TerraformCommand.INIT),
             self.run_command(TerraformCommand.APPLY),


### PR DESCRIPTION
- Move creating resource group to cloud class for decoupling 
- To not expose yaml condition in checking if cloud is azure, aws or gcp


Previously condition was checking if azure == azure 
with **condition=and(eq('{cloud}', 'azure')**
By moving to cloud class this can be removed
