### PR TITLE
Remove create resource group from cloud module since it is only relevant to Azure

### DIFF
--- a/pypeline/benchmark.py
+++ b/pypeline/benchmark.py
@@ -52,10 +52,6 @@ class Cloud(ABC):
     def delete_resource_group(self) -> str:
         pass
 
-    @abstractmethod
-    def create_resource_group(self) -> str:
-        pass
-
 
 @dataclass
 class Layout:

--- a/pypeline/terraform/terraform.py
+++ b/pypeline/terraform/terraform.py
@@ -233,9 +233,14 @@ def generate_apply_or_destroy_script(
 
 
 def create_resource_group(cloud: Cloud, region: str) -> Script:
+    if cloud.provider.value != CloudProvider.AZURE:
+        script_str = cloud.create_resource_group(region)
+    else:
+        script_str = "echo 'Resource group creation is only required for Azure.'"
+
     return Script(
         display_name="Create Resource Group",
-        script=cloud.create_resource_group(region),
+        script=script_str,
         condition="ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')",
     )
 


### PR DESCRIPTION
Asked Lei about this, there is no resource group at AWS and GCP, since create_resource_group is only relevant to azure. This PR is **to remove create_resource_group function from Cloud class**