### PR TITLE
Update Terraform Provider Version

### DIFF
--- a/modules/terraform/aws/versions.tf
+++ b/modules/terraform/aws/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "<= 5.89.0"
+      version = "<= 6.2.0"
     }
   }
 }

--- a/modules/terraform/azure/versions.tf
+++ b/modules/terraform/azure/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "<= 4.18.0"
+      version = "<= 4.35.0"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the required provider versions for Terraform modules to ensure compatibility with newer versions of AWS and Azure providers.

Provider version updates:

* [`modules/terraform/aws/versions.tf`](diffhunk://#diff-9c29578937d87994f79600b40d6b6a0219023626d9f4b1f4a045091a2d60b278L6-R6): Updated the `aws` provider version constraint from `<= 5.89.0` to `<= 6.2.0`.
* [`modules/terraform/azure/versions.tf`](diffhunk://#diff-db80da69c1925b208c7e0de8f495645e88cce4aee7e92412bc60cd5aec7c4a06L6-R6): Updated the `azurerm` provider version constraint from `<= 4.18.0` to `<= 4.35.0`.