### PR TITLE
apiserver-cm100: Raise deletion_delay to 10h

### DIFF
--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,34 +1,25 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: perf-eval
-  SCENARIO_NAME: apiserver-cm100
+  SCENARIO_TYPE: <scenario-type>
+  SCENARIO_NAME: <scenario-name>
 
 stages:
-  - stage: azure_eastus2
+  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml
+      - template: /jobs/competitive-test.yml # must keep as is
         parameters:
-          cloud: azure
-          regions:
-            - eastus2
-          engine: kperf
-          topology: kperf
-          matrix:
-            workload-low:
-              flowcontrol: "workload-low:1000"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "true"
-            exempt:
-              flowcontrol: "exempt:5"
-              extra_benchmark_subcmd_args: ""
-              disable_warmup: "true"
-          engine_input:
-            runner_image: ghcr.io/azure/kperf:0.3.4
-            benchmark_subcmd: list_configmaps
-            benchmark_subcmd_args: "--total 10000 --size=1024 --group-size=10 --configmap-amount=100"
-          max_parallel: 1
-          timeout_in_minutes: 360
-          credential_type: service_connection
+          cloud: <cloud> # e.g. azure, aws
+          regions: # list of regions
+            - region1 # e.g. eastus2
+          topology: <topology> # e.g. cluster-autoscaler
+          engine: <engine> # e.g. clusterloader2
+          matrix: # list of test parameters to customize the provisioned resources
+            <case-name>:
+              <key1>: <value1>
+              <key2>: <value2>
+          max_parallel: <number of concurrent jobs> # required
+          credential_type: service_connection # required
           ssh_key_enabled: false
+          timeout_in_minutes: 60 # if not specified, default is 60

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,25 +1,34 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: apiserver-cm100
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: azure_eastus2
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml # must keep as is
+      - template: /jobs/competitive-test.yml
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
-          credential_type: service_connection # required
+          cloud: azure
+          regions:
+            - eastus2
+          engine: kperf
+          topology: kperf
+          matrix:
+            workload-low:
+              flowcontrol: "workload-low:1000"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+            exempt:
+              flowcontrol: "exempt:5"
+              extra_benchmark_subcmd_args: ""
+              disable_warmup: "true"
+          engine_input:
+            runner_image: ghcr.io/azure/kperf:0.3.4
+            benchmark_subcmd: list_configmaps
+            benchmark_subcmd_args: "--total 10000 --size=1024 --group-size=10 --configmap-amount=100"
+          max_parallel: 1
+          timeout_in_minutes: 360
+          credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 60 # if not specified, default is 60

--- a/scenarios/perf-eval/apiserver-cm100/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/apiserver-cm100/terraform-inputs/azure.tfvars
@@ -1,6 +1,6 @@
 scenario_type  = "perf-eval"
 scenario_name  = "apiserver-cm100"
-deletion_delay = "2h"
+deletion_delay = "10h"
 owner          = "aks"
 
 aks_config_list = [


### PR DESCRIPTION
 Raise deletion_delay to avoid early RG cleanup during benchmark.