### PR TITLE
Resolve: Validate node duplication

### DIFF
--- a/modules/python/clusterloader2/job_controller/job_controller.py
+++ b/modules/python/clusterloader2/job_controller/job_controller.py
@@ -138,9 +138,9 @@ class JobController(ClusterLoader2Base):
             help="Operation timeout to wait for nodes to be ready",
         )
         parser.add_argument(
-            "--label",
+            "--node_label",
             type=str,
-            default="",
+            default=None,
             help="Node label selectors to filter nodes (e.g., 'kubernetes.io/role=worker')",
         )
 

--- a/modules/python/clusterloader2/job_controller/job_controller.py
+++ b/modules/python/clusterloader2/job_controller/job_controller.py
@@ -25,7 +25,7 @@ class JobController(ClusterLoader2Base):
     cl2_override_file: str = ""
     job_count: int = 1000
     job_throughput: int = -1
-    label: str = ""
+    node_label: str = ""
     cl2_image: str = ""
     cl2_config_dir: str = ""
     cl2_report_dir: str = ""
@@ -53,7 +53,7 @@ class JobController(ClusterLoader2Base):
     def validate_clusterloader2(self):
         kube_client = KubernetesClient()
         kube_client.wait_for_nodes_ready(
-            self.node_count, self.operation_timeout_in_minutes, self.label
+            self.node_count, self.operation_timeout_in_minutes, self.node_label
         )
 
     def execute_clusterloader2(self):

--- a/modules/python/tests/test_job_controller.py
+++ b/modules/python/tests/test_job_controller.py
@@ -129,7 +129,7 @@ class TestJobControllerParser(unittest.TestCase):
         validate_args = [a.dest for a in validate_parser._actions if a.dest != "help"]
         self.assertIn("node_count", validate_args)
         self.assertIn("operation_timeout_in_minutes", validate_args)
-        self.assertIn("label", validate_args)
+        self.assertIn("node_label", validate_args)
 
         # Test that execute subparser has expected arguments
         execute_parser = subparsers_action.choices["execute"]

--- a/modules/python/tests/test_job_controller.py
+++ b/modules/python/tests/test_job_controller.py
@@ -37,7 +37,7 @@ class TestJobControllerBenchmark(unittest.TestCase):
         benchmark = JobController(
             node_count=2,
             operation_timeout_in_minutes=600,
-            label="role=worker",
+            node_label="role=worker",
         )
         benchmark.validate_clusterloader2()
         mock_wait_for_nodes_ready.assert_called_once_with(2, 600, "role=worker")

--- a/steps/common/validate_node_count.yml
+++ b/steps/common/validate_node_count.yml
@@ -1,0 +1,28 @@
+parameters:
+  - name: desired_nodes
+    type: number
+  - name: operation_timeout_in_minutes
+    type: number
+    default: 20
+  - name: node_label
+    type: string
+    default: null
+  - name: python_script_file
+    type: string
+  
+steps:
+  - script: |
+      set -eo pipefail
+
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE validate \
+      --node_count $DESIRED_NODES \
+      --operation_timeout_in_minutes $VALIDATION_TIMEOUT \
+      --node_label $NODE_LABEL
+    workingDirectory: modules/python
+    timeoutInMinutes: ${{ parameters.operation_timeout_in_minutes }}
+    displayName: "Validate node count"
+    env:
+      DESIRED_NODES: ${{ parameters.desired_nodes }}
+      VALIDATION_TIMEOUT: ${{ parameters.operation_timeout_in_minutes }}
+      PYTHON_SCRIPT_FILE: ${{ parameters.python_script_file }}
+      NODE_LABEL: ${{ parameters.node_label }}

--- a/steps/common/validate_node_count.yml
+++ b/steps/common/validate_node_count.yml
@@ -1,28 +1,28 @@
 parameters:
-  - name: desired_nodes
-    type: number
-  - name: operation_timeout_in_minutes
-    type: number
-    default: 20
-  - name: node_label
-    type: string
-    default: null
-  - name: python_script_file
-    type: string
-  
-steps:
-  - script: |
-      set -eo pipefail
+- name: desired_nodes
+  type: number
+- name: operation_timeout_in_minutes
+  type: number
+  default: 20
+- name: node_label
+  type: string
+  default: null
+- name: python_script_file
+  type: string
 
