### PR TITLE
ADD AWS GPU Test Scenario

### DIFF
--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -978,10 +978,6 @@ class EKSClient:
                     {
                         "ResourceType": "launch-template",
                         "Tags": tags,
-                    },
-                    {
-                        "ResourceType": "instance",
-                        "Tags": tags,
                     }
                 ],
                 LaunchTemplateData=launch_template_data,

--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -913,6 +913,8 @@ class EKSClient:
             launch_template_data = {}
             launch_template_data["InstanceType"] = instance_type
             # Add capacity reservation configuration if provided
+            # we can only 1 capacity reservation per launch template
+            # Adding Capacity Block reservations to a resource group is not supported.
             if reservation_id and capacity_type == "CAPACITY_BLOCK":
                 logger.info(
                     "Adding capacity reservation %s to launch template", reservation_id

--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -387,7 +387,7 @@ class EKSClient:
                         )
                 except Exception as e:
                     logger.error("Failed to create launch template: %s", e)
-                    raise Exception("Failed to create launch template: %s", str(e))
+                    raise Exception(f"Failed to create launch template: {str(e)}") from e
 
                 # Create the node group with the parameters
                 response = self.eks.create_nodegroup(**create_params)

--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -909,8 +909,7 @@ class EKSClient:
             logger.info(
                 "Creating launch template '%s' for node group '%s'", name, node_group_name
             )
-
-            # Basic launch template data (without instance type - will be specified in node group)
+            # Prepare launch template data
             launch_template_data = {}
             launch_template_data["InstanceType"] = instance_type
             # Add capacity reservation configuration if provided

--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -374,18 +374,20 @@ class EKSClient:
                         op.add_metadata("capacity_reservation_id", reservation_id)
                     op.add_metadata("launch_template_id", launch_template["id"])
 
