### PR TITLE
Update k8s version to 1.33 for API server benchmark with lower max-in…

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -104,12 +104,12 @@ stages:
           topology: kperf
           matrix:
             podsize-20k:
-              kubernetes_version: "1.32.0"
+              kubernetes_version: "1.33.0"
               disable_warmup: "true"
               flowcontrol: "workload-low:1000"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"
             podsize-20k-exempt:
-              kubernetes_version: "1.32.0"
+              kubernetes_version: "1.33.0"
               disable_warmup: "true"
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: "--padding-bytes=16384"


### PR DESCRIPTION
This pull request updates the Kubernetes version used in the API Server Benchmark pipeline configuration for virtual nodes with 10k pods. The most important change is the upgrade of the `kubernetes_version` from `1.32.0` to `1.33.0` for both `podsize-20k` and `podsize-20k-exempt` configurations.

Pipeline configuration updates:

* [`pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml`](diffhunk://#diff-21a6c12576a439ab5dd498e0cb4d7d4aa251da7be5d94b839d63dd56a236c2d0L107-R112): Updated `kubernetes_version` from `1.32.0` to `1.33.0` for `podsize-20k` and `podsize-20k-exempt` matrix configurations.…flight