-      PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE validate \
-      --node_count $DESIRED_NODES \
-      --operation_timeout_in_minutes $VALIDATION_TIMEOUT \
-      --node_label $NODE_LABEL
-    workingDirectory: modules/python
-    timeoutInMinutes: ${{ parameters.operation_timeout_in_minutes }}
-    displayName: "Validate node count"
-    env:
-      DESIRED_NODES: ${{ parameters.desired_nodes }}
-      VALIDATION_TIMEOUT: ${{ parameters.operation_timeout_in_minutes }}
-      PYTHON_SCRIPT_FILE: ${{ parameters.python_script_file }}
-      NODE_LABEL: ${{ parameters.node_label }}
+steps:
+- script: |
+    set -eo pipefail
+
+    PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE validate \
+    --node_count $DESIRED_NODES \
+    --operation_timeout_in_minutes $VALIDATION_TIMEOUT \
+    --node_label $NODE_LABEL
+  workingDirectory: modules/python
+  timeoutInMinutes: ${{ parameters.operation_timeout_in_minutes }}
+  displayName: "Validate node count"
+  env:
+    DESIRED_NODES: ${{ parameters.desired_nodes }}
+    VALIDATION_TIMEOUT: ${{ parameters.operation_timeout_in_minutes }}
+    PYTHON_SCRIPT_FILE: ${{ parameters.python_script_file }}
+    NODE_LABEL: ${{ parameters.node_label }}

--- a/steps/engine/clusterloader2/job_controller/validate.yml
+++ b/steps/engine/clusterloader2/job_controller/validate.yml
@@ -5,18 +5,9 @@ parameters:
     type: number
     default: 20
 steps:
-  - script: |
-      set -eo pipefail
-
-      PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE validate \
-      --node_count $DESIRED_NODES \
-      --operation_timeout_in_minutes $VALIDATION_TIMEOUT \
-      --label $NODE_LABEL
-    workingDirectory: modules/python
-    timeoutInMinutes: ${{ parameters.operation_timeout_in_minutes }}
-    displayName: "Validate node count"
-    env:
-      DESIRED_NODES: ${{ parameters.desired_nodes }}
-      VALIDATION_TIMEOUT: ${{ parameters.operation_timeout_in_minutes }}
-      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/clusterloader2/job_controller/job_controller.py
-      NODE_LABEL: "default"
+  - template: /steps/common/validate_node_count.yml@self
+    parameters:
+      desired_nodes: ${{ parameters.desired_nodes }}
+      operation_timeout_in_minutes: ${{ parameters.operation_timeout_in_minutes }}
+      python_script_file: $(Pipeline.Workspace)/s/modules/python/clusterloader2/job_controller/job_controller.py
+      node_label: "default"

--- a/steps/engine/clusterloader2/job_controller/validate.yml
+++ b/steps/engine/clusterloader2/job_controller/validate.yml
@@ -1,13 +1,13 @@
 parameters:
-  - name: desired_nodes
-    type: number
-  - name: operation_timeout_in_minutes
-    type: number
-    default: 20
+- name: desired_nodes
+  type: number
+- name: operation_timeout_in_minutes
+  type: number
+  default: 20
 steps:
-  - template: /steps/common/validate_node_count.yml@self
-    parameters:
-      desired_nodes: ${{ parameters.desired_nodes }}
-      operation_timeout_in_minutes: ${{ parameters.operation_timeout_in_minutes }}
-      python_script_file: $(Pipeline.Workspace)/s/modules/python/clusterloader2/job_controller/job_controller.py
-      node_label: "default"
+- template: /steps/common/validate_node_count.yml@self
+  parameters:
+    desired_nodes: ${{ parameters.desired_nodes }}
+    operation_timeout_in_minutes: ${{ parameters.operation_timeout_in_minutes }}
+    python_script_file: $(Pipeline.Workspace)/s/modules/python/clusterloader2/job_controller/job_controller.py
+    node_label: "default"


### PR DESCRIPTION
This PR addresses feedback from @sumanthreddy29 regarding duplicated logic across multiple engines for node validation. Previously, each engine implemented same validation logic independently, leading to unnecessary repetition and maintenance overhead.

To resolve this, this PR added a reusable template that consolidates node count validation. 


<img src="https://github.com/user-attachments/assets/536c8302-d847-40c5-a464-971cc4b9ec2d" width="600" />


TODO: Replace the node count validation logic from the other script into this template once the engine is updated to support named parameters instead of positional ones.