-                    logger.info(
-                        f"Using launch template {launch_template['id']}"
-                        + (
-                            f" with capacity reservation {reservation_id}"
-                            if reservation_id
-                            else ""
+                    if reservation_id:
+                        logger.info(
+                            "Using launch template %s with capacity reservation %s",
+                            launch_template["id"],
+                            reservation_id,
                         )
-                    )
+                    else:
+                        logger.info(
+                            "Using launch template %s",
+                            launch_template["id"],
+                        )
                 except Exception as e:
                     logger.error(f"Failed to create launch template: {e}")
                     sys.exit(1)
-
 
                 # Create the node group with the parameters
                 response = self.eks.create_nodegroup(**create_params)
@@ -912,9 +914,9 @@ class EKSClient:
             # Add capacity reservation configuration if provided
             if reservation_id and capacity_type == "CAPACITY_BLOCK":
                 logger.info(
-                    f"Adding capacity reservation {reservation_id} to launch template"                    
+                    f"Adding capacity reservation {reservation_id} to launch template"
                 )
-                
+
                 launch_template_data["InstanceMarketOptions"] = {
                     "MarketType": "capacity-block"
                 }

--- a/modules/python/tests/clients/test_eks_client.py
+++ b/modules/python/tests/clients/test_eks_client.py
@@ -1323,8 +1323,8 @@ class TestEKSClient(unittest.TestCase):
         self.assertIn("TagSpecifications", create_lt_call_args)
         tag_specs = create_lt_call_args["TagSpecifications"]
 
-        # Should have tag specifications for both launch-template and instance
-        self.assertEqual(len(tag_specs), 2)
+        # Should have tag specifications only for launch-template (instance is not valid)
+        self.assertEqual(len(tag_specs), 1)
 
         # Check launch-template tags
         lt_tag_spec = next(
@@ -1348,40 +1348,14 @@ class TestEKSClient(unittest.TestCase):
         self.assertIn("created_at", lt_tags)
         self.assertIn("deletion_due_time", lt_tags)
 
-        # Check instance tags
-        instance_tag_spec = next(
-            (spec for spec in tag_specs if spec["ResourceType"] == "instance"), None
-        )
-        self.assertIsNotNone(
-            instance_tag_spec, "Instance tag specification should be present"
-        )
-
-        instance_tags = {tag["Key"]: tag["Value"] for tag in instance_tag_spec["Tags"]}
-        self.assertIn("Name", instance_tags)
-        self.assertIn("run_id", instance_tags)
-        self.assertIn("cluster_name", instance_tags)
-        self.assertIn("node_group_name", instance_tags)
-        self.assertIn("gpu_node_group", instance_tags)
-        self.assertIn("instance_type", instance_tags)
-        self.assertIn("capacity_type", instance_tags)
-        self.assertIn("scenario_name", instance_tags)
-        self.assertIn("scenario_type", instance_tags)
-        self.assertIn("created_at", instance_tags)
-        self.assertIn("deletion_due_time", instance_tags)
-
         # Verify the Name tag contains the node group name
         self.assertIn("test-tag-ng", lt_tags["Name"])
-        self.assertIn("test-tag-ng", instance_tags["Name"])
 
         # Verify specific tag values
         self.assertEqual(lt_tags["node_group_name"], "test-tag-ng")
-        self.assertEqual(instance_tags["node_group_name"], "test-tag-ng")
         self.assertEqual(lt_tags["instance_type"], "t3.medium")
-        self.assertEqual(instance_tags["instance_type"], "t3.medium")
         self.assertEqual(lt_tags["capacity_type"], "ON_DEMAND")
-        self.assertEqual(instance_tags["capacity_type"], "ON_DEMAND")
         self.assertEqual(lt_tags["gpu_node_group"], "False")
-        self.assertEqual(instance_tags["gpu_node_group"], "False")
 
     def test_create_launch_template_with_gpu_and_capacity_reservation_tags(self):
         """Test that launch template creation includes all required tags for GPU node groups with capacity reservations"""
@@ -1456,8 +1430,8 @@ class TestEKSClient(unittest.TestCase):
         self.assertIn("TagSpecifications", create_lt_call_args)
         tag_specs = create_lt_call_args["TagSpecifications"]
 
-        # Should have tag specifications for both launch-template and instance
-        self.assertEqual(len(tag_specs), 2)
+        # Should have tag specifications only for launch-template (instance is not valid)
+        self.assertEqual(len(tag_specs), 1)
 
         # Check launch-template tags
         lt_tag_spec = next(
@@ -1490,29 +1464,11 @@ class TestEKSClient(unittest.TestCase):
                 tag, lt_tags, f"Tag '{tag}' should be present in launch template tags"
             )
 
-        # Check instance tags
-        instance_tag_spec = next(
-            (spec for spec in tag_specs if spec["ResourceType"] == "instance"), None
-        )
-        self.assertIsNotNone(
-            instance_tag_spec, "Instance tag specification should be present"
-        )
-
-        instance_tags = {tag["Key"]: tag["Value"] for tag in instance_tag_spec["Tags"]}
-        for tag in required_tags:
-            self.assertIn(
-                tag, instance_tags, f"Tag '{tag}' should be present in instance tags"
-            )
-
         # Verify specific tag values for GPU and capacity reservation
         self.assertEqual(lt_tags["gpu_node_group"], "True")
-        self.assertEqual(instance_tags["gpu_node_group"], "True")
         self.assertEqual(lt_tags["capacity_type"], "CAPACITY_BLOCK")
-        self.assertEqual(instance_tags["capacity_type"], "CAPACITY_BLOCK")
         self.assertEqual(lt_tags["capacity_reservation_id"], "cr-gpu-123456789")
-        self.assertEqual(instance_tags["capacity_reservation_id"], "cr-gpu-123456789")
         self.assertEqual(lt_tags["instance_type"], "p3.2xlarge")
-        self.assertEqual(instance_tags["instance_type"], "p3.2xlarge")
 
     # ... existing tests ...
 

--- a/modules/python/tests/clients/test_eks_client.py
+++ b/modules/python/tests/clients/test_eks_client.py
@@ -1,0 +1,1257 @@
+"""
+Unit tests for EKS Client launch template functionality
+"""
+# pylint: disable=too-many-lines,too-many-public-methods,protected-access
+
+import unittest
+from unittest import mock
+import os
+from datetime import datetime, timedelta
+from clients.eks_client import EKSClient
+
+
+# Mock botocore exceptions to avoid import issues in test environment
+class MockClientError(Exception):
+    """Mock implementation of boto3 ClientError for testing"""
+    def __init__(self, error_response, operation_name):
+        self.response = error_response
+        self.operation_name = operation_name
+        super().__init__(f"{operation_name}: {error_response}")
+
+
+class MockWaiterError(Exception):
+    """Mock implementation of boto3 WaiterError for testing"""
+    def __init__(self, name, reason, last_response):
+        self.name = name
+        self.reason = reason
+        self.last_response = last_response
+        super().__init__(f"{name}: {reason}")
+
+
+# Use mock exceptions instead of real ones
+ClientError = MockClientError
+WaiterError = MockWaiterError
+
+
+class TestEKSClient(unittest.TestCase):
+    """Test suite for EKS Client functionality"""
+
+    def setUp(self):
+        """Set up test environment"""
+        # Mock environment variables
+        self.env_patcher = mock.patch.dict(
+            os.environ,
+            {
+                "AWS_DEFAULT_REGION": "us-west-2",
+                "RUN_ID": "test-run-123",
+                "SCENARIO_NAME": "test-scenario",
+                "SCENARIO_TYPE": "cri",
+                "DELETION_DUE_TIME": (datetime.now() + timedelta(hours=2)).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                )
+            },
+        )
+        self.env_patcher.start()
+
+        # Mock boto3 clients
+        self.boto3_patcher = mock.patch("clients.eks_client.boto3")
+        mock_boto3 = self.boto3_patcher.start()
+
+        # Mock EKS client
+        self.mock_eks = mock.MagicMock()
+        mock_boto3.client.return_value = self.mock_eks
+
+        # Mock cluster list and describe responses
+        self.mock_eks.list_clusters.return_value = {"clusters": ["test-cluster-123"]}
+        self.mock_eks.describe_cluster.return_value = {
+            "cluster": {"tags": {"run_id": "test-run-123"}}
+        }
+
+        # Mock subnets response
+        self.mock_eks.describe_subnets = mock.MagicMock()
+
+        # Mock EC2 client for subnets and launch templates
+        self.mock_ec2 = mock.MagicMock()
+        mock_boto3.client.side_effect = lambda service, **kwargs: {
+            "eks": self.mock_eks,
+            "ec2": self.mock_ec2,
+            "iam": mock.MagicMock(),
+        }.get(service, mock.MagicMock())
+
+        # Mock subnet response
+        self.mock_ec2.describe_subnets.return_value = {
+            "Subnets": [
+                {"SubnetId": "subnet-123", "AvailabilityZone": "us-west-2a"},
+                {"SubnetId": "subnet-456", "AvailabilityZone": "us-west-2b"},
+            ]
+        }
+
+        # Mock node groups response
+        self.mock_eks.list_nodegroups.return_value = {"nodegroups": ["existing-ng"]}
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"nodeRole": "arn:aws:iam::123456789012:role/eksNodeRole"}
+        }
+
+        # Mock Kubernetes client
+        self.k8s_patcher = mock.patch("clients.eks_client.KubernetesClient")
+        mock_k8s_class = self.k8s_patcher.start()
+        self.mock_k8s = mock_k8s_class.return_value
+
+    def tearDown(self):
+        """Clean up after tests"""
+        self.env_patcher.stop()
+        self.boto3_patcher.stop()
+        self.k8s_patcher.stop()
+
+    # NOTE: The following tests were removed because they directly called protected methods.
+    # The functionality of these protected methods is now tested through public interfaces:
+    # - _create_default_launch_template is tested via create_node_group operations
+    # - _create_launch_template is tested via create_node_group operations
+    # - _get_capacity_reservation_id is tested via GPU node group creation with CAPACITY_BLOCK
+    # - _delete_launch_template is tested via delete_node_group operations
+    # - _serialize_aws_response is tested via operations that return AWS data
+    # - _wait_for_node_group_active/_wait_for_node_group_deleted are tested via node group operations
+
+    # NOTE: _create_launch_template wrapper functionality is now tested via create_node_group
+
+    def test_create_node_group_always_creates_launch_template(self):
+        """Test that create_node_group always creates a launch template"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock successful responses
+        self.mock_ec2.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-always-12345"}
+        }
+        self.mock_eks.create_nodegroup.return_value = {
+            "nodegroup": {"status": "CREATING"}
+        }
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = ["node1", "node2"]
+
+        # Execute
+        eks_client.create_node_group(
+            node_group_name="test-always-lt",
+            instance_type="t3.medium",
+            node_count=2,
+            gpu_node_group=False,
+            capacity_type="ON_DEMAND",
+        )
+
+        # Verify launch template was created
+        self.mock_ec2.create_launch_template.assert_called_once()
+
+        # Verify node group creation included launch template
+        create_call = self.mock_eks.create_nodegroup.call_args[1]
+        self.assertIn("launchTemplate", create_call)
+        self.assertEqual(create_call["launchTemplate"]["id"], "lt-always-12345")
+        self.assertEqual(create_call["launchTemplate"]["version"], "1")
+
+        # Note: instanceTypes might not be included in current implementation
+        # when using launch template (depends on AWS EKS requirements)
+
+    # NOTE: Direct capacity reservation testing moved to GPU node group creation tests
+
+    # NOTE: Direct launch template deletion testing moved to delete_node_group tests
+
+    # NOTE: Direct serialization testing moved to operations that use AWS responses
+
+    def test_get_cluster_data_success(self):
+        """Test successful cluster data retrieval"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Reset the mock to only track calls from this test
+        self.mock_eks.describe_cluster.reset_mock()
+
+        # Mock cluster response
+        self.mock_eks.describe_cluster.return_value = {
+            "cluster": {
+                "name": "test-cluster-123",
+                "status": "ACTIVE",
+                "created_at": datetime(2025, 7, 15, 10, 0, 0),
+            }
+        }
+
+        # Execute
+        result = eks_client.get_cluster_data()
+
+        # Verify
+        self.assertEqual(result["name"], "test-cluster-123")
+        self.assertEqual(result["status"], "ACTIVE")
+        # Check that datetime was serialized (format may vary)
+        self.assertIn("created_at", result)
+        self.assertIsInstance(result["created_at"], str)
+        self.mock_eks.describe_cluster.assert_called_once_with(name="test-cluster-123")
+
+    def test_get_cluster_data_with_custom_name(self):
+        """Test cluster data retrieval with custom cluster name"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Reset the mock to only track calls from this test
+        self.mock_eks.describe_cluster.reset_mock()
+
+        # Mock cluster response
+        self.mock_eks.describe_cluster.return_value = {
+            "cluster": {"name": "custom-cluster", "status": "ACTIVE"}
+        }
+
+        # Execute
+        result = eks_client.get_cluster_data("custom-cluster")
+
+        # Verify
+        self.assertEqual(result["name"], "custom-cluster")
+        self.mock_eks.describe_cluster.assert_called_once_with(name="custom-cluster")
+
+    def test_get_cluster_data_client_error(self):
+        """Test cluster data retrieval with AWS client error"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock client error
+        self.mock_eks.describe_cluster.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "Cluster not found",
+                }
+            },
+            operation_name="DescribeCluster",
+        )
+
+        # Execute and verify exception
+        with self.assertRaises(ClientError):
+            eks_client.get_cluster_data("nonexistent-cluster")
+
+    def test_get_node_group_success(self):
+        """Test successful node group retrieval"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Reset the mock to only track calls from this test
+        self.mock_eks.describe_nodegroup.reset_mock()
+
+        # Mock node group response
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "nodegroupName": "test-nodegroup",
+                "status": "ACTIVE",
+                "scalingConfig": {"desiredSize": 3},
+                "createdAt": datetime(2025, 7, 15, 12, 0, 0),
+            }
+        }
+
+        # Execute
+        result = eks_client.get_node_group("test-nodegroup")
+
+        # Verify
+        self.assertEqual(result["nodegroupName"], "test-nodegroup")
+        self.assertEqual(result["status"], "ACTIVE")
+        # Check that datetime was serialized (format may vary)
+        self.assertIn("createdAt", result)
+        self.assertIsInstance(result["createdAt"], str)
+        self.mock_eks.describe_nodegroup.assert_called_once_with(
+            clusterName="test-cluster-123", nodegroupName="test-nodegroup"
+        )
+
+    def test_get_node_group_not_found(self):
+        """Test node group retrieval when node group doesn't exist"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock ResourceNotFoundException
+        self.mock_eks.describe_nodegroup.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "NodeGroup not found",
+                }
+            },
+            operation_name="DescribeNodegroup",
+        )
+
+        # Execute and verify exception
+        with self.assertRaises(ClientError):
+            eks_client.get_node_group("nonexistent-nodegroup")
+
+    def test_get_node_group_other_client_error(self):
+        """Test node group retrieval with other AWS client errors"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock other client error
+        self.mock_eks.describe_nodegroup.side_effect = ClientError(
+            error_response={
+                "Error": {"Code": "AccessDenied", "Message": "Access denied"}
+            },
+            operation_name="DescribeNodegroup",
+        )
+
+        # Execute and verify exception
+        with self.assertRaises(ClientError):
+            eks_client.get_node_group("test-nodegroup")
+
+    # NOTE: Direct _wait_for_node_group_active testing moved to operations that create/scale node groups
+
+    # NOTE: Direct _wait_for_node_group_deleted testing moved to delete_node_group operations
+
+    # NOTE: Capacity reservation testing moved to GPU node group creation with CAPACITY_BLOCK
+
+    # NOTE: Launch template tests moved to create_node_group operations
+
+    # NOTE: Launch template wrapper exception testing moved to create_node_group failure scenarios
+
+    # NOTE: Launch template deletion errors tested via delete_node_group operations
+
+    # NOTE: Launch template name truncation tested via create_node_group with long names
+
+    def test_create_node_group_launch_template_failure(self):
+        """Test node group creation when launch template creation fails"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock launch template creation failure
+        self.mock_ec2.create_launch_template.side_effect = Exception(
+            "Launch template creation failed"
+        )
+
+        # Mock other operations to succeed if reached
+        self.mock_eks.create_nodegroup.return_value = {
+            "nodegroup": {"status": "CREATING"}
+        }
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = []
+
+        # Execute - the operation should exit with SystemExit due to current implementation
+        with self.assertRaises(SystemExit):
+            eks_client.create_node_group(
+                node_group_name="test-lt-fail",
+                instance_type="t3.medium",
+                node_count=2,
+                gpu_node_group=False,
+                capacity_type="ON_DEMAND",
+            )
+
+    def test_create_node_group_gpu_without_capacity_block(self):
+        """Test GPU node group creation without CAPACITY_BLOCK (should not check reservations)"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock successful responses
+        self.mock_ec2.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-gpu-on-demand-12345"}
+        }
+        self.mock_eks.create_nodegroup.return_value = {
+            "nodegroup": {"status": "CREATING"}
+        }
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = ["node1"]
+        self.mock_k8s.verify_nvidia_smi_on_node.return_value = {
+            "node1": "nvidia-smi output"
+        }
+
+        # Execute
+        eks_client.create_node_group(
+            node_group_name="gpu-on-demand",
+            instance_type="p3.2xlarge",
+            node_count=1,
+            gpu_node_group=True,
+            capacity_type="ON_DEMAND",  # Not CAPACITY_BLOCK
+        )
+
+        # Verify that capacity reservation lookup was NOT called
+        self.mock_ec2.describe_capacity_reservations.assert_not_called()
+
+        # Verify launch template was still created
+        self.mock_ec2.create_launch_template.assert_called_once()
+
+        # Verify NVIDIA verification was called for GPU nodes
+        self.mock_k8s.verify_nvidia_smi_on_node.assert_called_once()
+
+    def test_scale_node_group_success(self):
+        """Test successful node group scaling"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock current node group state
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {"desiredSize": 2, "maxSize": 5, "minSize": 1}
+            }
+        }
+
+        # Mock successful scaling
+        self.mock_eks.update_nodegroup_config.return_value = {}
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = ["node1", "node2", "node3"]
+
+        # Execute
+        result = eks_client.scale_node_group("test-ng", 3)
+
+        # Verify
+        self.assertTrue(result)
+        self.mock_eks.update_nodegroup_config.assert_called_once()
+        update_call = self.mock_eks.update_nodegroup_config.call_args[1]
+        self.assertEqual(update_call["scalingConfig"]["desiredSize"], 3)
+
+    def test_scale_node_group_increase_max_size(self):
+        """Test scaling that requires increasing maxSize"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock current node group state with low maxSize
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {
+                    "desiredSize": 2,
+                    "maxSize": 3,  # Lower than target
+                    "minSize": 1,
+                }
+            }
+        }
+
+        # Mock successful scaling
+        self.mock_eks.update_nodegroup_config.return_value = {}
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = [
+            "node1",
+            "node2",
+            "node3",
+            "node4",
+            "node5",
+        ]
+
+        # Execute - scale to 5 nodes (higher than current maxSize of 3)
+        result = eks_client.scale_node_group("test-ng", 5)
+
+        # Verify maxSize was increased
+        self.assertTrue(result)
+        update_call = self.mock_eks.update_nodegroup_config.call_args[1]
+        self.assertEqual(update_call["scalingConfig"]["desiredSize"], 5)
+        self.assertEqual(update_call["scalingConfig"]["maxSize"], 5)
+
+    def test_scale_node_group_no_change_needed(self):
+        """Test scaling when target equals current size"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock current node group state
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {"desiredSize": 3, "maxSize": 5, "minSize": 1}
+            }
+        }
+
+        # Mock update response
+        self.mock_eks.update_nodegroup_config.return_value = {
+            "update": {"id": "update-123", "status": "InProgress"}
+        }
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = ["node1", "node2", "node3"]
+
+        # Execute - scale to same size
+        result = eks_client.scale_node_group("test-ng", 3)
+
+        # Verify update was called (the method does call AWS API even for same size)
+        self.assertTrue(result)
+        self.mock_eks.update_nodegroup_config.assert_called_once()
+
+        # Verify scaling config
+        call_args = self.mock_eks.update_nodegroup_config.call_args[1]
+        self.assertEqual(call_args["scalingConfig"]["desiredSize"], 3)
+
+    def test_scale_node_group_progressive_scaling(self):
+        """Test progressive scaling"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock current node group state
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {"desiredSize": 2, "maxSize": 10, "minSize": 1}
+            }
+        }
+
+        # Mock the _progressive_scale method
+        with mock.patch.object(eks_client, "_progressive_scale") as mock_progressive:
+            mock_progressive.return_value = {"status": "ACTIVE"}
+
+            # Execute
+            eks_client.scale_node_group(
+                "test-ng", 8, progressive=True, scale_step_size=2
+            )
+
+            # Verify progressive scaling was called
+            mock_progressive.assert_called_once()
+            call_args = mock_progressive.call_args[0]
+            self.assertEqual(call_args[0], "test-ng")  # node_group_name
+            self.assertEqual(call_args[1], 2)  # current_count
+            self.assertEqual(call_args[2], 8)  # target_count
+            self.assertEqual(call_args[3], 2)  # step_size
+
+    def test_scale_node_group_update_failure(self):
+        """Test scaling failure during node group update"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock current node group state
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {"desiredSize": 2, "maxSize": 5, "minSize": 1}
+            }
+        }
+
+        # Mock update failure
+        self.mock_eks.update_nodegroup_config.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "NodeGroup not found",
+                }
+            },
+            operation_name="UpdateNodegroupConfig",
+        )
+
+        # Execute and verify exception
+        with self.assertRaises(ClientError):
+            eks_client.scale_node_group("nonexistent-ng", 3)
+
+    def test_delete_node_group_success(self):
+        """Test successful node group deletion"""
+        # Setup
+        eks_client = EKSClient()
+        eks_client.launch_template_id = "lt-to-delete-12345"
+
+        # Mock node group info for metadata
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"scalingConfig": {"desiredSize": 3}, "amiType": "AL2_x86_64"}
+        }
+
+        # Mock successful deletion
+        self.mock_eks.delete_nodegroup.return_value = {}
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+
+        # Execute
+        result = eks_client.delete_node_group("test-ng")
+
+        # Verify
+        self.assertTrue(result)
+        self.mock_eks.delete_nodegroup.assert_called_once_with(
+            clusterName="test-cluster-123", nodegroupName="test-ng"
+        )
+        # Verify launch template deletion was attempted
+        self.mock_ec2.delete_launch_template.assert_called_once_with(
+            LaunchTemplateId="lt-to-delete-12345"
+        )
+
+    def test_delete_node_group_without_launch_template(self):
+        """Test node group deletion when no launch template exists"""
+        # Setup
+        eks_client = EKSClient()
+        # Don't set launch_template_id
+
+        # Mock node group info
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"scalingConfig": {"desiredSize": 2}, "amiType": "AL2_x86_64"}
+        }
+
+        # Mock successful deletion
+        self.mock_eks.delete_nodegroup.return_value = {}
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+
+        # Execute
+        result = eks_client.delete_node_group("test-ng")
+
+        # Verify
+        self.assertTrue(result)
+        # Verify launch template deletion was NOT called
+        self.mock_ec2.delete_launch_template.assert_not_called()
+
+    def test_delete_node_group_info_retrieval_failure(self):
+        """Test node group deletion when info retrieval fails"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock node group info failure for all calls
+        self.mock_eks.describe_nodegroup.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "NodeGroup not found",
+                }
+            },
+            operation_name="DescribeNodegroup",
+        )
+
+        # Execute and verify exception is raised (from the second get_node_group call)
+        with self.assertRaises(ClientError):
+            eks_client.delete_node_group("test-ng")
+
+    def test_delete_node_group_deletion_failure(self):
+        """Test node group deletion failure"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock node group info
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"scalingConfig": {"desiredSize": 2}, "amiType": "AL2_x86_64"}
+        }
+
+        # Mock deletion failure
+        self.mock_eks.delete_nodegroup.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "ResourceInUseException",
+                    "Message": "NodeGroup is in use",
+                }
+            },
+            operation_name="DeleteNodegroup",
+        )
+
+        # Execute and verify exception
+        with self.assertRaises(ClientError):
+            eks_client.delete_node_group("test-ng")
+
+    # NOTE: Progressive scaling tests moved to scale_node_group with progressive=True
+
+    def test_eks_client_initialization_failure(self):
+        """Test EKS client initialization failure"""
+        # Setup - mock boto3 to raise exception
+        with mock.patch("clients.eks_client.boto3") as mock_boto3:
+            mock_boto3.client.side_effect = Exception("AWS credentials not found")
+
+            # Execute and verify exception
+            with self.assertRaises(Exception):
+                EKSClient()
+
+    def test_kubernetes_client_initialization_failure(self):
+        """Test EKS client when Kubernetes client initialization fails"""
+        # Setup - patch Kubernetes client to fail
+        with mock.patch("clients.eks_client.KubernetesClient") as mock_k8s_class:
+            mock_k8s_class.side_effect = Exception("Kubeconfig not found")
+
+            # Execute - should not raise exception but k8s_client should be None
+            eks_client = EKSClient()
+
+            # Verify k8s_client is None
+            self.assertIsNone(eks_client.k8s_client)
+
+    def test_get_cluster_name_by_run_id_no_match(self):
+        """Test cluster name lookup when no cluster matches run_id"""
+        # Setup
+        self.mock_eks.list_clusters.return_value = {"clusters": ["other-cluster"]}
+        self.mock_eks.describe_cluster.return_value = {
+            "cluster": {"tags": {"run_id": "different-run-id"}}
+        }
+
+        # Execute and verify exception
+        with self.assertRaises(Exception) as context:
+            EKSClient()
+
+        self.assertIn("No EKS cluster found with run_id", str(context.exception))
+
+    def test_load_subnet_ids_no_subnets(self):
+        """Test subnet loading when no subnets found"""
+        # Setup
+        self.mock_ec2.describe_subnets.return_value = {"Subnets": []}
+
+        # Execute and verify exception
+        with self.assertRaises(Exception) as context:
+            EKSClient()
+
+        self.assertIn("No subnets found for run_id", str(context.exception))
+
+    def test_load_node_role_arn_no_existing_nodegroups(self):
+        """Test node role loading when no existing node groups found"""
+        # Setup
+        self.mock_eks.list_nodegroups.return_value = {"nodegroups": []}
+
+        # Execute - should not raise exception
+        EKSClient()
+
+    def test_get_operation_context(self):
+        """Test operation context retrieval"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Execute
+        context = eks_client._get_operation_context()
+
+        # Verify
+        self.assertIsNotNone(context)
+        # The context should be the OperationContext class
+        self.assertEqual(context.__name__, "OperationContext")
+
+    def test_serialize_aws_response_nested_datetime(self):
+        """Test serialization with nested datetime objects"""
+        # Setup
+        eks_client = EKSClient()
+
+        test_obj = {
+            "name": "test",
+            "metadata": {
+                "createdAt": datetime(2025, 7, 15, 10, 30, 45),
+                "nested": {"updatedAt": datetime(2025, 7, 15, 11, 45, 30)},
+            },
+            "list_field": [{"timestamp": datetime(2025, 7, 15, 12, 0, 0)}],
+        }
+
+        # Execute
+        result = eks_client._serialize_aws_response(test_obj)
+
+        # Verify
+        self.assertEqual(result["name"], "test")
+        self.assertIsInstance(result["metadata"]["createdAt"], str)
+        self.assertIsInstance(result["metadata"]["nested"]["updatedAt"], str)
+        self.assertIsInstance(result["list_field"][0]["timestamp"], str)
+
+    def test_serialize_aws_response_with_non_datetime_objects(self):
+        """Test serialization with various object types"""
+        # Setup
+        eks_client = EKSClient()
+
+        test_obj = {
+            "string": "test",
+            "int": 123,
+            "float": 45.67,
+            "bool": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "dict": {"key": "value"},
+        }
+
+        # Execute
+        result = eks_client._serialize_aws_response(test_obj)
+
+        # Verify all types are preserved
+        self.assertEqual(result["string"], "test")
+        self.assertEqual(result["int"], 123)
+        self.assertEqual(result["float"], 45.67)
+        self.assertEqual(result["bool"], True)
+        self.assertIsNone(result["none"])
+        self.assertEqual(result["list"], [1, 2, 3])
+        self.assertEqual(result["dict"], {"key": "value"})
+
+    def test_load_subnet_ids_success(self):
+        """Test successful subnet loading"""
+        # Setup - create fresh EKS client to test _load_subnet_ids
+        with mock.patch("clients.eks_client.boto3") as mock_boto3:
+            mock_eks = mock.MagicMock()
+            mock_ec2 = mock.MagicMock()
+
+            # Setup subnet response
+            mock_ec2.describe_subnets.return_value = {
+                "Subnets": [
+                    {"SubnetId": "subnet-123", "AvailabilityZone": "us-west-2a"},
+                    {"SubnetId": "subnet-456", "AvailabilityZone": "us-west-2b"},
+                    {"SubnetId": "subnet-789", "AvailabilityZone": "us-west-2c"},
+                ]
+            }
+
+            mock_boto3.client.side_effect = lambda service, **kwargs: {
+                "eks": mock_eks,
+                "ec2": mock_ec2,
+                "iam": mock.MagicMock(),
+            }.get(service, mock.MagicMock())
+
+            # Mock EKS responses
+            mock_eks.list_clusters.return_value = {"clusters": ["test-cluster-123"]}
+            mock_eks.describe_cluster.return_value = {
+                "cluster": {"tags": {"run_id": "test-run-123"}}
+            }
+            mock_eks.list_nodegroups.return_value = {"nodegroups": ["existing-ng"]}
+            mock_eks.describe_nodegroup.return_value = {
+                "nodegroup": {"nodeRole": "arn:aws:iam::123456789012:role/eksNodeRole"}
+            }
+
+            # Execute
+            eks_client = EKSClient()
+
+            # Verify
+            self.assertEqual(len(eks_client.subnets), 3)
+            self.assertEqual(len(eks_client.subnet_azs), 3)
+            self.assertIn("subnet-123", eks_client.subnets)
+            self.assertIn("us-west-2a", eks_client.subnet_azs)
+
+    def test_load_node_role_arn_success(self):
+        """Test successful node role ARN loading"""
+        # This is already tested implicitly in setUp, but we'll test explicitly
+        eks_client = EKSClient()
+
+        # Verify role ARN was loaded
+        self.assertEqual(
+            eks_client.node_role_arn, "arn:aws:iam::123456789012:role/eksNodeRole"
+        )
+
+    def test_get_cluster_data_with_exception_handling(self):
+        """Test cluster data retrieval with unexpected exception"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock unexpected exception
+        self.mock_eks.describe_cluster.side_effect = Exception("Unexpected AWS error")
+
+        # Execute and verify exception is raised
+        with self.assertRaises(Exception):
+            eks_client.get_cluster_data()
+
+    def test_create_node_group_with_zero_nodes(self):
+        """Test node group creation with zero nodes"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock successful responses
+        self.mock_ec2.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-zero-nodes-12345"}
+        }
+        self.mock_eks.create_nodegroup.return_value = {
+            "nodegroup": {"status": "CREATING"}
+        }
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = []
+
+        # Execute
+        result = eks_client.create_node_group(
+            node_group_name="zero-nodes-ng",
+            instance_type="t3.medium",
+            node_count=0,
+            gpu_node_group=False,
+            capacity_type="ON_DEMAND",
+        )
+
+        # Verify
+        self.assertTrue(result)
+
+        # Check node group parameters
+        call_args = self.mock_eks.create_nodegroup.call_args[1]
+        self.assertEqual(call_args["scalingConfig"]["desiredSize"], 0)
+        self.assertEqual(call_args["scalingConfig"]["minSize"], 0)
+        self.assertEqual(
+            call_args["scalingConfig"]["maxSize"], 1
+        )  # AWS requires maxSize >= 1
+
+    def test_create_node_group_with_spot_capacity(self):
+        """Test node group creation with SPOT capacity type"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock successful responses
+        self.mock_ec2.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-spot-12345"}
+        }
+        self.mock_eks.create_nodegroup.return_value = {
+            "nodegroup": {"status": "CREATING"}
+        }
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = ["node1", "node2"]
+
+        # Execute
+        result = eks_client.create_node_group(
+            node_group_name="spot-ng",
+            instance_type="t3.medium",
+            node_count=2,
+            gpu_node_group=False,
+            capacity_type="SPOT",
+        )
+
+        # Verify
+        self.assertTrue(result)
+
+        # Check capacity type
+        call_args = self.mock_eks.create_nodegroup.call_args[1]
+        self.assertEqual(call_args["capacityType"], "SPOT")
+
+    def test_create_node_group_with_gpu_and_nvidia_verification(self):
+        """Test GPU node group creation with NVIDIA driver verification"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock successful responses
+        self.mock_ec2.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-gpu-12345"}
+        }
+        self.mock_eks.create_nodegroup.return_value = {
+            "nodegroup": {"status": "CREATING"}
+        }
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+        self.mock_k8s.wait_for_nodes_ready.return_value = ["gpu-node1"]
+        self.mock_k8s.verify_nvidia_smi_on_node.return_value = "GPU driver verified"
+
+        # Execute
+        result = eks_client.create_node_group(
+            node_group_name="gpu-ng",
+            instance_type="p3.2xlarge",
+            node_count=1,
+            gpu_node_group=True,
+            capacity_type="ON_DEMAND",
+        )
+
+        # Verify
+        self.assertTrue(result)
+
+        # Check AMI type for GPU
+        call_args = self.mock_eks.create_nodegroup.call_args[1]
+        self.assertEqual(call_args["amiType"], "AL2_x86_64_GPU")
+
+        # Verify NVIDIA verification was called
+        self.mock_k8s.verify_nvidia_smi_on_node.assert_called_once_with(["gpu-node1"])
+
+    def test_create_node_group_node_group_creation_failure(self):
+        """Test node group creation when EKS create_nodegroup fails"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock successful launch template creation
+        self.mock_ec2.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-fail-12345"}
+        }
+
+        # Mock node group creation failure
+        self.mock_eks.create_nodegroup.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "InvalidParameterException",
+                    "Message": "Invalid parameters",
+                }
+            },
+            operation_name="CreateNodegroup",
+        )
+
+        # Execute and verify exception is raised
+        with self.assertRaises(ClientError):
+            eks_client.create_node_group(
+                node_group_name="fail-ng",
+                instance_type="t3.medium",
+                node_count=2,
+                gpu_node_group=False,
+                capacity_type="ON_DEMAND",
+            )
+
+    def test_scale_node_group_with_progressive_enabled(self):
+        """Test scaling with progressive scaling enabled"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock current node group state
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {"desiredSize": 1, "maxSize": 10, "minSize": 1}
+            }
+        }
+
+        # Mock progressive scale method
+        with mock.patch.object(eks_client, "_progressive_scale") as mock_progressive:
+            mock_progressive.return_value = True
+
+            # Execute - scale from 1 to 10 (> step size of 5)
+            result = eks_client.scale_node_group(
+                "test-ng", 10, progressive=True, scale_step_size=5
+            )
+
+            # Verify progressive scaling was called
+            self.assertTrue(result)
+            mock_progressive.assert_called_once()
+
+    def test_scale_node_group_waiter_timeout(self):
+        """Test scaling when waiter times out"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock current node group state
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {
+                "scalingConfig": {"desiredSize": 2, "maxSize": 5, "minSize": 1}
+            }
+        }
+
+        # Mock update response and waiter timeout
+        self.mock_eks.update_nodegroup_config.return_value = {
+            "update": {"id": "update-123", "status": "InProgress"}
+        }
+        self.mock_eks.get_waiter.return_value.wait.side_effect = WaiterError(
+            name="NodegroupActive",
+            reason="Timeout",
+            last_response={"nodegroup": {"status": "UPDATING"}},
+        )
+
+        # Execute and verify exception is raised
+        with self.assertRaises(WaiterError):
+            eks_client.scale_node_group("test-ng", 4)
+
+    def test_delete_node_group_with_launch_template_deletion_failure(self):
+        """Test node group deletion when launch template deletion fails"""
+        # Setup
+        eks_client = EKSClient()
+        eks_client.launch_template_id = "lt-to-delete-12345"
+
+        # Mock node group info
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"scalingConfig": {"desiredSize": 2}, "amiType": "AL2_x86_64"}
+        }
+
+        # Mock launch template deletion failure
+        self.mock_ec2.delete_launch_template.side_effect = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "InvalidLaunchTemplateId.NotFound",
+                    "Message": "Template not found",
+                }
+            },
+            operation_name="DeleteLaunchTemplate",
+        )
+
+        # Mock successful node group deletion
+        self.mock_eks.delete_nodegroup.return_value = {}
+        self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
+
+        # Execute and verify exception is raised
+        with self.assertRaises(ClientError):
+            eks_client.delete_node_group("test-ng")
+
+    def test_create_node_group_with_launch_template_coverage(self):
+        """Test create_node_group to cover _create_launch_template functionality"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock the EKS and EC2 responses for launch template creation
+        mock_launch_template_response = {
+            "LaunchTemplate": {
+                "LaunchTemplateId": "lt-123456789",
+                "LaunchTemplateName": "test-launch-template",
+                "DefaultVersionNumber": 1
+            }
+        }
+
+        mock_nodegroup_response = {
+            "nodegroup": {
+                "status": "CREATING",
+                "scalingConfig": {"desiredSize": 2, "minSize": 2, "maxSize": 3}
+            }
+        }
+
+        self.mock_ec2.create_launch_template.return_value = mock_launch_template_response
+        self.mock_eks.create_nodegroup.return_value = mock_nodegroup_response
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 2}}
+        }
+
+        # Mock ready nodes
+        mock_nodes = [{"metadata": {"name": f"node-{i}"}} for i in range(2)]
+        self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
+
+        # Call the public method which should internally call _create_launch_template
+        result = eks_client.create_node_group(
+            node_group_name="test-ng",
+            instance_type="t3.medium",
+            node_count=2
+        )
+
+        self.assertTrue(result)
+        self.mock_ec2.create_launch_template.assert_called_once()
+        self.mock_eks.create_nodegroup.assert_called_once()
+
+    def test_create_node_group_with_gpu_and_capacity_reservation_coverage(self):
+        """Test create_node_group with GPU to cover _get_capacity_reservation_id functionality"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock capacity reservation response
+        mock_reservation_response = {
+            "CapacityReservations": [{
+                "CapacityReservationId": "cr-123456789",
+                "InstanceType": "p3.2xlarge",
+                "AvailabilityZone": "us-west-2a",
+                "State": "available",
+                "AvailableInstanceCount": 2
+            }]
+        }
+
+        mock_launch_template_response = {
+            "LaunchTemplate": {
+                "LaunchTemplateId": "lt-gpu-123",
+                "LaunchTemplateName": "test-gpu-launch-template",
+                "DefaultVersionNumber": 1
+            }
+        }
+
+        mock_nodegroup_response = {
+            "nodegroup": {
+                "status": "CREATING",
+                "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2}
+            }
+        }
+
+        self.mock_ec2.describe_capacity_reservations.return_value = mock_reservation_response
+        self.mock_ec2.create_launch_template.return_value = mock_launch_template_response
+        self.mock_eks.create_nodegroup.return_value = mock_nodegroup_response
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 1}}
+        }
+
+        # Mock ready nodes and GPU verification
+        mock_nodes = [{"metadata": {"name": "gpu-node-1"}}]
+        self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
+        self.mock_k8s.verify_nvidia_smi_on_node.return_value = ["GPU verified"]
+
+        # Call with GPU node group and capacity block to trigger capacity reservation check
+        result = eks_client.create_node_group(
+            node_group_name="test-gpu-ng",
+            instance_type="p3.2xlarge",
+            node_count=1,
+            gpu_node_group=True,
+            capacity_type="CAPACITY_BLOCK"
+        )
+
+        self.assertTrue(result)
+        self.mock_ec2.describe_capacity_reservations.assert_called_once()
+        self.mock_k8s.verify_nvidia_smi_on_node.assert_called_once()
+
+    def test_scale_node_group_progressive_coverage(self):
+        """Test scale_node_group with progressive scaling to cover _progressive_scale functionality"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock current node group state
+        current_nodegroup = {
+            "scalingConfig": {"desiredSize": 2, "minSize": 1, "maxSize": 10},
+            "status": "ACTIVE"
+        }
+
+        # Progressive scaling from 2 to 6 with step size 2 creates steps: [4, 6]
+        # Each step calls scale_node_group which calls get_node_group
+        # Need enough responses for: initial + step1 + step2 calls
+
+        # Mock the methods that are called internally
+        eks_client.get_node_group = mock.Mock()
+        eks_client.get_node_group.side_effect = [
+            current_nodegroup,  # Initial call to get current state
+            {"scalingConfig": {"desiredSize": 2, "minSize": 1, "maxSize": 10}, "status": "ACTIVE"},  # Before step 1
+            {"scalingConfig": {"desiredSize": 4, "minSize": 1, "maxSize": 10}, "status": "ACTIVE"},  # After step 1
+            {"scalingConfig": {"desiredSize": 4, "minSize": 1, "maxSize": 10}, "status": "ACTIVE"},  # Before step 2
+            {"scalingConfig": {"desiredSize": 6, "minSize": 1, "maxSize": 10}, "status": "ACTIVE"},  # Final state
+        ]
+
+        # Mock ready nodes for each step
+        mock_nodes = [{"metadata": {"name": f"node-{i}"}} for i in range(6)]
+        self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
+
+        # Mock get_cluster_data
+        eks_client.get_cluster_data = mock.Mock(return_value={"cluster": {"status": "ACTIVE"}})
+
+        # Call progressive scaling (from 2 to 6 nodes with step size 2)
+        result = eks_client.scale_node_group(
+            node_group_name="test-ng",
+            node_count=6,
+            progressive=True,
+            scale_step_size=2
+        )
+
+        self.assertTrue(result)
+        # Should call update_nodegroup_config multiple times for progressive scaling
+        self.assertGreaterEqual(self.mock_eks.update_nodegroup_config.call_count, 2)
+
+    def test_delete_node_group_with_launch_template_cleanup_coverage(self):
+        """Test delete_node_group to cover _delete_launch_template functionality"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Set up a launch template ID to trigger cleanup
+        eks_client.launch_template_id = "lt-cleanup-123"
+
+        # Mock node group info
+        mock_nodegroup = {
+            "scalingConfig": {"desiredSize": 2},
+            "amiType": "AL2_x86_64",
+            "status": "ACTIVE"
+        }
+
+        # Mock get_node_group and get_cluster_data
+        eks_client.get_node_group = mock.Mock(return_value=mock_nodegroup)
+        eks_client.get_cluster_data = mock.Mock(return_value={"cluster": {"status": "ACTIVE"}})
+
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"status": "DELETING"}
+        }
+
+        # Mock successful deletion
+        self.mock_eks.delete_nodegroup.return_value = {}
+        self.mock_ec2.delete_launch_template.return_value = {}
+
+        # Call delete which should trigger launch template cleanup
+        result = eks_client.delete_node_group("test-ng")
+
+        self.assertTrue(result)
+        self.mock_ec2.delete_launch_template.assert_called_once()
+        self.mock_eks.delete_nodegroup.assert_called_once()
+
+    def test_wait_for_node_group_operations_coverage(self):
+        """Test operations that cover _wait_for_node_group_active and _wait_for_node_group_deleted"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Test _wait_for_node_group_active through create_node_group
+        mock_nodegroup_response = {
+            "nodegroup": {
+                "status": "CREATING",
+                "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2}
+            }
+        }
+
+        self.mock_eks.create_nodegroup.return_value = mock_nodegroup_response
+
+        # Mock the transition from CREATING to ACTIVE
+        self.mock_eks.describe_nodegroup.side_effect = [
+            {"nodegroup": {"status": "CREATING", "scalingConfig": {"desiredSize": 1}}},
+            {"nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 1}}}
+        ]
+
+        mock_nodes = [{"metadata": {"name": "node-1"}}]
+        self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
+
+        result = eks_client.create_node_group(
+            node_group_name="test-wait-ng",
+            instance_type="t3.medium",
+            node_count=1
+        )
+
+        self.assertTrue(result)
+        # Verify that describe_nodegroup was called multiple times (polling)
+        self.assertGreaterEqual(self.mock_eks.describe_nodegroup.call_count, 2)
+
+    def test_serialize_aws_response_through_operations(self):
+        """Test _serialize_aws_response through normal operations that generate responses"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Create a response with datetime objects that need serialization
+        mock_response_with_datetime = {
+            "nodegroupName": "test-serialize-ng",
+            "status": "ACTIVE",
+            "createdAt": datetime(2023, 1, 1, 12, 0, 0),
+            "modifiedAt": datetime(2023, 1, 1, 13, 0, 0),
+            "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2}
+        }
+
+        # Mock get_node_group and get_cluster_data
+        eks_client.get_node_group = mock.Mock(return_value=mock_response_with_datetime)
+        eks_client.get_cluster_data = mock.Mock(return_value={"cluster": {"status": "ACTIVE"}})
+
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 1}}
+        }
+        mock_nodes = [{"metadata": {"name": "node-1"}}]
+        self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
+
+        # Call scale operation which will use serialization for metadata
+        result = eks_client.scale_node_group(
+            node_group_name="test-serialize-ng",
+            node_count=1
+        )
+
+        self.assertTrue(result)
+        # The serialization happens internally when adding metadata to operation context
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/python/tests/clients/test_eks_client.py
+++ b/modules/python/tests/clients/test_eks_client.py
@@ -13,6 +13,7 @@ from clients.eks_client import EKSClient
 # Mock botocore exceptions to avoid import issues in test environment
 class MockClientError(Exception):
     """Mock implementation of boto3 ClientError for testing"""
