### PR TITLE
Update Azure login with client Id

### DIFF
--- a/steps/cloud/azure/login.yml
+++ b/steps/cloud/azure/login.yml
@@ -14,7 +14,7 @@ steps:
       set -eu
 
       echo "login to Azure in $REGION"
-      az login --identity --username $AZURE_MI_ID
+      az login --identity --client-id $AZURE_MI_ID
       az account set --subscription "${AZURE_MI_SUBSCRIPTION_ID}"
       az config set defaults.location="$REGION"
       az account show


### PR DESCRIPTION
This pull request includes a small change to the Azure login step in the `steps/cloud/azure/login.yml` file. The change modifies the `az login` command to use the `--client-id` parameter instead of `--username` for logging in to Azure.