### PR TITLE
Update API server benchmark 100 nodes 3k pods

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -30,14 +30,14 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.2.0
+            runner_image: ghcr.io/azure/kperf:0.3.3
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2
           timeout_in_minutes: 360
           credential_type: service_connection
           ssh_key_enabled: false
-  - stage: azure_eastus2_default
+  - stage: azure_eastus2
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml
@@ -57,36 +57,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "false"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.2.0
-            benchmark_subcmd: node100_job1_pod3k
-            benchmark_subcmd_args: "--total 36000"
-          max_parallel: 2
-          timeout_in_minutes: 360
-          credential_type: service_connection
-          ssh_key_enabled: false
-  - stage: azure_eastus2_lower_max_inflight
-    dependsOn: []
-    variables:
-      - group: API-Server-L4-Config-MI50
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - eastus2
-          engine: kperf
-          topology: kperf
-          matrix:
-            workload-low:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "false"
-            exempt:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "false"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.2.0
+            runner_image: ghcr.io/azure/kperf:0.3.3
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -64,3 +64,27 @@ stages:
           timeout_in_minutes: 360
           credential_type: service_connection
           ssh_key_enabled: false
+  - stage: gcp_eastus1
+    dependsOn: []
+    condition: eq(variables['Build.Reason'], 'Manual')
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: gcp
+          regions:
+            - us-east1
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.3
+            benchmark_subcmd: node100_job1_pod3k
+            benchmark_subcmd_args: "--total 36000"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/scenarios/perf-eval/apiserver-vn100pod3k/terraform-inputs/gcp.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod3k/terraform-inputs/gcp.tfvars
@@ -1,5 +1,5 @@
 scenario_type = "perf-eval"
-scenario_name = "apiserver-vn100-p3k"
+scenario_name = "apiserver-vn100pod3k"
 owner         = "aks"
 network_config_list = [
   {
@@ -35,7 +35,7 @@ network_config_list = [
 gke_config_list = [
   {
     role        = "client"
-    name        = "vn100-p3k"
+    name        = "vn100p3k"
     vpc_name    = "client-vpc"
     subnet_name = "client-subnet"
     default_node_pool = {

--- a/scenarios/perf-eval/apiserver-vn100pod3k/terraform-inputs/gcp.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod3k/terraform-inputs/gcp.tfvars
@@ -1,0 +1,53 @@
+scenario_type = "perf-eval"
+scenario_name = "apiserver-vn100-p3k"
+owner         = "aks"
+network_config_list = [
+  {
+    role     = "client"
+    vpc_name = "client-vpc"
+    vpc_cidr = "10.0.0.0/16"
+    subnets = [
+      {
+        name                = "client-subnet"
+        cidr                = "10.0.0.0/24"
+        secondary_ip_ranges = []
+    }]
+    firewall_rules = [
+      {
+        name               = "allow-all-egress"
+        direction          = "EGRESS"
+        priority           = 1000
+        source_ranges      = []
+        destination_ranges = ["0.0.0.0/0"]
+        source_tags        = []
+        target_tags        = []
+        allow = [
+          {
+            protocol = "all"
+            ports    = []
+          }
+        ]
+      }
+    ]
+  }
+]
+
+gke_config_list = [
+  {
+    role        = "client"
+    name        = "vn100-p3k"
+    vpc_name    = "client-vpc"
+    subnet_name = "client-subnet"
+    default_node_pool = {
+      name         = "default",
+      machine_type = "n1-standard-8",
+      node_count   = 1
+    }
+    extra_node_pools = [
+      {
+        name         = "runner",
+        machine_type = "n1-standard-16",
+        node_count   = 1
+      }
+    ]
+}]

--- a/scenarios/perf-eval/apiserver-vn100pod3k/terraform-test-inputs/gcp.json
+++ b/scenarios/perf-eval/apiserver-vn100pod3k/terraform-test-inputs/gcp.json
@@ -1,0 +1,5 @@
+{
+    "project_id"                       : "123456789",
+    "run_id"                           : "123456789",
+    "region"                           : "us-east1"
+}


### PR DESCRIPTION
This pull request updates the configuration for the API Server Benchmark pipeline to improve compatibility and adjust deployment parameters. The most notable changes include updating the `runner_image` to a newer version, modifying stage names and dependencies, and switching the cloud provider for one of the stages.

### Updates to runner image:
* Updated `runner_image` from `ghcr.io/azure/kperf:0.2.0` to `ghcr.io/azure/kperf:0.3.3` across multiple stages to use the latest version of the benchmarking tool. [[1]](diffhunk://#diff-958ba5049aa0309c1f097c99a46cec23442642fa6c5643a30f40fa553e1999fcL33-R40) [[2]](diffhunk://#diff-958ba5049aa0309c1f097c99a46cec23442642fa6c5643a30f40fa553e1999fcL60-R84)

### Stage modifications:
* Renamed the stage `azure_eastus2_default` to `azure_eastus2` for clarity.
* Replaced the stage `azure_eastus2_lower_max_inflight` with `gcp_eastus1`, changing the cloud provider from Azure to Google Cloud Platform (GCP) and adjusting associated variables and parameters.

### Deployment adjustments:
* Added a condition to the `gcp_eastus1` stage to execute only when the build reason is manual (`eq(variables['Build.Reason'], 'Manual')`).
* Modified the region for the `gcp_eastus1` stage from `eastus2` to `us-east1`, aligning with the GCP naming convention.
* Disabled warmup for the `workload-low` matrix in the `gcp_eastus1` stage by setting `disable_warmup` to `"true"`.This pull request updates the API Server Benchmark pipeline configuration by upgrading the `runner_image` version and simplifying the stages. The most notable changes include updating the `runner_image` to a newer version and removing a stage with specific configurations.

Updates to `runner_image`:

* Upgraded `runner_image` from `ghcr.io/azure/kperf:0.2.0` to `ghcr.io/azure/kperf:0.3.3`, ensuring the pipeline uses the latest version of the benchmarking tool. [[1]](diffhunk://#diff-958ba5049aa0309c1f097c99a46cec23442642fa6c5643a30f40fa553e1999fcL33-R40) [[2]](diffhunk://#diff-958ba5049aa0309c1f097c99a46cec23442642fa6c5643a30f40fa553e1999fcL60-R60)

Simplification of stages:

* Removed the `azure_eastus2_lower_max_inflight` stage, including its specific configurations such as `variables`, `matrix`, and `jobs`, to streamline the pipeline.
* Renamed the `azure_eastus2_default` stage to `azure_eastus2` for consistency and clarity.