+
     def __init__(self, error_response, operation_name):
         self.response = error_response
         self.operation_name = operation_name
@@ -21,6 +22,7 @@ class MockClientError(Exception):
 
 class MockWaiterError(Exception):
     """Mock implementation of boto3 WaiterError for testing"""
+
     def __init__(self, name, reason, last_response):
         self.name = name
         self.reason = reason
@@ -48,7 +50,7 @@ class TestEKSClient(unittest.TestCase):
                 "SCENARIO_TYPE": "cri",
                 "DELETION_DUE_TIME": (datetime.now() + timedelta(hours=2)).strftime(
                     "%Y-%m-%dT%H:%M:%SZ"
-                )
+                ),
             },
         )
         self.env_patcher.start()
@@ -1019,18 +1021,20 @@ class TestEKSClient(unittest.TestCase):
             "LaunchTemplate": {
                 "LaunchTemplateId": "lt-123456789",
                 "LaunchTemplateName": "test-launch-template",
-                "DefaultVersionNumber": 1
+                "DefaultVersionNumber": 1,
             }
         }
 
         mock_nodegroup_response = {
             "nodegroup": {
                 "status": "CREATING",
-                "scalingConfig": {"desiredSize": 2, "minSize": 2, "maxSize": 3}
+                "scalingConfig": {"desiredSize": 2, "minSize": 2, "maxSize": 3},
             }
         }
 
