### PR TITLE
Update Job Templates for BYO & E2E

### DIFF
--- a/jobs/competitive-test.yml
+++ b/jobs/competitive-test.yml
@@ -24,7 +24,7 @@ parameters:
 - name: terraform_arguments
   type: string
   default: ''
-- name: terraform_input_varibles
+- name: terraform_input_variables
   type: object
   default: {}
 - name: test_modules_dir
@@ -50,13 +50,14 @@ parameters:
   default: true
 
 jobs:
-- job: ${{ parameters.cloud }}
+# BYO Resources job - runs when SKIP_RESOURCE_MANAGEMENT is true and not on main branch
+- job: ${{ parameters.cloud }}_byo
+  condition: and(eq(variables['SKIP_RESOURCE_MANAGEMENT'], 'true'), and(ne(variables['Build.Reason'], 'Schedule'), ne(variables['Build.SourceBranchName'], 'main')))
   strategy:
     maxParallel: ${{ parameters.max_parallel }}
     matrix:
       ${{ parameters.matrix }}
   timeoutInMinutes: ${{ parameters.timeout_in_minutes }}
-  condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
   steps:
   - template: /steps/setup-tests.yml
     parameters:
@@ -67,16 +68,6 @@ jobs:
       retry_attempt_count: ${{ parameters.retry_attempt_count }}
       credential_type: ${{ parameters.credential_type }}
       ssh_key_enabled: ${{ parameters.ssh_key_enabled }}
-  - template: /steps/provision-resources.yml
-    parameters:
-      cloud: ${{ parameters.cloud }}
-      regions: ${{ parameters.regions }}
-      terraform_modules_dir: ${{ parameters.terraform_modules_dir }}
-      terraform_input_file_mapping: ${{ parameters.terraform_input_file_mapping }}
-      terraform_arguments: ${{ parameters.terraform_arguments }}
-      terraform_input_varibles: ${{ parameters.terraform_input_varibles }}
-      retry_attempt_count: ${{ parameters.retry_attempt_count }}
-      credential_type: ${{ parameters.credential_type }}
   - template: /steps/validate-resources.yml
     parameters:
       cloud: ${{ parameters.cloud }}
@@ -98,6 +89,55 @@ jobs:
       regions: ${{ parameters.regions }}
       engine_input: ${{ parameters.engine_input }}
       credential_type: ${{ parameters.credential_type }}
