### PR TITLE
Rename delete_resource_group to delete_resources, since resource group is not relevant to cloud module (aws and gcp do not have resource group)

### DIFF
--- a/pypeline/benchmark.py
+++ b/pypeline/benchmark.py
@@ -49,7 +49,7 @@ class Cloud(ABC):
         pass
 
     @abstractmethod
-    def delete_resource_group(self) -> str:
+    def delete_resources(self) -> str:
         pass
 
     @abstractmethod

--- a/pypeline/cloud/azure.py
+++ b/pypeline/cloud/azure.py
@@ -133,7 +133,7 @@ class Azure(Cloud):
             """
         ).strip()
 
-    def delete_resource_group(self) -> str:
+    def delete_resources(self) -> str:
         return dedent(
             """
             echo "Deleting resources and removing state file before retrying"

--- a/pypeline/terraform/terraform.py
+++ b/pypeline/terraform/terraform.py
@@ -198,7 +198,7 @@ def generate_apply_or_destroy_script(
     if (
         TerraformCommand.APPLY == command and cloud.provider == CloudProvider.AZURE
     ) or (TerraformCommand.DESTROY == command and cloud.provider == CloudProvider.AWS):
-        error_handling_script = indent(cloud.delete_resource_group(), " " * 16)
+        error_handling_script = indent(cloud.delete_resources(), " " * 16)
 
     return dedent(
         f"""


### PR DESCRIPTION
- Rename _**delete_resource_group**_ to _**delete_resources**_ since **_delete_resource_group_** is not relevant to the cloud module, as GCP and AWS do not have the concept of a resource group.

- TODO: The delete_resource_group function will be added to the Azure class only.