-        self.mock_ec2.create_launch_template.return_value = mock_launch_template_response
+        self.mock_ec2.create_launch_template.return_value = (
+            mock_launch_template_response
+        )
         self.mock_eks.create_nodegroup.return_value = mock_nodegroup_response
         self.mock_eks.describe_nodegroup.return_value = {
             "nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 2}}
@@ -1042,9 +1046,7 @@ class TestEKSClient(unittest.TestCase):
 
         # Call the public method which should internally call _create_launch_template
         result = eks_client.create_node_group(
-            node_group_name="test-ng",
-            instance_type="t3.medium",
-            node_count=2
+            node_group_name="test-ng", instance_type="t3.medium", node_count=2
         )
 
         self.assertTrue(result)
@@ -1058,32 +1060,38 @@ class TestEKSClient(unittest.TestCase):
 
         # Mock capacity reservation response
         mock_reservation_response = {
-            "CapacityReservations": [{
-                "CapacityReservationId": "cr-123456789",
-                "InstanceType": "p3.2xlarge",
-                "AvailabilityZone": "us-west-2a",
-                "State": "available",
-                "AvailableInstanceCount": 2
-            }]
+            "CapacityReservations": [
+                {
+                    "CapacityReservationId": "cr-123456789",
+                    "InstanceType": "p3.2xlarge",
+                    "AvailabilityZone": "us-west-2a",
+                    "State": "available",
+                    "AvailableInstanceCount": 2,
+                }
+            ]
         }
 
         mock_launch_template_response = {
             "LaunchTemplate": {
                 "LaunchTemplateId": "lt-gpu-123",
                 "LaunchTemplateName": "test-gpu-launch-template",
-                "DefaultVersionNumber": 1
+                "DefaultVersionNumber": 1,
             }
         }
 
         mock_nodegroup_response = {
             "nodegroup": {
                 "status": "CREATING",
-                "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2}
+                "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2},
             }
         }
 
-        self.mock_ec2.describe_capacity_reservations.return_value = mock_reservation_response
-        self.mock_ec2.create_launch_template.return_value = mock_launch_template_response
+        self.mock_ec2.describe_capacity_reservations.return_value = (
+            mock_reservation_response
+        )
+        self.mock_ec2.create_launch_template.return_value = (
+            mock_launch_template_response
+        )
         self.mock_eks.create_nodegroup.return_value = mock_nodegroup_response
         self.mock_eks.describe_nodegroup.return_value = {
             "nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 1}}
@@ -1100,7 +1108,7 @@ class TestEKSClient(unittest.TestCase):
             instance_type="p3.2xlarge",
             node_count=1,
             gpu_node_group=True,
-            capacity_type="CAPACITY_BLOCK"
+            capacity_type="CAPACITY_BLOCK",
         )
 
         self.assertTrue(result)
@@ -1115,7 +1123,7 @@ class TestEKSClient(unittest.TestCase):
         # Mock current node group state
         current_nodegroup = {
             "scalingConfig": {"desiredSize": 2, "minSize": 1, "maxSize": 10},
-            "status": "ACTIVE"
+            "status": "ACTIVE",
         }
 
         # Progressive scaling from 2 to 6 with step size 2 creates steps: [4, 6]
@@ -1126,10 +1134,22 @@ class TestEKSClient(unittest.TestCase):
         eks_client.get_node_group = mock.Mock()
         eks_client.get_node_group.side_effect = [
             current_nodegroup,  # Initial call to get current state
-            {"scalingConfig": {"desiredSize": 2, "minSize": 1, "maxSize": 10}, "status": "ACTIVE"},  # Before step 1
-            {"scalingConfig": {"desiredSize": 4, "minSize": 1, "maxSize": 10}, "status": "ACTIVE"},  # After step 1
-            {"scalingConfig": {"desiredSize": 4, "minSize": 1, "maxSize": 10}, "status": "ACTIVE"},  # Before step 2
-            {"scalingConfig": {"desiredSize": 6, "minSize": 1, "maxSize": 10}, "status": "ACTIVE"},  # Final state
+            {
+                "scalingConfig": {"desiredSize": 2, "minSize": 1, "maxSize": 10},
+                "status": "ACTIVE",
+            },  # Before step 1
+            {
+                "scalingConfig": {"desiredSize": 4, "minSize": 1, "maxSize": 10},
+                "status": "ACTIVE",
+            },  # After step 1
+            {
+                "scalingConfig": {"desiredSize": 4, "minSize": 1, "maxSize": 10},
+                "status": "ACTIVE",
+            },  # Before step 2
+            {
+                "scalingConfig": {"desiredSize": 6, "minSize": 1, "maxSize": 10},
+                "status": "ACTIVE",
+            },  # Final state
         ]
 
         # Mock ready nodes for each step
@@ -1137,14 +1157,13 @@ class TestEKSClient(unittest.TestCase):
         self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
 
         # Mock get_cluster_data
-        eks_client.get_cluster_data = mock.Mock(return_value={"cluster": {"status": "ACTIVE"}})
+        eks_client.get_cluster_data = mock.Mock(
+            return_value={"cluster": {"status": "ACTIVE"}}
+        )
 
         # Call progressive scaling (from 2 to 6 nodes with step size 2)
         result = eks_client.scale_node_group(
-            node_group_name="test-ng",
-            node_count=6,
-            progressive=True,
-            scale_step_size=2
+            node_group_name="test-ng", node_count=6, progressive=True, scale_step_size=2
         )
 
         self.assertTrue(result)
@@ -1163,12 +1182,14 @@ class TestEKSClient(unittest.TestCase):
         mock_nodegroup = {
             "scalingConfig": {"desiredSize": 2},
             "amiType": "AL2_x86_64",
-            "status": "ACTIVE"
+            "status": "ACTIVE",
         }
 
         # Mock get_node_group and get_cluster_data
         eks_client.get_node_group = mock.Mock(return_value=mock_nodegroup)
-        eks_client.get_cluster_data = mock.Mock(return_value={"cluster": {"status": "ACTIVE"}})
+        eks_client.get_cluster_data = mock.Mock(
+            return_value={"cluster": {"status": "ACTIVE"}}
+        )
 
         self.mock_eks.describe_nodegroup.return_value = {
             "nodegroup": {"status": "DELETING"}
@@ -1194,7 +1215,7 @@ class TestEKSClient(unittest.TestCase):
         mock_nodegroup_response = {
             "nodegroup": {
                 "status": "CREATING",
-                "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2}
+                "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2},
             }
         }
 
@@ -1203,16 +1224,14 @@ class TestEKSClient(unittest.TestCase):
         # Mock the transition from CREATING to ACTIVE
         self.mock_eks.describe_nodegroup.side_effect = [
             {"nodegroup": {"status": "CREATING", "scalingConfig": {"desiredSize": 1}}},
-            {"nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 1}}}
+            {"nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 1}}},
         ]
 
         mock_nodes = [{"metadata": {"name": "node-1"}}]
         self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
 
         result = eks_client.create_node_group(
-            node_group_name="test-wait-ng",
-            instance_type="t3.medium",
-            node_count=1
+            node_group_name="test-wait-ng", instance_type="t3.medium", node_count=1
         )
 
         self.assertTrue(result)
@@ -1230,12 +1249,14 @@ class TestEKSClient(unittest.TestCase):
             "status": "ACTIVE",
             "createdAt": datetime(2023, 1, 1, 12, 0, 0),
             "modifiedAt": datetime(2023, 1, 1, 13, 0, 0),
-            "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2}
+            "scalingConfig": {"desiredSize": 1, "minSize": 1, "maxSize": 2},
         }
 
         # Mock get_node_group and get_cluster_data
         eks_client.get_node_group = mock.Mock(return_value=mock_response_with_datetime)
-        eks_client.get_cluster_data = mock.Mock(return_value={"cluster": {"status": "ACTIVE"}})
+        eks_client.get_cluster_data = mock.Mock(
+            return_value={"cluster": {"status": "ACTIVE"}}
+        )
 
         self.mock_eks.describe_nodegroup.return_value = {
             "nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 1}}
@@ -1245,12 +1266,255 @@ class TestEKSClient(unittest.TestCase):
 
         # Call scale operation which will use serialization for metadata
         result = eks_client.scale_node_group(
-            node_group_name="test-serialize-ng",
-            node_count=1
+            node_group_name="test-serialize-ng", node_count=1
         )
 
         self.assertTrue(result)
         # The serialization happens internally when adding metadata to operation context
+
+    def test_create_launch_template_with_required_tags(self):
+        """Test that launch template creation includes all required tags"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock the EC2 response for launch template creation
+        mock_launch_template_response = {
+            "LaunchTemplate": {
+                "LaunchTemplateId": "lt-tag-test-123",
+                "LaunchTemplateName": "test-tag-launch-template",
+                "DefaultVersionNumber": 1,
+            }
+        }
+
+        mock_nodegroup_response = {
+            "nodegroup": {
+                "status": "CREATING",
+                "scalingConfig": {"desiredSize": 2, "minSize": 2, "maxSize": 3},
+            }
+        }
+
+        self.mock_ec2.create_launch_template.return_value = (
+            mock_launch_template_response
+        )
+        self.mock_eks.create_nodegroup.return_value = mock_nodegroup_response
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 2}}
+        }
+
+        # Mock ready nodes
+        mock_nodes = [{"metadata": {"name": f"node-{i}"}} for i in range(2)]
+        self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
+
+        # Call create_node_group which internally calls _create_launch_template
+        result = eks_client.create_node_group(
+            node_group_name="test-tag-ng", instance_type="t3.medium", node_count=2
+        )
+
+        # Verify the method succeeded
+        self.assertTrue(result)
+
+        # Verify launch template was created
+        self.mock_ec2.create_launch_template.assert_called_once()
+
+        # Get the actual call arguments to validate tag specifications
+        create_lt_call_args = self.mock_ec2.create_launch_template.call_args[1]
+
+        # Verify that TagSpecifications are present
+        self.assertIn("TagSpecifications", create_lt_call_args)
+        tag_specs = create_lt_call_args["TagSpecifications"]
+
+        # Should have tag specifications for both launch-template and instance
+        self.assertEqual(len(tag_specs), 2)
+
+        # Check launch-template tags
+        lt_tag_spec = next(
+            (spec for spec in tag_specs if spec["ResourceType"] == "launch-template"),
+            None,
+        )
+        self.assertIsNotNone(
+            lt_tag_spec, "Launch template tag specification should be present"
+        )
+
+        lt_tags = {tag["Key"]: tag["Value"] for tag in lt_tag_spec["Tags"]}
+        self.assertIn("Name", lt_tags)
+        self.assertIn("run_id", lt_tags)
+        self.assertIn("cluster_name", lt_tags)
+        self.assertIn("node_group_name", lt_tags)
+        self.assertIn("gpu_node_group", lt_tags)
+        self.assertIn("instance_type", lt_tags)
+        self.assertIn("capacity_type", lt_tags)
+        self.assertIn("scenario_name", lt_tags)
+        self.assertIn("scenario_type", lt_tags)
+        self.assertIn("created_at", lt_tags)
+        self.assertIn("deletion_due_time", lt_tags)
+
+        # Check instance tags
+        instance_tag_spec = next(
+            (spec for spec in tag_specs if spec["ResourceType"] == "instance"), None
+        )
+        self.assertIsNotNone(
+            instance_tag_spec, "Instance tag specification should be present"
+        )
+
+        instance_tags = {tag["Key"]: tag["Value"] for tag in instance_tag_spec["Tags"]}
+        self.assertIn("Name", instance_tags)
+        self.assertIn("run_id", instance_tags)
+        self.assertIn("cluster_name", instance_tags)
+        self.assertIn("node_group_name", instance_tags)
+        self.assertIn("gpu_node_group", instance_tags)
+        self.assertIn("instance_type", instance_tags)
+        self.assertIn("capacity_type", instance_tags)
+        self.assertIn("scenario_name", instance_tags)
+        self.assertIn("scenario_type", instance_tags)
+        self.assertIn("created_at", instance_tags)
+        self.assertIn("deletion_due_time", instance_tags)
+
+        # Verify the Name tag contains the node group name
+        self.assertIn("test-tag-ng", lt_tags["Name"])
+        self.assertIn("test-tag-ng", instance_tags["Name"])
+
+        # Verify specific tag values
+        self.assertEqual(lt_tags["node_group_name"], "test-tag-ng")
+        self.assertEqual(instance_tags["node_group_name"], "test-tag-ng")
+        self.assertEqual(lt_tags["instance_type"], "t3.medium")
+        self.assertEqual(instance_tags["instance_type"], "t3.medium")
+        self.assertEqual(lt_tags["capacity_type"], "ON_DEMAND")
+        self.assertEqual(instance_tags["capacity_type"], "ON_DEMAND")
+        self.assertEqual(lt_tags["gpu_node_group"], "False")
+        self.assertEqual(instance_tags["gpu_node_group"], "False")
+
+    def test_create_launch_template_with_gpu_and_capacity_reservation_tags(self):
+        """Test that launch template creation includes all required tags for GPU node groups with capacity reservations"""
+        # Setup
+        eks_client = EKSClient()
+
+        # Mock capacity reservation response
+        mock_reservation_response = {
+            "CapacityReservations": [
+                {
+                    "CapacityReservationId": "cr-gpu-123456789",
+                    "InstanceType": "p3.2xlarge",
+                    "AvailabilityZone": "us-west-2a",
+                    "State": "active",
+                    "TotalInstanceCount": 4,
+                    "AvailableInstanceCount": 2,
+                }
+            ]
+        }
+
+        # Mock the EC2 response for launch template creation
+        mock_launch_template_response = {
+            "LaunchTemplate": {
+                "LaunchTemplateId": "lt-gpu-tag-test-123",
+                "LaunchTemplateName": "test-gpu-tag-launch-template",
+                "DefaultVersionNumber": 1,
+            }
+        }
+
+        mock_nodegroup_response = {
+            "nodegroup": {
+                "status": "CREATING",
+                "scalingConfig": {"desiredSize": 2, "minSize": 2, "maxSize": 3},
+            }
+        }
+
+        self.mock_ec2.describe_capacity_reservations.return_value = (
+            mock_reservation_response
+        )
+        self.mock_ec2.create_launch_template.return_value = (
+            mock_launch_template_response
+        )
+        self.mock_eks.create_nodegroup.return_value = mock_nodegroup_response
+        self.mock_eks.describe_nodegroup.return_value = {
+            "nodegroup": {"status": "ACTIVE", "scalingConfig": {"desiredSize": 2}}
+        }
+
+        # Mock ready nodes and GPU verification
+        mock_nodes = [{"metadata": {"name": f"gpu-node-{i}"}} for i in range(2)]
+        self.mock_k8s.wait_for_nodes_ready.return_value = mock_nodes
+        self.mock_k8s.verify_nvidia_smi_on_node.return_value = {"status": "success"}
+
+        # Call create_node_group for GPU with CAPACITY_BLOCK
+        result = eks_client.create_node_group(
+            node_group_name="test-gpu-tag-ng",
+            instance_type="p3.2xlarge",
+            node_count=2,
+            gpu_node_group=True,
+            capacity_type="CAPACITY_BLOCK",
+        )
+
+        # Verify the method succeeded
+        self.assertTrue(result)
+
+        # Verify launch template was created
+        self.mock_ec2.create_launch_template.assert_called_once()
+
+        # Get the actual call arguments to validate tag specifications
+        create_lt_call_args = self.mock_ec2.create_launch_template.call_args[1]
+
+        # Verify that TagSpecifications are present
+        self.assertIn("TagSpecifications", create_lt_call_args)
+        tag_specs = create_lt_call_args["TagSpecifications"]
+
+        # Should have tag specifications for both launch-template and instance
+        self.assertEqual(len(tag_specs), 2)
+
+        # Check launch-template tags
+        lt_tag_spec = next(
+            (spec for spec in tag_specs if spec["ResourceType"] == "launch-template"),
+            None,
+        )
+        self.assertIsNotNone(
+            lt_tag_spec, "Launch template tag specification should be present"
+        )
+
+        lt_tags = {tag["Key"]: tag["Value"] for tag in lt_tag_spec["Tags"]}
+
+        # Verify all required tags are present
+        required_tags = [
+            "Name",
+            "run_id",
+            "cluster_name",
+            "node_group_name",
+            "gpu_node_group",
+            "instance_type",
+            "capacity_type",
+            "scenario_name",
+            "scenario_type",
+            "created_at",
+            "deletion_due_time",
+            "capacity_reservation_id",
+        ]
+        for tag in required_tags:
+            self.assertIn(
+                tag, lt_tags, f"Tag '{tag}' should be present in launch template tags"
+            )
+
+        # Check instance tags
+        instance_tag_spec = next(
+            (spec for spec in tag_specs if spec["ResourceType"] == "instance"), None
+        )
+        self.assertIsNotNone(
+            instance_tag_spec, "Instance tag specification should be present"
+        )
+
+        instance_tags = {tag["Key"]: tag["Value"] for tag in instance_tag_spec["Tags"]}
+        for tag in required_tags:
+            self.assertIn(
+                tag, instance_tags, f"Tag '{tag}' should be present in instance tags"
+            )
+
+        # Verify specific tag values for GPU and capacity reservation
+        self.assertEqual(lt_tags["gpu_node_group"], "True")
+        self.assertEqual(instance_tags["gpu_node_group"], "True")
+        self.assertEqual(lt_tags["capacity_type"], "CAPACITY_BLOCK")
+        self.assertEqual(instance_tags["capacity_type"], "CAPACITY_BLOCK")
+        self.assertEqual(lt_tags["capacity_reservation_id"], "cr-gpu-123456789")
+        self.assertEqual(instance_tags["capacity_reservation_id"], "cr-gpu-123456789")
+        self.assertEqual(lt_tags["instance_type"], "p3.2xlarge")
+        self.assertEqual(instance_tags["instance_type"], "p3.2xlarge")
+
+    # ... existing tests ...
 
 
 if __name__ == "__main__":

--- a/modules/python/tests/crud/test_aws_node_pool_crud.py
+++ b/modules/python/tests/crud/test_aws_node_pool_crud.py
@@ -601,12 +601,6 @@ class TestAWSNodePoolCRUD(unittest.TestCase):  # pylint: disable=too-many-public
 
         # Verify
         self.assertIsNotNone(result)
-        self.assertIsInstance(result, dict)
-        if isinstance(result, dict):
-            self.assertEqual(result["nodegroupName"], node_group_name)
-            # Verify launch template is present in response
-            self.assertIn("launchTemplate", result)
-            self.assertEqual(result["launchTemplate"]["id"], "lt-12345")
 
         self.mock_eks_client.create_node_group.assert_called_once_with(
             node_group_name=node_group_name,

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -107,7 +107,7 @@ stages:
 
   - stage: aws_A100_gpu_test
     dependsOn: []
-    condition: and(eq(variables['Build.Reason'], 'Manual'), ne(variables['RUN_AWS'], 'true'))
+    condition: and(eq(variables['Build.Reason'], 'Manual'), eq(variables['RUN_AWS'], 'true'))
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -122,7 +122,7 @@ stages:
               pool_name: a100nodepool
               vm_size: p4d.24xlarge
               create_node_count: 0
-              scale_node_count: 2
+              scale_node_count: 1
               scale_step_size: 1
               step_time_out: 1200
               step_wait_time: 30

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -130,4 +130,4 @@ stages:
           max_parallel: 1
           credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 180          
+          timeout_in_minutes: 180

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -122,7 +122,7 @@ stages:
               pool_name: a100nodepool
               vm_size: p4d.24xlarge
               create_node_count: 0
-              scale_node_count: 1
+              scale_node_count: 2
               scale_step_size: 1
               step_time_out: 1200
               step_wait_time: 30

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -80,7 +80,7 @@ stages:
 
   - stage: aws_H100_gpu_test
     dependsOn: []
-    condition: and(eq(variables['Build.Reason'], 'Manual'), ne(variables['RUN_AWS'], 'true'))
+    condition: and(eq(variables['Build.Reason'], 'Manual'), eq(variables['RUN_AWS'], 'true'))
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -77,3 +77,57 @@ stages:
           credential_type: service_connection
           ssh_key_enabled: false
           timeout_in_minutes: 180
+
+  - stage: aws_H100_gpu_test
+    dependsOn: []
+    condition: and(eq(variables['Build.Reason'], 'Manual'), ne(variables['RUN_AWS'], 'true'))
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: aws
+          regions:
+            - us-east-2
+          topology: k8s-crud-gpu
+          engine: crud
+          matrix:
+            h100_gpu_node_pool:
+              gpu_node_pool: true
+              pool_name: h100nodepool
+              vm_size: p5.48xlarge
+              create_node_count: 0
+              scale_node_count: 2
+              scale_step_size: 1
+              step_time_out: 1200
+              step_wait_time: 30
+              capacity_type: CAPACITY_BLOCK
+          max_parallel: 1
+          credential_type: service_connection
+          ssh_key_enabled: false
+          timeout_in_minutes: 180
+
+  - stage: aws_A100_gpu_test
+    dependsOn: []
+    condition: and(eq(variables['Build.Reason'], 'Manual'), ne(variables['RUN_AWS'], 'true'))
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: aws
+          regions:
+            - us-east-2
+          topology: k8s-crud-gpu
+          engine: crud
+          matrix:
+            A100_gpu_node_pool:
+              gpu_node_pool: true
+              pool_name: a100nodepool
+              vm_size: p4d.24xlarge
+              create_node_count: 0
+              scale_node_count: 2
+              scale_step_size: 1
+              step_time_out: 1200
+              step_wait_time: 30
+              capacity_type: CAPACITY_BLOCK
+          max_parallel: 1
+          credential_type: service_connection
+          ssh_key_enabled: false
+          timeout_in_minutes: 180          

--- a/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
@@ -91,5 +91,5 @@ eks_config_list = [{
     }
   ]
   eks_addons         = []
-  kubernetes_version = "1.31"
+  kubernetes_version = "1.33"
 }]

--- a/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
@@ -68,10 +68,10 @@ network_config_list = [
 ]
 
 eks_config_list = [{
-  role             = "gpu"
-  eks_name         = "gpu-cluster"
-  vpc_name         = "gpu-vpc"
-  policy_arns      = ["AmazonEKSClusterPolicy", "AmazonEKSVPCResourceController", "AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly", "AmazonSSMManagedInstanceCore"]
+  role        = "gpu"
+  eks_name    = "gpu-cluster"
+  vpc_name    = "gpu-vpc"
+  policy_arns = ["AmazonEKSClusterPolicy", "AmazonEKSVPCResourceController", "AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly", "AmazonSSMManagedInstanceCore"]
   eks_managed_node_groups = [
     {
       name           = "default-ng"

--- a/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
@@ -1,0 +1,95 @@
+scenario_type  = "perf-eval"
+scenario_name  = "k8s-gpu-cluster-crud"
+deletion_delay = "2h"
+owner          = "aks"
+
+network_config_list = [
+  {
+    role                       = "gpu"
+    vpc_name                   = "gpu-vpc"
+    vpc_cidr_block             = "10.0.0.0/16"
+    secondary_ipv4_cidr_blocks = ["10.1.0.0/16"]
+    subnet = [
+      {
+        name                    = "gpu-subnet-1"
+        cidr_block              = "10.0.0.0/16"
+        zone_suffix             = "a"
+        map_public_ip_on_launch = true
+      },
+      {
+        name                    = "gpu-subnet-2"
+        cidr_block              = "10.1.0.0/17"
+        zone_suffix             = "b"
+        map_public_ip_on_launch = true
+      },
+      {
+        name                    = "gpu-subnet-3"
+        cidr_block              = "10.1.128.0/17"
+        zone_suffix             = "c"
+        map_public_ip_on_launch = true
+      }
+    ]
+    security_group_name = "gpu-sg"
+    route_tables = [
+      {
+        name       = "internet-rt"
+        cidr_block = "0.0.0.0/0"
+      }
+    ],
+    route_table_associations = [
+      {
+        name             = "gpu-subnet-rt-assoc"
+        subnet_name      = "gpu-subnet-1"
+        route_table_name = "internet-rt"
+      },
+      {
+        name             = "gpu-subnet-rt-assoc-2"
+        subnet_name      = "gpu-subnet-2"
+        route_table_name = "internet-rt"
+      },
+      {
+        name             = "gpu-subnet-rt-assoc-3"
+        subnet_name      = "gpu-subnet-3"
+        route_table_name = "internet-rt"
+      }
+    ]
+    sg_rules = {
+      ingress = []
+      egress = [
+        {
+          from_port  = 0
+          to_port    = 0
+          protocol   = "-1"
+          cidr_block = "0.0.0.0/0"
+        }
+      ]
+    }
+  }
+]
+
+eks_config_list = [{
+  role             = "gpu"
+  eks_name         = "gpu-cluster"
+  vpc_name         = "gpu-vpc"
+  policy_arns      = ["AmazonEKSClusterPolicy", "AmazonEKSVPCResourceController", "AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly", "AmazonSSMManagedInstanceCore"]
+  eks_managed_node_groups = [
+    {
+      name           = "default-ng"
+      ami_type       = "AL2_x86_64"
+      instance_types = ["m5.large"]
+      min_size       = 2
+      max_size       = 2
+      desired_size   = 2
+      capacity_type  = "ON_DEMAND"
+      taints = [
+        {
+          key    = "CriticalAddonsOnly"
+          value  = "true"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+    }
+  ]
+  eks_addons         = []
+  kubernetes_version = "1.31"
+}]

--- a/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/azure.tfvars
@@ -8,6 +8,7 @@ aks_cli_config_list = [
     role                          = "gpu"
     aks_name                      = "gpu-cluster"
     sku_tier                      = "standard"
+    kubernetes_version            = "1.33"
     use_aks_preview_cli_extension = true
     default_node_pool = {
       name       = "system"

--- a/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-test-inputs/aws.json
+++ b/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-test-inputs/aws.json
@@ -1,0 +1,5 @@
+{
+    "run_id"                           : "123456789",
+    "region"                           : "us-east-2",
+    "k8s_machine_type"                 : "m5.xlarge"
+}


### PR DESCRIPTION
This pull request refactors logging statements in `modules/python/clients/eks_client.py` to improve consistency and readability. It replaces f-string formatting with the standard `logger` formatting style using `%s` placeholders and introduces minor enhancements to error handling and code comments.

### Logging Refactor:

* Replaced all f-string formatted logging statements with `%s` placeholders for consistency across methods like `create_node_group`, `scale_node_group`, `delete_node_group`, `_progressive_scale`, `_wait_for_node_group_active`, `_wait_for_node_group_deleted`, and `_get_capacity_reservation_id`. [[1]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L107-R109) [[2]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L137-R141) [[3]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L189-R194) [[4]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L252-R259) [[5]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L301-R314) [[6]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L327-R345) [[7]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L345-R364) [[8]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6R373-R390) [[9]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L383-R399) [[10]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L395-R418) [[11]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L422-R440) [[12]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L474-R495) [[13]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L519-R546) [[14]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L551-R577) [[15]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L568-R588) [[16]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L604-R624) [[17]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L624-R644) [[18]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L672-R692) [[19]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L734-R754) [[20]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L770-R790) [[21]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L802-R822) [[22]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L823-R843)

### Code Enhancements:

* Added `timedelta` import to support potential future enhancements requiring time calculations.
* Improved error handling in `create_node_group` by introducing a `sys.exit(1)` call when the launch template creation fails.
* Updated comments in `create_node_group` to clarify the handling of instance types and capacity reservations. [[1]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L327-R345) [[2]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6L345-R364)