### PR TITLE
Implement EKS Auto Mode configuration and add related test cases

### DIFF
--- a/modules/terraform/aws/eks/output.tf
+++ b/modules/terraform/aws/eks/output.tf
@@ -27,3 +27,13 @@ output "eks_node_groups" {
   description = "Used for unit tests"
   value       = aws_eks_node_group.eks_managed_node_groups
 }
+
+output "eks_cluster" {
+  description = "Used for unit tests"
+  value       = aws_eks_cluster.eks
+}
+
+output "eks_role_policy_attachments" {
+  description = "Used for unit tests"
+  value       = aws_iam_role_policy_attachment.policy_attachments
+}

--- a/modules/terraform/aws/eks/variables.tf
+++ b/modules/terraform/aws/eks/variables.tf
@@ -40,6 +40,7 @@ variable "eks_config" {
     enable_cluster_autoscaler = optional(bool, false)
     vpc_name                  = string
     policy_arns               = list(string)
+    auto_mode                 = optional(bool, false)
     eks_managed_node_groups = list(object({
       name           = string
       ami_type       = string

--- a/modules/terraform/aws/tests/data.tfmock.hcl
+++ b/modules/terraform/aws/tests/data.tfmock.hcl
@@ -8,7 +8,7 @@ override_data {
         "Principal": {
           "Service": ["eks.amazonaws.com", "ec2.amazonaws.com"]
         },
-        "Action": ["sts:AssumeRole"]
+        "Action": ["sts:AssumeRole", "sts:TagSession"]
       }]
     } 
     EOT

--- a/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
@@ -1,0 +1,128 @@
+variables {
+  scenario_type  = "perf-eval"
+  scenario_name  = "my_scenario"
+  deletion_delay = "2h"
+  owner          = "aks"
+  json_input = {
+    "run_id" : "123456789",
+    "region" : "us-east-1",
+    "creation_time" : "2024-11-12T16:39:54Z"
+  }
+
+  network_config_list = [
+    {
+      role           = "my-role"
+      vpc_name       = "my-vpc"
+      vpc_cidr_block = "10.0.0.0/16"
+      subnet = [
+        {
+          name                    = "my-subnet"
+          cidr_block              = "10.0.32.0/19"
+          zone_suffix             = "a"
+          map_public_ip_on_launch = true
+        }
+      ]
+      security_group_name = "my-sg"
+      route_tables = [
+        {
+          name       = "internet-rt"
+          cidr_block = "0.0.0.0/0"
+        }
+      ],
+      route_table_associations = [
+        {
+          name             = "my-subnet-rt-assoc"
+          subnet_name      = "my-subnet"
+          route_table_name = "internet-rt"
+        }
+      ]
+      sg_rules = {
+        ingress = []
+        egress = [
+          {
+            from_port  = 0
+            to_port    = 0
+            protocol   = "-1"
+            cidr_block = "0.0.0.0/0"
+          }
+        ]
+      }
+    }
+  ]
+
+  eks_config_list = [{
+    role                    = "my-role"
+    eks_name                = "auto_mode_true"
+    vpc_name                = "my-vpc"
+    auto_mode               = true
+    policy_arns             = ["AmazonEKS_CNI_Policy"]
+    eks_managed_node_groups = []
+    eks_addons              = []
+    }, {
+    role                    = "my-role"
+    eks_name                = "auto_mode_false"
+    vpc_name                = "my-vpc"
+    auto_mode               = false
+    policy_arns             = ["AmazonEKS_CNI_Policy"]
+    eks_managed_node_groups = []
+    eks_addons              = []
+  }]
+}
+
+run "eks_auto_mode_enabled" {
+
+  command = plan
+
+  # Define the assertions to validate the resources
+  assert {
+    condition     = module.eks["auto_mode_true"].eks_cluster.bootstrap_self_managed_addons == false
+    error_message = "EKS Auto Mode should disable self-managed addons"
+  }
+
+  assert {
+    condition     = module.eks["auto_mode_true"].eks_cluster.compute_config[0].enabled == true
+    error_message = "EKS Auto Mode should enable compute_config"
+  }
+
+  assert {
+    condition     = module.eks["auto_mode_true"].eks_cluster.storage_config[0].block_storage[0].enabled == true
+    error_message = "EKS Auto Mode should enable block storage"
+  }
+
+  assert {
+    condition     = module.eks["auto_mode_true"].eks_cluster.kubernetes_network_config[0].elastic_load_balancing[0].enabled == true
+    error_message = "EKS Auto Mode should enable elastic load balancing"
+  }
+
+  assert {
+    condition     = alltrue([for item in ["AmazonEKSBlockStoragePolicy", "AmazonEKSComputePolicy", "AmazonEKSLoadBalancingPolicy", "AmazonEKSNetworkingPolicy"] : contains(keys(module.eks["auto_mode_true"].eks_role_policy_attachments), item)])
+    error_message = "EKS Auto Mode should attach both AmazonEKSBlockStoragePolicy and AmazonEKSComputePolicy"
+  }
+
+  expect_failures = [check.deletion_due_time]
+}
+
+run "eks_auto_mode_disabled" {
+  command = plan
+
+  # Define the assertions to validate the resources
+  assert {
+    condition     = module.eks["auto_mode_false"].eks_cluster.bootstrap_self_managed_addons == true
+    error_message = "EKS Auto Mode should enable self-managed addons when disabled"
+  }
+
+  assert {
+    condition     = length(module.eks["auto_mode_false"].eks_cluster.compute_config) == 0
+    error_message = "EKS Auto Mode should not enable compute_config when disabled"
+  }
+
+  assert {
+    condition     = length(module.eks["auto_mode_false"].eks_cluster.storage_config) == 0
+    error_message = "EKS Auto Mode should not enable block storage when disabled"
+  }
+
+
+  # note: kubernetes_network_config.elastic_load_balancing.enabled is unknown during planing
+
+  expect_failures = [check.deletion_due_time]
+}

--- a/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
@@ -96,7 +96,7 @@ run "eks_auto_mode_enabled" {
 
   assert {
     condition     = alltrue([for item in ["AmazonEKSBlockStoragePolicy", "AmazonEKSComputePolicy", "AmazonEKSLoadBalancingPolicy", "AmazonEKSNetworkingPolicy"] : contains(keys(module.eks["auto_mode_true"].eks_role_policy_attachments), item)])
-    error_message = "EKS Auto Mode should attach both AmazonEKSBlockStoragePolicy and AmazonEKSComputePolicy"
+    error_message = "EKS Auto Mode should attach AmazonEKSBlockStoragePolicy, AmazonEKSComputePolicy, AmazonEKSLoadBalancingPolicy, and AmazonEKSNetworkingPolicy"
   }
 
   expect_failures = [check.deletion_due_time]

--- a/modules/terraform/aws/variables.tf
+++ b/modules/terraform/aws/variables.tf
@@ -109,6 +109,7 @@ variable "eks_config_list" {
     policy_arns               = list(string)
     enable_karpenter          = optional(bool, false)
     enable_cluster_autoscaler = optional(bool, false)
+    auto_mode                 = optional(bool, false)
     eks_managed_node_groups = list(object({
       name           = string
       ami_type       = string

--- a/scenarios/perf-eval/cluster-automatic/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cluster-automatic/terraform-inputs/aws.tfvars
@@ -1,0 +1,80 @@
+scenario_type  = "perf-eval"
+scenario_name  = "cluster-automatic"
+deletion_delay = "2h"
+owner          = "aks"
+network_config_list = [
+  {
+    role           = "automatic"
+    vpc_name       = "automatic-vpc"
+    vpc_cidr_block = "10.0.0.0/16"
+    subnet = [
+      {
+        name                    = "automatic-subnet"
+        cidr_block              = "10.0.32.0/19"
+        zone_suffix             = "a"
+        map_public_ip_on_launch = true
+      },
+      {
+        name                    = "automatic-subnet-2"
+        cidr_block              = "10.0.64.0/19"
+        zone_suffix             = "b"
+        map_public_ip_on_launch = true
+      }
+    ]
+    security_group_name = "automatic-sg"
+    route_tables = [
+      {
+        name       = "internet-rt"
+        cidr_block = "0.0.0.0/0"
+      }
+    ],
+    route_table_associations = [
+      {
+        name             = "automatic-subnet-rt-assoc"
+        subnet_name      = "automatic-subnet"
+        route_table_name = "internet-rt"
+      },
+      {
+        name             = "automatic-subnet-rt-assoc-2"
+        subnet_name      = "automatic-subnet-2"
+        route_table_name = "internet-rt"
+      }
+    ]
+    sg_rules = {
+      ingress = [
+        {
+          from_port  = 80
+          to_port    = 80
+          protocol   = "tcp"
+          cidr_block = "0.0.0.0/0"
+        }
+      ]
+      egress = [
+        {
+          from_port  = 0
+          to_port    = 0
+          protocol   = "-1"
+          cidr_block = "0.0.0.0/0"
+        }
+      ]
+    }
+  }
+]
+
+eks_config_list = [{
+  role        = "automatic"
+  eks_name    = "automatic"
+  vpc_name    = "automatic-vpc"
+  policy_arns = [
+    "AmazonEKSClusterPolicy", 
+    "AmazonEKSVPCResourceController", 
+    "AmazonEKSWorkerNodePolicy", 
+    "AmazonEKS_CNI_Policy", 
+    "AmazonEC2ContainerRegistryReadOnly", 
+    "AmazonSSMManagedInstanceCore"
+  ]
+  auto_mode   = true
+  eks_managed_node_groups = []
+  eks_addons         = [{ name = "vpc-cni" }]
+  kubernetes_version = "1.32"
+}]

--- a/scenarios/perf-eval/cluster-automatic/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cluster-automatic/terraform-inputs/aws.tfvars
@@ -62,19 +62,19 @@ network_config_list = [
 ]
 
 eks_config_list = [{
-  role        = "automatic"
-  eks_name    = "automatic"
-  vpc_name    = "automatic-vpc"
+  role     = "automatic"
+  eks_name = "automatic"
+  vpc_name = "automatic-vpc"
   policy_arns = [
-    "AmazonEKSClusterPolicy", 
-    "AmazonEKSVPCResourceController", 
-    "AmazonEKSWorkerNodePolicy", 
-    "AmazonEKS_CNI_Policy", 
-    "AmazonEC2ContainerRegistryReadOnly", 
+    "AmazonEKSClusterPolicy",
+    "AmazonEKSVPCResourceController",
+    "AmazonEKSWorkerNodePolicy",
+    "AmazonEKS_CNI_Policy",
+    "AmazonEC2ContainerRegistryReadOnly",
     "AmazonSSMManagedInstanceCore"
   ]
-  auto_mode   = true
+  auto_mode               = true
   eks_managed_node_groups = []
-  eks_addons         = [{ name = "vpc-cni" }]
-  kubernetes_version = "1.32"
+  eks_addons              = [{ name = "vpc-cni" }]
+  kubernetes_version      = "1.32"
 }]

--- a/scenarios/perf-eval/cluster-automatic/terraform-test-inputs/aws.json
+++ b/scenarios/perf-eval/cluster-automatic/terraform-test-inputs/aws.json
@@ -1,0 +1,5 @@
+{
+    "run_id"                           : "123456789",
+    "region"                           : "us-east-2",
+    "k8s_machine_type"                 : "m7i.12xlarge"
+}


### PR DESCRIPTION
This pull request introduces support for EKS Auto Mode in the Terraform module for AWS EKS. The changes include updates to configuration variables, resource definitions, IAM policies, outputs, and test scenarios to enable and validate this feature. EKS Auto Mode simplifies cluster management by automating the configuration of compute, storage, and networking resources.

### EKS Auto Mode Implementation:

* **Configuration Updates**:
  - Added the `auto_mode` variable to `eks_config` and `eks_config_list` to toggle EKS Auto Mode. [[1]](diffhunk://#diff-8abbc84758137371997b88238369c9fd9f08384fc96dc0932a3841a66cdf83abR43) [[2]](diffhunk://#diff-9bd8d786978d8f7797b6b7bb3cf1d957ceab3be62c9fb17ec3ad6a3ee53f22caR112)
  - Updated `policy_arns` to include EKS Auto Mode-specific policies when `auto_mode` is enabled.

* **Resource Definition Changes**:
  - Modified `aws_eks_cluster` to conditionally enable `compute_config`, `storage_config`, and `kubernetes_network_config` when `auto_mode` is true. Also disabled `bootstrap_self_managed_addons` in Auto Mode.
  - Added `sts:TagSession` to IAM policy actions to support EKS Auto Mode. [[1]](diffhunk://#diff-fd5dd7320a4e52fded4d41f24c016f50020f4b1ce1578d83fec5442c437e09ebL88-R98) [[2]](diffhunk://#diff-abfc1891321e5fe9b8f3f6368dbfe6db99cece019daad58d1495e94e9ff89d02L11-R11)

### Testing and Validation:

* **Unit Test Enhancements**:
  - Added outputs for `eks_cluster` and `eks_role_policy_attachments` to facilitate unit testing.
  - Introduced `test_eks_auto_mode.tftest.hcl` to validate EKS Auto Mode behavior, including assertions for resource configurations and attached policies.

* **Performance Evaluation Scenarios**:
  - Created new test inputs (`aws.tfvars` and `aws.json`) for performance evaluation of clusters with EKS Auto Mode enabled. [[1]](diffhunk://#diff-5cb958355c29302157269bcdf882af22db35ab5a2dbfe151986770e50c4b94cfR1-R80) [[2]](diffhunk://#diff-842a1f617f205294585c3034b4579e9b929b20b3c7c46465fa28d6b8282baaacR1-R5)