### PR TITLE
Update AWS AMI Type for default k8s version

### DIFF
--- a/modules/terraform/aws/eks/README.md
+++ b/modules/terraform/aws/eks/README.md
@@ -12,13 +12,13 @@ To use the EKS module, follow these steps:
 
 ```hcl
   eks_config_list = [{
-  eks_name                = "sumanth-test"
+  eks_name                = "eks-test"
   vpc_name                = "client-vpc"
   policy_arns = ["AmazonEKSClusterPolicy", "AmazonEKSVPCResourceController", "AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly"]
   eks_managed_node_groups = [
     {
       name           = "node-group-1"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["t3.small"]
       min_size       = 1
       max_size       = 3

--- a/modules/terraform/aws/tests/test_eks_machine_type.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_machine_type.tftest.hcl
@@ -59,7 +59,7 @@ variables {
     eks_managed_node_groups = [
       {
         name           = "default"
-        ami_type       = "AL2_x86_64"
+        ami_type       = "AL2023_x86_64_STANDARD"
         instance_types = ["m4.large"]
         min_size       = 1
         max_size       = 2
@@ -67,7 +67,7 @@ variables {
       },
       {
         name           = "userpool"
-        ami_type       = "AL2_x86_64"
+        ami_type       = "AL2023_x86_64_STANDARD"
         instance_types = ["m4.large"]
         min_size       = 5
         max_size       = 5

--- a/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
@@ -57,14 +57,14 @@ variables {
     policy_arns = ["AmazonEKS_CNI_Policy"]
     eks_managed_node_groups = [{
       name           = "my_scenario-ng"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.large"]
       min_size       = 5
       max_size       = 5
       desired_size   = 5
       }, {
       name           = "my_scenario-ng-2"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.large"]
       min_size       = 5
       max_size       = 5

--- a/modules/terraform/aws/tests/test_eks_node_groups_subnets.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups_subnets.tftest.hcl
@@ -64,7 +64,7 @@ variables {
     eks_managed_node_groups = [
       {
         name           = "default"
-        ami_type       = "AL2_x86_64"
+        ami_type       = "AL2023_x86_64_STANDARD"
         instance_types = ["m4.large"]
         min_size       = 1
         max_size       = 2
@@ -72,7 +72,7 @@ variables {
       },
       {
         name           = "userpool"
-        ami_type       = "AL2_x86_64"
+        ami_type       = "AL2023_x86_64_STANDARD"
         instance_types = ["m4.large"]
         min_size       = 5
         max_size       = 5

--- a/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
@@ -65,7 +65,7 @@ run "valid_vpc_config_default" {
       eks_managed_node_groups = [
         {
           name           = "my_scenario-ng"
-          ami_type       = "AL2_x86_64"
+          ami_type       = "AL2023_x86_64_STANDARD"
           instance_types = ["m4.large"]
           min_size       = 5
           max_size       = 5
@@ -103,7 +103,7 @@ run "valid_vpc_config_set" {
       eks_managed_node_groups = [
         {
           name           = "my_scenario-ng"
-          ami_type       = "AL2_x86_64"
+          ami_type       = "AL2023_x86_64_STANDARD"
           instance_types = ["m5a.xlarge"]
           min_size       = 5
           max_size       = 5
@@ -143,7 +143,7 @@ run "valid_karpenter_set" {
       eks_managed_node_groups = [
         {
           name           = "my_scenario-ng"
-          ami_type       = "AL2_x86_64"
+          ami_type       = "AL2023_x86_64_STANDARD"
           instance_types = ["m5a.xlarge"]
           min_size       = 5
           max_size       = 5
@@ -181,7 +181,7 @@ run "valid_add_after_before_compute" {
       eks_managed_node_groups = [
         {
           name           = "my_scenario-ng"
-          ami_type       = "AL2_x86_64"
+          ami_type       = "AL2023_x86_64_STANDARD"
           instance_types = ["m5a.xlarge"]
           min_size       = 5
           max_size       = 5

--- a/scenarios/perf-eval/apiserver-vn10pod100/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/apiserver-vn10pod100/terraform-inputs/aws.tfvars
@@ -63,7 +63,7 @@ eks_config_list = [{
   eks_managed_node_groups = [
     {
       name           = "idle"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.large"]
       min_size       = 1
       max_size       = 1
@@ -73,7 +73,7 @@ eks_config_list = [{
     },
     {
       name           = "virtualnodes"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.2xlarge"]
       min_size       = 5
       max_size       = 5
@@ -83,7 +83,7 @@ eks_config_list = [{
     },
     {
       name           = "runner"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.4xlarge"]
       min_size       = 3
       max_size       = 3


### PR DESCRIPTION
This pull request updates the Amazon Machine Image (AMI) type for Amazon EKS (Elastic Kubernetes Service) managed node groups across various Terraform modules, test configurations, and performance evaluation scenarios. The changes ensure consistency by upgrading from the `AL2_x86_64` AMI type to the newer `AL2023_x86_64_STANDARD` AMI type.

### Updates to EKS AMI Type:

* **Terraform Module Documentation:**
  - Updated the example configuration in `modules/terraform/aws/eks/README.md` to use the `AL2023_x86_64_STANDARD` AMI type instead of `AL2_x86_64`.

* **Test Configurations:**
  - Modified the AMI type in test files such as `test_eks_machine_type.tftest.hcl`, `test_eks_node_groups.tftest.hcl`, `test_eks_node_groups_subnets.tftest.hcl`, and `test_eks_vpc_config.tftest.hcl` to reflect the new `AL2023_x86_64_STANDARD` AMI type. [[1]](diffhunk://#diff-1b106091258228aa38192ee94d2d3e653b976dc1ef6460533fad771397dff84aL62-R70) [[2]](diffhunk://#diff-d510eb2a3a55b7e7d3c553c9fca75fc15dd64d3e9be6c8497c06db64aefca94dL60-R67) [[3]](diffhunk://#diff-687cc76dfe4eae8d5d4d2bbb17ff54479f64f2ed00a9c1441e3af45450e6af96L67-R75) [[4]](diffhunk://#diff-3cdfe68c32ee39fea7c49a7e5fbe9e9792f884e6c431193485f28a59a58cc499L68-R68) [[5]](diffhunk://#diff-3cdfe68c32ee39fea7c49a7e5fbe9e9792f884e6c431193485f28a59a58cc499L106-R106) [[6]](diffhunk://#diff-3cdfe68c32ee39fea7c49a7e5fbe9e9792f884e6c431193485f28a59a58cc499L146-R146) [[7]](diffhunk://#diff-3cdfe68c32ee39fea7c49a7e5fbe9e9792f884e6c431193485f28a59a58cc499L184-R184)

* **Performance Evaluation Scenarios:**
  - Updated the AMI type in performance evaluation configurations under `scenarios/perf-eval/apiserver-vn10pod100/terraform-inputs/aws.tfvars` for multiple node groups (e.g., `idle`, `virtualnodes`, and `runner`). [[1]](diffhunk://#diff-7d4848afcdcae41aa65f57e05675b70e57b34cf0fab531f205e01c9613eac829L66-R66) [[2]](diffhunk://#diff-7d4848afcdcae41aa65f57e05675b70e57b34cf0fab531f205e01c9613eac829L76-R76) [[3]](diffhunk://#diff-7d4848afcdcae41aa65f57e05675b70e57b34cf0fab531f205e01c9613eac829L86-R86)