### PR TITLE
Add NSR Validation & Update NSR Priority values

### DIFF
--- a/modules/terraform/azure/network/network-security-rule/variables.tf
+++ b/modules/terraform/azure/network/network-security-rule/variables.tf
@@ -6,6 +6,10 @@ variable "name" {
 variable "priority" {
   description = "Priority for the network security rule."
   type        = number
+  validation {
+    condition     = var.priority >= 120 && var.priority <= 4096
+    error_message = "Priority must be between 120 and 4096."
+  }
 }
 
 variable "direction" {

--- a/scenarios/perf-eval/pod-diff-node-same-zone/terraform-inputs/azure-ubuntu2404.tfvars
+++ b/scenarios/perf-eval/pod-diff-node-same-zone/terraform-inputs/azure-ubuntu2404.tfvars
@@ -19,7 +19,7 @@ network_config_list = [
     nsr_rules = [
       {
         name                       = "Allow-Port-5201"
-        priority                   = 100
+        priority                   = 120
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -30,7 +30,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-Port-20000"
-        priority                   = 101
+        priority                   = 121
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -41,7 +41,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-Port-20003"
-        priority                   = 102
+        priority                   = 122
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -52,7 +52,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-Port-20005"
-        priority                   = 103
+        priority                   = 123
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -63,7 +63,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-Port-80"
-        priority                   = 104
+        priority                   = 124
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -74,7 +74,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-API-Server"
-        priority                   = 105
+        priority                   = 125
         direction                  = "Outbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -85,7 +85,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-WebSocket"
-        priority                   = 106
+        priority                   = 126
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"

--- a/scenarios/perf-eval/pod-diff-node-same-zone/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/pod-diff-node-same-zone/terraform-inputs/azure.tfvars
@@ -19,7 +19,7 @@ network_config_list = [
     nsr_rules = [
       {
         name                       = "Allow-Port-5201"
-        priority                   = 100
+        priority                   = 120
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -30,7 +30,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-Port-20000"
-        priority                   = 101
+        priority                   = 121
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -41,7 +41,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-Port-20003"
-        priority                   = 102
+        priority                   = 122
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -52,7 +52,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-Port-20005"
-        priority                   = 103
+        priority                   = 123
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -63,7 +63,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-Port-80"
-        priority                   = 104
+        priority                   = 124
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -74,7 +74,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-API-Server"
-        priority                   = 105
+        priority                   = 125
         direction                  = "Outbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -85,7 +85,7 @@ network_config_list = [
       },
       {
         name                       = "Allow-WebSocket"
-        priority                   = 106
+        priority                   = 126
         direction                  = "Inbound"
         access                     = "Allow"
         protocol                   = "Tcp"


### PR DESCRIPTION
This pull request introduces a validation rule for the priority variable in the `network-security-rule` module and updates priority values in two Terraform input files (`azure-ubuntu2404.tfvars` and `azure.tfvars`) to comply with the new validation constraints. The most important changes include adding the validation logic and updating priority values across multiple configurations.

### Validation rule for priority variable:
* [`modules/terraform/azure/network/network-security-rule/variables.tf`](diffhunk://#diff-0ea03a02e36a57904655505af23fa79e0a95736f0d4953f20ca748b93733b082R9-R12): Added a validation block to ensure `priority` values are between 120 and 4096, with a clear error message for invalid inputs.

### Updates to priority values:
#### `azure-ubuntu2404.tfvars`:
* Updated priority values for multiple `nsr_rules` to comply with the new validation rule:
  - Changed priority for "Allow-Port-5201" from 100 to 120.
  - Changed priority for "Allow-Port-20000" from 101 to 121.
  - Changed priority for "Allow-Port-20003" from 102 to 122.
  - Changed priority for "Allow-Port-20005" from 103 to 123.
  - Changed priority for "Allow-Port-80" from 104 to 124.

#### `azure.tfvars`:
* Updated priority values for multiple `nsr_rules` to comply with the new validation rule:
  - Changed priority for "Allow-Port-5201" from 100 to 120.
  - Changed priority for "Allow-Port-20000" from 101 to 121.
  - Changed priority for "Allow-Port-20003" from 102 to 122.
  - Changed priority for "Allow-Port-20005" from 103 to 123.
  - Changed priority for "Allow-Port-80" from 104 to 124.