### PR TITLE
Add support for EKS auto mode with node pool configurations

### DIFF
--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -143,7 +143,7 @@ resource "aws_iam_role_policy_attachment" "cw_policy_attachment" {
 }
 
 resource "aws_iam_role" "eks_node_pool_role" {
-  count = var.eks_config.auto_mode && (var.eks_config.node_pool_general_purpose || var.eks_config.node_pool_system) ? 1 : 0
+  count              = var.eks_config.auto_mode && (var.eks_config.node_pool_general_purpose || var.eks_config.node_pool_system) ? 1 : 0
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -184,7 +184,7 @@ resource "aws_eks_cluster" "eks" {
         var.eks_config.node_pool_general_purpose ? ["general-purpose"] : [],
         var.eks_config.node_pool_system ? ["system"] : []
       )
-      node_role_arn =  var.eks_config.node_pool_general_purpose || var.eks_config.node_pool_system ? aws_iam_role.eks_node_pool_role[0].arn : null
+      node_role_arn = var.eks_config.node_pool_general_purpose || var.eks_config.node_pool_system ? aws_iam_role.eks_node_pool_role[0].arn : null
     }
   }
   dynamic "storage_config" {

--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -50,6 +50,11 @@ locals {
     "AmazonEKSNetworkingPolicy"
   ] : []
 
+  node_pools_policies = var.eks_config.auto_mode && (var.eks_config.node_pool_general_purpose || var.eks_config.node_pool_system) ? [
+    "AmazonEKSWorkerNodeMinimalPolicy",
+    "AmazonEC2ContainerRegistryPullOnly",
+  ] : []
+
   policy_arns = concat(var.eks_config.policy_arns, local.auto_mode_policies)
 
   addons_policy_arns  = flatten([for addon in local.eks_addons_map : addon.policy_arns if can(addon.policy_arns)])
@@ -137,6 +142,18 @@ resource "aws_iam_role_policy_attachment" "cw_policy_attachment" {
   role       = aws_iam_role.eks_cluster_role.name
 }
 
+resource "aws_iam_role" "eks_node_pool_role" {
+  count = var.eks_config.auto_mode && (var.eks_config.node_pool_general_purpose || var.eks_config.node_pool_system) ? 1 : 0
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_pools_policy_attachments" {
+  for_each = toset(local.node_pools_policies)
+
+  policy_arn = "arn:aws:iam::aws:policy/${each.value}"
+  role       = aws_iam_role.eks_node_pool_role[0].name
+}
+
 # Create EKS Cluster
 resource "aws_eks_cluster" "eks" {
   name     = local.eks_cluster_name
@@ -163,6 +180,11 @@ resource "aws_eks_cluster" "eks" {
     for_each = var.eks_config.auto_mode ? { "compute_config" : true } : {}
     content {
       enabled = true
+      node_pools = concat(
+        var.eks_config.node_pool_general_purpose ? ["general-purpose"] : [],
+        var.eks_config.node_pool_system ? ["system"] : []
+      )
+      node_role_arn =  var.eks_config.node_pool_general_purpose || var.eks_config.node_pool_system ? aws_iam_role.eks_node_pool_role[0].arn : null
     }
   }
   dynamic "storage_config" {
@@ -183,7 +205,8 @@ resource "aws_eks_cluster" "eks" {
   }
 
   depends_on = [
-    aws_iam_role_policy_attachment.policy_attachments
+    aws_iam_role_policy_attachment.policy_attachments,
+    aws_iam_role_policy_attachment.eks_node_pools_policy_attachments
   ]
 
   tags = {

--- a/modules/terraform/aws/eks/variables.tf
+++ b/modules/terraform/aws/eks/variables.tf
@@ -41,6 +41,8 @@ variable "eks_config" {
     vpc_name                  = string
     policy_arns               = list(string)
     auto_mode                 = optional(bool, false)
+    node_pool_general_purpose = optional(bool, false)
+    node_pool_system          = optional(bool, false)
     eks_managed_node_groups = list(object({
       name           = string
       ami_type       = string

--- a/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
@@ -51,13 +51,15 @@ variables {
   ]
 
   eks_config_list = [{
-    role                    = "my-role"
-    eks_name                = "auto_mode_true"
-    vpc_name                = "my-vpc"
-    auto_mode               = true
-    policy_arns             = ["AmazonEKS_CNI_Policy"]
-    eks_managed_node_groups = []
-    eks_addons              = []
+    role                      = "my-role"
+    eks_name                  = "auto_mode_true"
+    vpc_name                  = "my-vpc"
+    auto_mode                 = true
+    node_pool_general_purpose = true
+    node_pool_system          = true
+    policy_arns               = ["AmazonEKS_CNI_Policy"]
+    eks_managed_node_groups   = []
+    eks_addons                = []
     }, {
     role                    = "my-role"
     eks_name                = "auto_mode_false"
@@ -82,6 +84,11 @@ run "eks_auto_mode_enabled" {
   assert {
     condition     = module.eks["auto_mode_true"].eks_cluster.compute_config[0].enabled == true
     error_message = "EKS Auto Mode should enable compute_config"
+  }
+
+  assert {
+    condition     = sort(module.eks["auto_mode_true"].eks_cluster.compute_config[0].node_pools) == sort(["general-purpose", "system"])
+    error_message = "Node pools in compute config should contain general-purpose and system"
   }
 
   assert {

--- a/modules/terraform/aws/variables.tf
+++ b/modules/terraform/aws/variables.tf
@@ -110,6 +110,8 @@ variable "eks_config_list" {
     enable_karpenter          = optional(bool, false)
     enable_cluster_autoscaler = optional(bool, false)
     auto_mode                 = optional(bool, false)
+    node_pool_general_purpose = optional(bool, false)
+    node_pool_system          = optional(bool, false)
     eks_managed_node_groups = list(object({
       name           = string
       ami_type       = string

--- a/scenarios/perf-eval/cluster-automatic/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cluster-automatic/terraform-inputs/aws.tfvars
@@ -73,8 +73,10 @@ eks_config_list = [{
     "AmazonEC2ContainerRegistryReadOnly",
     "AmazonSSMManagedInstanceCore"
   ]
-  auto_mode               = true
-  eks_managed_node_groups = []
-  eks_addons              = [{ name = "vpc-cni" }]
-  kubernetes_version      = "1.32"
+  auto_mode                 = true
+  node_pool_general_purpose = true
+  node_pool_system          = true
+  eks_managed_node_groups   = []
+  eks_addons                = [{ name = "vpc-cni" }]
+  kubernetes_version        = "1.32"
 }]


### PR DESCRIPTION
Add support for EKS auto mode built-in node pools: general-purpose and system. 

### Enhancements to EKS Cluster Configuration:
* [`modules/terraform/aws/eks/main.tf`](diffhunk://#diff-fd5dd7320a4e52fded4d41f24c016f50020f4b1ce1578d83fec5442c437e09ebR53-R57): Added support for general-purpose and system node pools in auto mode by introducing `node_pools_policies` and creating new IAM roles (`eks_node_pool_role`) and policy attachments (`eks_node_pools_policy_attachments`). Updated `aws_eks_cluster` resource to include `node_pools` and `node_role_arn` fields. [[1]](diffhunk://#diff-fd5dd7320a4e52fded4d41f24c016f50020f4b1ce1578d83fec5442c437e09ebR53-R57) [[2]](diffhunk://#diff-fd5dd7320a4e52fded4d41f24c016f50020f4b1ce1578d83fec5442c437e09ebR145-R156) [[3]](diffhunk://#diff-fd5dd7320a4e52fded4d41f24c016f50020f4b1ce1578d83fec5442c437e09ebR183-R187) [[4]](diffhunk://#diff-fd5dd7320a4e52fded4d41f24c016f50020f4b1ce1578d83fec5442c437e09ebL186-R209)

### Updates to Variables:
* [`modules/terraform/aws/eks/variables.tf`](diffhunk://#diff-8abbc84758137371997b88238369c9fd9f08384fc96dc0932a3841a66cdf83abR44-R45): Added new optional variables `node_pool_general_purpose` and `node_pool_system` to configure node pools in auto mode.
* [`modules/terraform/aws/variables.tf`](diffhunk://#diff-9bd8d786978d8f7797b6b7bb3cf1d957ceab3be62c9fb17ec3ad6a3ee53f22caR113-R114): Extended `eks_config_list` with `node_pool_general_purpose` and `node_pool_system` variables to support node pool configurations.

### Adjustments to Test Cases:
* [`modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl`](diffhunk://#diff-90ba4574efdc1b59287ec73a6fba7282bc726d7c3358ddebd2b373669f1833b1R58-R59): Updated test cases to validate that general-purpose and system node pools are included in the compute configuration when auto mode is enabled. [[1]](diffhunk://#diff-90ba4574efdc1b59287ec73a6fba7282bc726d7c3358ddebd2b373669f1833b1R58-R59) [[2]](diffhunk://#diff-90ba4574efdc1b59287ec73a6fba7282bc726d7c3358ddebd2b373669f1833b1R89-R93)

### Scenario Updates:
* [`scenarios/perf-eval/cluster-automatic/terraform-inputs/aws.tfvars`](diffhunk://#diff-5cb958355c29302157269bcdf882af22db35ab5a2dbfe151986770e50c4b94cfR77-R78): Modified performance evaluation scenarios to enable general-purpose and system node pools in auto mode.