+
+- job: ${{ parameters.cloud }}_full
+  condition: or(and(eq(variables['Build.Reason'], 'Manual'),ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+  strategy:
+    maxParallel: ${{ parameters.max_parallel }}
+    matrix:
+      ${{ parameters.matrix }}
+  timeoutInMinutes: ${{ parameters.timeout_in_minutes }}
+  steps:
+  - template: /steps/setup-tests.yml
+    parameters:
+      cloud: ${{ parameters.cloud }}
+      region: ${{ parameters.regions[0] }}
+      run_id: ${{ parameters.run_id }}
+      test_modules_dir: ${{ parameters.test_modules_dir }}
+      retry_attempt_count: ${{ parameters.retry_attempt_count }}
+      credential_type: ${{ parameters.credential_type }}
+      ssh_key_enabled: ${{ parameters.ssh_key_enabled }}
+  # - template: /steps/provision-resources.yml
+  #   parameters:
+  #     cloud: ${{ parameters.cloud }}
+  #     regions: ${{ parameters.regions }}
+  #     terraform_modules_dir: ${{ parameters.terraform_modules_dir }}
+  #     terraform_input_file_mapping: ${{ parameters.terraform_input_file_mapping }}
+  #     terraform_arguments: ${{ parameters.terraform_arguments }}
+  #     terraform_input_varibles: ${{ parameters.terraform_input_variables }}
+  #     retry_attempt_count: ${{ parameters.retry_attempt_count }}
+  #     credential_type: ${{ parameters.credential_type }}
+  # - template: /steps/validate-resources.yml
+  #   parameters:
+  #     cloud: ${{ parameters.cloud }}
+  #     regions: ${{ parameters.regions }}
+  #     topology: ${{ parameters.topology }}
+  #     engine: ${{ parameters.engine }}
+  # - template: /steps/execute-tests.yml
+  #   parameters:
+  #     cloud: ${{ parameters.cloud }}
+  #     topology: ${{ parameters.topology }}
+  #     engine: ${{ parameters.engine }}
+  #     regions: ${{ parameters.regions }}
+  #     engine_input: ${{ parameters.engine_input }}
+  # - template: /steps/publish-results.yml
+  #   parameters:
+  #     cloud: ${{ parameters.cloud }}
+  #     topology: ${{ parameters.topology }}
+  #     engine: ${{ parameters.engine }}
+  #     regions: ${{ parameters.regions }}
+  #     engine_input: ${{ parameters.engine_input }}
+  #     credential_type: ${{ parameters.credential_type }}
   - template: /steps/cleanup-resources.yml
     parameters:
       cloud: ${{ parameters.cloud }}

--- a/steps/cleanup-resources.yml
+++ b/steps/cleanup-resources.yml
@@ -30,7 +30,7 @@ steps:
     echo "Delete resource group $RUN_ID"
     az group delete --name $RUN_ID --yes
   displayName: "Destroy Resource Group"
-  condition: and(${{ eq(parameters.cloud, 'azure') }}, ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true'))
+  condition: ${{ eq(parameters.cloud, 'azure') }}
 
 - ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
   - template: /steps/collect-terraform-operation-metadata.yml

--- a/steps/collect-terraform-operation-metadata.yml
+++ b/steps/collect-terraform-operation-metadata.yml
@@ -12,7 +12,6 @@ steps:
     $TERRAFORM_WORKING_DIRECTORY "$TEST_RESULTS_DIR/terraform_operation_metadata.json" "$SCENARIO_TYPE" "$SCENARIO_NAME"
     echo "##vso[task.setvariable variable=TERRAFORM_OPERATION_METADATA_FILE]$TEST_RESULTS_DIR/terraform_operation_metadata.json"
   displayName: "Collect Terraform Operation Metadata"
-  condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
   workingDirectory: modules/python/terraform
   env:
     PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/terraform/extract_terraform_operation_metadata.py

--- a/steps/provision-resources.yml
+++ b/steps/provision-resources.yml
@@ -58,7 +58,6 @@ steps:
     echo "Owner: $owner"
     echo "##vso[task.setvariable variable=OWNER]$owner"
   displayName: "Get Deletion Due Time and Owner"
-  condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
   env:
     region: ${{ parameters.regions[0] }}
 
@@ -68,7 +67,7 @@ steps:
     az group create --name $RUN_ID --location $region \
       --tags "run_id=$RUN_ID" "scenario=${SCENARIO_TYPE}-${SCENARIO_NAME}" "owner=${OWNER}" "creation_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "deletion_due_time=${DELETION_DUE_TIME}" "SkipAKSCluster=1"
   displayName: "Create Resource Group"
-  condition: and(${{ eq(parameters.cloud, 'azure') }}, ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true'))
+  condition: ${{ eq(parameters.cloud, 'azure') }}
   env:
     region: ${{ parameters.regions[0] }}
 

--- a/steps/ssh/setup-key.yml
+++ b/steps/ssh/setup-key.yml
@@ -28,4 +28,3 @@ steps:
     cat $SSH_KEY_PATH
     echo "##vso[task.setvariable variable=SSH_KEY_PATH;]${SSH_KEY_PATH}"
   displayName: "Download SSH Key"
-  condition: eq(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')

--- a/steps/terraform/run-command.yml
+++ b/steps/terraform/run-command.yml
@@ -81,7 +81,6 @@ steps:
       terraform ${{ parameters.command }} ${{ parameters.arguments }}
     fi
   displayName: "Run Terraform ${{ parameters.command }} Command"
-  condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
   retryCountOnTaskFailure: ${{ parameters.retry_attempt_count }}
   env:
     REGIONS: ${{ convertToJson(parameters.regions) }}

--- a/steps/terraform/set-input-file.yml
+++ b/steps/terraform/set-input-file.yml
@@ -29,7 +29,6 @@ steps:
     echo "##vso[task.setvariable variable=REGIONAL_CONFIG]$regional_config_str"
 
   displayName: 'Set Terraform Input File'
-  condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
   env:
     CLOUD: ${{ parameters.cloud }}
     REGIONS: ${{ convertToJson(parameters.regions) }}

--- a/steps/terraform/set-input-variables-aws.yml
+++ b/steps/terraform/set-input-variables-aws.yml
@@ -48,7 +48,6 @@ steps:
       echo "##vso[task.setvariable variable=TERRAFORM_REGIONAL_CONFIG]$regional_config_str"
 
     displayName: 'Set Terraform Input Variables'
-    condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
     env:
       CLOUD: ${{ parameters.cloud }}
       REGIONS: ${{ convertToJson(parameters.regions) }}

--- a/steps/terraform/set-input-variables-azure.yml
+++ b/steps/terraform/set-input-variables-azure.yml
@@ -68,7 +68,6 @@ steps:
       echo "##vso[task.setvariable variable=TERRAFORM_REGIONAL_CONFIG]$regional_config_str"
 
     displayName: 'Set Terraform Input Variables'
-    condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
     env:
       CLOUD: ${{ parameters.cloud }}
       REGIONS: ${{ convertToJson(parameters.regions) }}

--- a/steps/terraform/set-input-variables-gcp.yml
+++ b/steps/terraform/set-input-variables-gcp.yml
@@ -39,7 +39,6 @@ steps:
       echo "##vso[task.setvariable variable=TERRAFORM_REGIONAL_CONFIG]$regional_config_str"
 
     displayName: 'Set Terraform Input Variables'
-    condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
     env:
       CLOUD: ${{ parameters.cloud }}
       REGIONS: ${{ convertToJson(parameters.regions) }}

--- a/steps/terraform/set-user-data-path.yml
+++ b/steps/terraform/set-user-data-path.yml
@@ -20,6 +20,5 @@ steps:
     fi
 
   displayName: 'Set Terraform User Data Path'
-  condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
   env:
     USER_DATA_PATH: ${{ parameters.user_data_path }}

--- a/steps/terraform/set-working-directory.yml
+++ b/steps/terraform/set-working-directory.yml
@@ -16,7 +16,6 @@ steps:
     echo "Terraform Working Directory: $terraform_working_directory"
 
   displayName: 'Set Terraform Working Directory'
-  condition: ne(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
   env:
     CLOUD: ${{ parameters.cloud }}
     MODULES_DIR: ${{ parameters.modules_dir }}

--- a/steps/validate-resources.yml
+++ b/steps/validate-resources.yml
@@ -16,7 +16,6 @@ steps:
       exit 1
     fi
   displayName: "Validate OWNER info"
-  condition: eq(variables['SKIP_RESOURCE_MANAGEMENT'], 'true')
 - template: /steps/topology/${{ parameters.topology }}/validate-resources.yml@self
   parameters:
     cloud: ${{ parameters.cloud }}


### PR DESCRIPTION
This pull request introduces significant updates to the `jobs/competitive-test.yml` file and related step templates to refine resource management logic and improve job configurations. The changes primarily focus on adjusting conditions related to the `SKIP_RESOURCE_MANAGEMENT` variable, renaming parameters for consistency, and adding new job definitions. Below is a categorized summary of the most important changes:

### Job Configuration Updates:
* Added a new job `${{ parameters.cloud }}_byo` to handle scenarios where `SKIP_RESOURCE_MANAGEMENT` is true and the build is not on the main branch. This job skips resource provisioning and focuses on validation (`jobs/competitive-test.yml`).
* Introduced a `${{ parameters.cloud }}_full` job for cases where manual builds or scheduled builds on the main branch require full resource management. Resource provisioning steps are commented out for now (`jobs/competitive-test.yml`).

### Parameter Renaming:
* Corrected the parameter name from `terraform_input_varibles` to `terraform_input_variables` for clarity and consistency (`jobs/competitive-test.yml`).

### Condition Adjustments:
* Removed conditions tied to `SKIP_RESOURCE_MANAGEMENT` in several step templates, simplifying logic and ensuring steps execute based on other factors:
  - `steps/cleanup-resources.yml`
  - `steps/provision-resources.yml` [[1]](diffhunk://#diff-bb57749fbaaea2fbff3adb99cba62fb712d6502e1e7fd2f985fa7581fa0a513bL61) [[2]](diffhunk://#diff-bb57749fbaaea2fbff3adb99cba62fb712d6502e1e7fd2f985fa7581fa0a513bL71-R70)
  - Various Terraform-related templates, including `run-command.yml`, `set-input-file.yml`, `set-input-variables-*`, `set-user-data-path.yml`, and `set-working-directory.yml` [[1]](diffhunk://#diff-43b0a6e7ca97b5e7f9289dc2fc51830da2782e6b82fc5d0d091508c6b60ad70aL84) [[2]](diffhunk://#diff-107bcc098693e516ce658343462e53b0fc6dfb6590c9ee599d840a3e1656b8eeL32) [[3]](diffhunk://#diff-b1d17104ad89c5ea4450be089594bfb9f160bb24f46d2055e5476522a2c59c20L51) [[4]](diffhunk://#diff-7ed544f040598d432bcfbc28c60048961ade121d6ab97091671a37e4d365f86eL71) [[5]](diffhunk://#diff-94407567e3f052d4952c4bb7c0931959b2f3a450211a6145e0add06b865d18f6L42) [[6]](diffhunk://#diff-7c2771b5f5209c8a7cb2dd1ea381f4ae6f816eb9f87dcd79249a3b086751608cL23) [[7]](diffhunk://#diff-4ceb7f9a82cc9cf852e7b26a984f89fd69a06fd8f92cbb4856b29a722d79ee22L19)
  - `steps/validate-resources.yml`

### Resource Management Logic:
* Removed the `provision-resources.yml` step template from the default job configuration, aligning with scenarios where resource provisioning is skipped (`jobs/competitive-test.yml`).

These changes streamline job execution and improve parameter clarity, while enabling flexibility in resource management workflows.