### PR TITLE
Update Kperf image to latest version

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
@@ -32,7 +32,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2
@@ -59,7 +59,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2
@@ -83,7 +83,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -30,7 +30,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -54,7 +54,7 @@ stages:
               flowcontrol: "workload-low:1000"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -83,7 +83,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -114,7 +114,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -147,7 +147,7 @@ stages:
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
               warmup_subcmd_args: "--total 48000 --core-warmup-ready-threshold=16"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -30,7 +30,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2
@@ -57,7 +57,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "false"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2
@@ -81,7 +81,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2


### PR DESCRIPTION
In Kperf v0.3.3, CRDs are managed by a single nodepool release, which causes failures when adding new nodepools. This PR updates the Kperf image to v0.3.4 to fix the issue, incorporating changes from [https://github.com/Azure/kperf/pull/173](https://github.com/Azure/kperf/pull/173)