### PR TITLE
Update Kperf image to latest version

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
@@ -32,7 +32,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2
@@ -59,7 +59,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2
@@ -83,7 +83,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node10_job1_pod100
             benchmark_subcmd_args: "--total 1000"
           max_parallel: 2

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -30,7 +30,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -54,7 +54,7 @@ stages:
               flowcontrol: "workload-low:1000"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -83,7 +83,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -114,7 +114,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2
@@ -147,7 +147,7 @@ stages:
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
               warmup_subcmd_args: "--total 48000 --core-warmup-ready-threshold=16"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
           max_parallel: 2

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -30,7 +30,7 @@ stages:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2
@@ -57,7 +57,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "false"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2
@@ -81,7 +81,7 @@ stages:
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
           engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.3
+            runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_job1_pod3k
             benchmark_subcmd_args: "--total 36000"
           max_parallel: 2

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,25 +1,148 @@
 trigger: none
-
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: apiserver-vn100pod10k
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: aws_eastus2
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml # must keep as is
+      - template: /jobs/competitive-test.yml
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
-          credential_type: service_connection # required
+          cloud: aws
+          regions:
+            - us-east-2
+          engine: kperf
+          topology: kperf
+          matrix:
+            podsize-20k:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+            podsize-20k-exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node100_pod10k
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+          max_parallel: 2
+          timeout_in_minutes: 760
+          credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 60 # if not specified, default is 60
+  - stage: gcp_eastus1
+    dependsOn: []
+    condition: eq(variables['Build.Reason'], 'Manual')
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: gcp
+          regions:
+            - us-east1
+          engine: kperf
+          topology: kperf
+          matrix:
+            podsize-20k:
+              disable_warmup: "true"
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node100_pod10k
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: azure_eastus2
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            podsize-20k:
+              kubernetes_version: "1.33.0"
+              disable_warmup: "true"
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+            podsize-20k-exempt:
+              kubernetes_version: "1.33.0"
+              disable_warmup: "true"
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node100_pod10k
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+          max_parallel: 2
+          timeout_in_minutes: 760
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: azure_eastus2_lower_max_inflight
+    dependsOn: []
+    variables:
+      - group: API-Server-Lower-Max-Inflight
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            podsize-20k:
+              kubernetes_version: "1.32.0"
+              disable_warmup: "true"
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+            podsize-20k-exempt:
+              kubernetes_version: "1.32.0"
+              disable_warmup: "true"
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node100_pod10k
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+          max_parallel: 2
+          timeout_in_minutes: 760
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: azure_eastus2_higher_cpu_cores
+    dependsOn: []
+    variables:
+      - group: API-Server-Higher-CPU-Cores
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            podsize-20k:
+              kubernetes_version: "1.33.0"
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+              disable_warmup: "false"
+              warmup_subcmd_args: "--total 48000 --core-warmup-ready-threshold=16"
+            podsize-20k-exempt:
+              kubernetes_version: "1.33.0"
+              disable_warmup: "false"
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: "--padding-bytes=16384"
+              warmup_subcmd_args: "--total 48000 --core-warmup-ready-threshold=16"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node100_pod10k
+            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+          max_parallel: 2
+          timeout_in_minutes: 760
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,25 +1,85 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: apiserver-vn10pod100
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: aws_eastus2
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml # must keep as is
+      - template: /jobs/competitive-test.yml
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
-          credential_type: service_connection # required
+          cloud: aws
+          regions:
+            - us-east-2
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+            exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node10_job1_pod100
+            benchmark_subcmd_args: "--total 1000"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 60 # if not specified, default is 60
+  - stage: azure_eastus2
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+            exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node10_job1_pod100
+            benchmark_subcmd_args: "--total 1000"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: gcp_eastus1
+    dependsOn: []
+    condition: eq(variables['Build.Reason'], 'Manual')
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: gcp
+          regions:
+            - us-east1
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node10_job1_pod100
+            benchmark_subcmd_args: "--total 1000"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,83 +1,25 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: perf-eval
-  SCENARIO_NAME: apiserver-vn100pod3k
+  SCENARIO_TYPE: <scenario-type>
+  SCENARIO_NAME: <scenario-name>
 
 stages:
-  - stage: aws_eastus2
+  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml
+      - template: /jobs/competitive-test.yml # must keep as is
         parameters:
-          cloud: aws
-          regions:
-            - us-east-2
-          engine: kperf
-          topology: kperf
-          matrix:
-            workload-low:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: ""
-            exempt:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: ""
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node100_job1_pod3k
-            benchmark_subcmd_args: "--total 36000"
-          max_parallel: 2
-          timeout_in_minutes: 360
-          credential_type: service_connection
+          cloud: <cloud> # e.g. azure, aws
+          regions: # list of regions
+            - region1 # e.g. eastus2
+          topology: <topology> # e.g. cluster-autoscaler
+          engine: <engine> # e.g. clusterloader2
+          matrix: # list of test parameters to customize the provisioned resources
+            <case-name>:
+              <key1>: <value1>
+              <key2>: <value2>
+          max_parallel: <number of concurrent jobs> # required
+          credential_type: service_connection # required
           ssh_key_enabled: false
-  - stage: azure_eastus2
-    dependsOn: []
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - eastus2
-          engine: kperf
-          topology: kperf
-          matrix:
-            workload-low:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "false"
-            exempt:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "false"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node100_job1_pod3k
-            benchmark_subcmd_args: "--total 36000"
-          max_parallel: 2
-          timeout_in_minutes: 360
-          credential_type: service_connection
-          ssh_key_enabled: false
-  - stage: gcp_eastus1
-    dependsOn: []
-    condition: eq(variables['Build.Reason'], 'Manual')
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: gcp
-          regions:
-            - us-east1
-          engine: kperf
-          topology: kperf
-          matrix:
-            workload-low:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "true"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node100_job1_pod3k
-            benchmark_subcmd_args: "--total 36000"
-          max_parallel: 2
-          timeout_in_minutes: 360
-          credential_type: service_connection
-          ssh_key_enabled: false
+          timeout_in_minutes: 60 # if not specified, default is 60

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,85 +1,25 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: perf-eval
-  SCENARIO_NAME: apiserver-vn10pod100
+  SCENARIO_TYPE: <scenario-type>
+  SCENARIO_NAME: <scenario-name>
 
 stages:
-  - stage: aws_eastus2
+  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml
+      - template: /jobs/competitive-test.yml # must keep as is
         parameters:
-          cloud: aws
-          regions:
-            - us-east-2
-          engine: kperf
-          topology: kperf
-          matrix:
-            workload-low:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "true"
-            exempt:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "true"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node10_job1_pod100
-            benchmark_subcmd_args: "--total 1000"
-          max_parallel: 2
-          timeout_in_minutes: 360
-          credential_type: service_connection
+          cloud: <cloud> # e.g. azure, aws
+          regions: # list of regions
+            - region1 # e.g. eastus2
+          topology: <topology> # e.g. cluster-autoscaler
+          engine: <engine> # e.g. clusterloader2
+          matrix: # list of test parameters to customize the provisioned resources
+            <case-name>:
+              <key1>: <value1>
+              <key2>: <value2>
+          max_parallel: <number of concurrent jobs> # required
+          credential_type: service_connection # required
           ssh_key_enabled: false
-  - stage: azure_eastus2
-    dependsOn: []
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - eastus2
-          engine: kperf
-          topology: kperf
-          matrix:
-            workload-low:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "true"
-            exempt:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "true"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node10_job1_pod100
-            benchmark_subcmd_args: "--total 1000"
-          max_parallel: 2
-          timeout_in_minutes: 360
-          credential_type: service_connection
-          ssh_key_enabled: false
-  - stage: gcp_eastus1
-    dependsOn: []
-    condition: eq(variables['Build.Reason'], 'Manual')
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: gcp
-          regions:
-            - us-east1
-          engine: kperf
-          topology: kperf
-          matrix:
-            workload-low:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "true"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node10_job1_pod100
-            benchmark_subcmd_args: "--total 1000"
-          max_parallel: 2
-          timeout_in_minutes: 360
-          credential_type: service_connection
-          ssh_key_enabled: false
+          timeout_in_minutes: 60 # if not specified, default is 60

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,148 +1,25 @@
 trigger: none
+
 variables:
-  SCENARIO_TYPE: perf-eval
-  SCENARIO_NAME: apiserver-vn100pod10k
+  SCENARIO_TYPE: <scenario-type>
+  SCENARIO_NAME: <scenario-name>
 
 stages:
-  - stage: aws_eastus2
+  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml
+      - template: /jobs/competitive-test.yml # must keep as is
         parameters:
-          cloud: aws
-          regions:
-            - us-east-2
-          engine: kperf
-          topology: kperf
-          matrix:
-            podsize-20k:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-            podsize-20k-exempt:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node100_pod10k
-            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-          max_parallel: 2
-          timeout_in_minutes: 760
-          credential_type: service_connection
+          cloud: <cloud> # e.g. azure, aws
+          regions: # list of regions
+            - region1 # e.g. eastus2
+          topology: <topology> # e.g. cluster-autoscaler
+          engine: <engine> # e.g. clusterloader2
+          matrix: # list of test parameters to customize the provisioned resources
+            <case-name>:
+              <key1>: <value1>
+              <key2>: <value2>
+          max_parallel: <number of concurrent jobs> # required
+          credential_type: service_connection # required
           ssh_key_enabled: false
-  - stage: gcp_eastus1
-    dependsOn: []
-    condition: eq(variables['Build.Reason'], 'Manual')
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: gcp
-          regions:
-            - us-east1
-          engine: kperf
-          topology: kperf
-          matrix:
-            podsize-20k:
-              disable_warmup: "true"
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node100_pod10k
-            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-          max_parallel: 2
-          timeout_in_minutes: 360
-          credential_type: service_connection
-          ssh_key_enabled: false
-  - stage: azure_eastus2
-    dependsOn: []
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - eastus2
-          engine: kperf
-          topology: kperf
-          matrix:
-            podsize-20k:
-              kubernetes_version: "1.33.0"
-              disable_warmup: "true"
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-            podsize-20k-exempt:
-              kubernetes_version: "1.33.0"
-              disable_warmup: "true"
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node100_pod10k
-            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-          max_parallel: 2
-          timeout_in_minutes: 760
-          credential_type: service_connection
-          ssh_key_enabled: false
-  - stage: azure_eastus2_lower_max_inflight
-    dependsOn: []
-    variables:
-      - group: API-Server-Lower-Max-Inflight
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - eastus2
-          engine: kperf
-          topology: kperf
-          matrix:
-            podsize-20k:
-              kubernetes_version: "1.32.0"
-              disable_warmup: "true"
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-            podsize-20k-exempt:
-              kubernetes_version: "1.32.0"
-              disable_warmup: "true"
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node100_pod10k
-            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-          max_parallel: 2
-          timeout_in_minutes: 760
-          credential_type: service_connection
-          ssh_key_enabled: false
-  - stage: azure_eastus2_higher_cpu_cores
-    dependsOn: []
-    variables:
-      - group: API-Server-Higher-CPU-Cores
-    jobs:
-      - template: /jobs/competitive-test.yml
-        parameters:
-          cloud: azure
-          regions:
-            - eastus2
-          engine: kperf
-          topology: kperf
-          matrix:
-            podsize-20k:
-              kubernetes_version: "1.33.0"
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-              disable_warmup: "false"
-              warmup_subcmd_args: "--total 48000 --core-warmup-ready-threshold=16"
-            podsize-20k-exempt:
-              kubernetes_version: "1.33.0"
-              disable_warmup: "false"
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: "--padding-bytes=16384"
-              warmup_subcmd_args: "--total 48000 --core-warmup-ready-threshold=16"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: node100_pod10k
-            benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-          max_parallel: 2
-          timeout_in_minutes: 760
-          credential_type: service_connection
-          ssh_key_enabled: false
+          timeout_in_minutes: 60 # if not specified, default is 60

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,25 +1,83 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: apiserver-vn100pod3k
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: aws_eastus2
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml # must keep as is
+      - template: /jobs/competitive-test.yml
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
-          credential_type: service_connection # required
+          cloud: aws
+          regions:
+            - us-east-2
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+            exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: ""
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node100_job1_pod3k
+            benchmark_subcmd_args: "--total 36000"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 60 # if not specified, default is 60
+  - stage: azure_eastus2
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "false"
+            exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "false"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node100_job1_pod3k
+            benchmark_subcmd_args: "--total 36000"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false
+  - stage: gcp_eastus1
+    dependsOn: []
+    condition: eq(variables['Build.Reason'], 'Manual')
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: gcp
+          regions:
+            - us-east1
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: node100_job1_pod3k
+            benchmark_subcmd_args: "--total 36000"
+          max_parallel: 2
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false


### PR DESCRIPTION
In Kperf v0.3.3, CRDs are managed by a single nodepool release, which causes failures when adding new nodepools. This PR updates the Kperf image to v0.3.4 to fix the issue, incorporating changes from [https://github.com/Azure/kperf/pull/173](https://github.com/Azure/kperf/pull/173)