### PR TITLE
Implement CLI Argument Parser for KWOK Topology Invocation

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -41,13 +41,14 @@ jobs:
           else
             pylint $file_changes
           fi
-      - name: Set up kwokctl
-        uses: kubernetes-sigs/kwok@main
-        with:
-          command: kwokctl
-      - run: kwokctl create cluster --name kwok-test
-        env:
-          KWOK_KUBE_VERSION: v1.28.0
+      - name: Install kwokctl
+        run: |
+          curl -LO https://github.com/kubernetes-sigs/kwok/releases/latest/download/kwokctl-linux-amd64
+          chmod +x kwokctl-linux-amd64
+          sudo mv kwokctl-linux-amd64 /usr/local/bin/kwokctl
+
+      - name: Create KWOK cluster
+        run: kwokctl create cluster --name kwok-test
       - name: Run Python Unit Tests
         working-directory: ${{ env.PYTHON_MODULES_DIR }}
         run: coverage run -m unittest discover

--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -41,14 +41,13 @@ jobs:
           else
             pylint $file_changes
           fi
-      - name: Install kwokctl
-        run: |
-          curl -LO https://github.com/kubernetes-sigs/kwok/releases/latest/download/kwokctl-linux-amd64
-          chmod +x kwokctl-linux-amd64
-          sudo mv kwokctl-linux-amd64 /usr/local/bin/kwokctl
-
-      - name: Create KWOK cluster
-        run: kwokctl create cluster --name kwok-test
+      - name: Set up kwokctl
+        uses: kubernetes-sigs/kwok@main
+        with:
+          command: kwokctl
+      - run: kwokctl create cluster --name kwok-test
+        env:
+          KWOK_KUBE_VERSION: v1.28.0
       - name: Run Python Unit Tests
         working-directory: ${{ env.PYTHON_MODULES_DIR }}
         run: coverage run -m unittest discover

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -1,6 +1,8 @@
 import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+import argparse
+import sys
 
 import requests
 
@@ -143,4 +145,44 @@ class Pod(KWOK):
         pass
 
 
-# TODO: Implement an argument parser so that KWOK can be invoked in the topology.
+def main():
+    parser = argparse.ArgumentParser(
+        description="KWOK: Kubernetes WithOut Kubelet - Virtual Node/Pod Simulator")
+    parser.add_argument("--mode", choices=["node", "pod"], required=True,
+        help="KWOK simulation mode: 'node' for virtual nodes, 'pod' for virtual pods.",)
+    parser.add_argument("--node-count", type=int, default=1,
+        help="Number of virtual nodes to create (only for --mode node).",)
+    parser.add_argument("--node-manifest-path", type=str, default="kwok/config/kwok-node.yaml",
+        help="Path to the node manifest YAML template.",)
+    parser.add_argument("--kwok-release", type=str, default=None,
+        help="KWOK release version to use (default: latest).",)
+    parser.add_argument("--enable-metrics", action="store_true",
+        help="Enable metrics simulation by applying metrics-usage.yaml.",)
+    parser.add_argument("--action", choices=["create", "validate", "tear_down"], required=True,
+        help="Action to perform: create, validate, or tear_down.",)
+
+    args = parser.parse_args()
+
+    if args.mode == "node":
+        node = Node(
+            node_manifest_path=args.node_manifest_path,
+            node_count=args.node_count,
+            kwok_release=args.kwok_release,
+            enable_metrics=args.enable_metrics,
+        )
+        if args.action == "create":
+            node.create()
+        elif args.action == "validate":
+            node.validate()
+        elif args.action == "tear_down":
+            node.tear_down()
+    elif args.mode == "pod":
+        # TODO: Implement the logic for KWOK pods
+        pass
+    else:
+        print("Unknown mode specified.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -1,11 +1,10 @@
+import argparse
 import subprocess
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-import argparse
-import sys
 
 import requests
-
 
 from clients.kubernetes_client import KubernetesClient
 
@@ -147,19 +146,43 @@ class Pod(KWOK):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="KWOK: Kubernetes WithOut Kubelet - Virtual Node/Pod Simulator")
-    parser.add_argument("--mode", choices=["node", "pod"], required=True,
-        help="KWOK simulation mode: 'node' for virtual nodes, 'pod' for virtual pods.",)
-    parser.add_argument("--node-count", type=int, default=1,
-        help="Number of virtual nodes to create (only for --mode node).",)
-    parser.add_argument("--node-manifest-path", type=str, default="kwok/config/kwok-node.yaml",
-        help="Path to the node manifest YAML template.",)
-    parser.add_argument("--kwok-release", type=str, default=None,
-        help="KWOK release version to use (default: latest).",)
-    parser.add_argument("--enable-metrics", action="store_true",
-        help="Enable metrics simulation by applying metrics-usage.yaml.",)
-    parser.add_argument("--action", choices=["create", "validate", "tear_down"], required=True,
-        help="Action to perform: create, validate, or tear_down.",)
+        description="KWOK: Kubernetes WithOut Kubelet - Virtual Node/Pod Simulator"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["node", "pod"],
+        required=True,
+        help="KWOK simulation mode: 'node' for virtual nodes, 'pod' for virtual pods.",
+    )
+    parser.add_argument(
+        "--node-count",
+        type=int,
+        default=1,
+        help="Number of virtual nodes to create (only for --mode node).",
+    )
+    parser.add_argument(
+        "--node-manifest-path",
+        type=str,
+        default="kwok/config/kwok-node.yaml",
+        help="Path to the node manifest YAML template.",
+    )
+    parser.add_argument(
+        "--kwok-release",
+        type=str,
+        default=None,
+        help="KWOK release version to use (default: latest).",
+    )
+    parser.add_argument(
+        "--enable-metrics",
+        action="store_true",
+        help="Enable metrics simulation by applying metrics-usage.yaml.",
+    )
+    parser.add_argument(
+        "--action",
+        choices=["create", "validate", "tear_down"],
+        required=True,
+        help="Action to perform: create, validate, or tear_down.",
+    )
 
     args = parser.parse_args()
 

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -169,7 +169,7 @@ def main():
     parser.add_argument(
         "--kwok-release",
         type=str,
-        default=None,
+        default="",
         help="KWOK release version to use (default: latest).",
     )
     parser.add_argument(


### PR DESCRIPTION
Implement an argument parser so that KWOK can be invoked in the topology.

**Create 2 virtual nodes using the latest KWOK release:**

> python -m kwok.kwok --mode node --action create --node-count 2

**Validate that 2 KWOK nodes are present**

> python -m kwok.kwok --mode node --action validate --node-count 2

**Tear down (delete) 2 KWOK nodes**

> python -m kwok.kwok --mode node --action tear_down --node-count 2

**Create nodes with a specific KWOK release and enable metrics:**

> python -m kwok.kwok --mode node --action create --node-count 2 --kwok-release v0.7.0 --enable-metrics

**Use a custom node manifest:**

> python -m kwok.kwok --mode node --action create --node-manifest-path path/to/custom-node.yaml