### PR TITLE
Add A100 GPU CRUD Test 

### DIFF
--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -7,6 +7,12 @@ schedules:
       include:
         - main
     always: true
+  - cron: "30 */6 * * *"
+    displayName: "At 30 minute past every 6th hour"
+    branches:
+      include:
+        - main
+    always: true    
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-gpu-cluster-crud
@@ -41,11 +47,12 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
           timeout_in_minutes: 180
+          
   - stage: azure_ND_A100_gpu_test
     dependsOn: []
     condition: |
       or(
-        eq(variables['Build.CronSchedule.DisplayName'], 'Every 6 hours'),
+        eq(variables['Build.CronSchedule.DisplayName'], 'At 30 minute past every 6th hour'),
         eq(variables['Build.Reason'], 'Manual')
       )
     jobs:
@@ -59,10 +66,10 @@ stages:
           matrix:
             a100_gpu_node_pool:
               gpu_node_pool: true
-              pool_name: a100nodepool
+              pool_name: A100nodepool
               vm_size: Standard_ND96asr_v4
               create_node_count: 0
-              scale_node_count: 1
+              scale_node_count: 2
               scale_step_size: 1
               step_time_out: 600
               step_wait_time: 30

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -12,7 +12,7 @@ variables:
   SCENARIO_NAME: k8s-gpu-cluster-crud
 
 stages:
-  - stage: azure_H100_t4_gpu_test
+  - stage: azure_H100_gpu_test
     dependsOn: []
     condition: |
       or(
@@ -34,6 +34,35 @@ stages:
               vm_size: Standard_NC40ads_H100_v5
               create_node_count: 0
               scale_node_count: 2
+              scale_step_size: 1
+              step_time_out: 600
+              step_wait_time: 30
+          max_parallel: 1
+          credential_type: service_connection
+          ssh_key_enabled: false
+          timeout_in_minutes: 180
+  - stage: azure_ND_A100_gpu_test
+    dependsOn: []
+    condition: |
+      or(
+        eq(variables['Build.CronSchedule.DisplayName'], 'Every 6 hours'),
+        eq(variables['Build.Reason'], 'Manual')
+      )
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - southcentralus
+          topology: k8s-crud-gpu
+          engine: crud
+          matrix:
+            a100_gpu_node_pool:
+              gpu_node_pool: true
+              pool_name: a100nodepool
+              vm_size: Standard_ND96asr_v4
+              create_node_count: 0
+              scale_node_count: 1
               scale_step_size: 1
               step_time_out: 600
               step_wait_time: 30


### PR DESCRIPTION
This pull request introduces updates to the GPU benchmarking pipeline configuration in `pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml`. The changes include adding a new cron schedule, modifying an existing stage, and introducing a new GPU test stage.

### Pipeline schedule updates:
* Added a new cron schedule to run the pipeline at "30 minutes past every 6th hour," targeting the `main` branch.

### Stage modifications and additions:
* Renamed the `azure_H100_t4_gpu_test` stage to `azure_H100_gpu_test` for clarity.
* Added a new `azure_ND_A100_gpu_test` stage with specific conditions (`Build.CronSchedule.DisplayName` or `Build.Reason`) and parameters for testing A100 GPUs in a Kubernetes cluster. This includes configurations for node pools, scaling, and timeouts.