### PR TITLE
Update AMI for K8s Gpu Test

### DIFF
--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -17,7 +17,6 @@ import time
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Any, List
 import json
-from decimal import Decimal
 
 # Third party imports
 import boto3
@@ -329,7 +328,7 @@ class EKSClient:
                     "subnets": self.subnets,
                     "capacityType": capacity_type,
                     "nodeRole": self.node_role_arn,
-                    "amiType": self.get_AMI_type_with_k8s_version(gpu_node_group=gpu_node_group),
+                    "amiType": self.get_ami_type_with_k8s_version(gpu_node_group=gpu_node_group),
                     "labels": {
                         "cluster-name": self.cluster_name,
                         "nodegroup-name": node_group_name,
@@ -1074,7 +1073,7 @@ class EKSClient:
             )
             raise
 
-    def get_AMI_type_with_k8s_version(
+    def get_ami_type_with_k8s_version(
         self, gpu_node_group: bool = False,
     ) -> str:
         """
@@ -1096,7 +1095,7 @@ class EKSClient:
             # Determine AMI type based on Kubernetes version and GPU requirement
             k8s_version_numeric = float(self.k8s_version)
             logger.info("Determining AMI type for Kubernetes version: %s", self.k8s_version)
-            
+
             if k8s_version_numeric < 1.33:
                 # For Kubernetes versions < 1.33, use AL2_x86_64 for non-GPU and AL2_x86_64_GPU for GPU
                 if gpu_node_group:
@@ -1110,10 +1109,10 @@ class EKSClient:
                 else:
                     ami_type = "AL2023_x86_64_STANDARD"
 
-            logger.info("Selected AMI type: %s for k8s version %s (GPU: %s)", 
+            logger.info("Selected AMI type: %s for k8s version %s (GPU: %s)",
                        ami_type, self.k8s_version, gpu_node_group)
             return ami_type
-            
+
         except (ValueError, TypeError) as e:
             error_msg = f"Invalid Kubernetes version format '{self.k8s_version}': {str(e)}"
             logger.error(error_msg)

--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -324,7 +324,7 @@ class EKSClient:
                     "subnets": self.subnets,
                     "capacityType": capacity_type,
                     "nodeRole": self.node_role_arn,
-                    "amiType": "AL2_x86_64" if not gpu_node_group else "AL2_x86_64_GPU",
+                    "amiType": "AL2_x86_64" if not gpu_node_group else "AL2023_x86_64_NVIDIA",
                     "labels": {
                         "cluster-name": self.cluster_name,
                         "nodegroup-name": node_group_name,

--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -17,6 +17,7 @@ import time
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Any, List
 import json
+from decimal import Decimal
 
 # Third party imports
 import boto3
@@ -95,6 +96,7 @@ class EKSClient:
         self.operation_timeout_minutes = operation_timeout_minutes
         self.vm_size = None
         self.launch_template_id = None
+        self.k8s_version = None
 
         try:
             self.eks = boto3.client("eks", region_name=self.region)
@@ -148,6 +150,9 @@ class EKSClient:
                     logger.info(
                         "Matched cluster: %s with run_id: %s", cluster_name, run_id
                     )
+                    # get k8s version and set it in the client
+                    self.k8s_version = details["cluster"].get("version")
+                    logger.info("Kubernetes version for cluster %s: %s", cluster_name, self.k8s_version)
                     return cluster_name
             raise Exception("No EKS cluster found with run_id: " + run_id)
         except Exception as e:
@@ -324,7 +329,7 @@ class EKSClient:
                     "subnets": self.subnets,
                     "capacityType": capacity_type,
                     "nodeRole": self.node_role_arn,
-                    "amiType": "AL2_x86_64" if not gpu_node_group else "AL2023_x86_64_NVIDIA",
+                    "amiType": self.get_AMI_type_with_k8s_version(gpu_node_group=gpu_node_group),
                     "labels": {
                         "cluster-name": self.cluster_name,
                         "nodegroup-name": node_group_name,
@@ -1068,3 +1073,32 @@ class EKSClient:
                 "Failed to delete launch template %s: %s", self.launch_template_id, str(e)
             )
             raise
+
+    def get_AMI_type_with_k8s_version(
+        self, gpu_node_group: bool = False,
+    ) -> str:
+        """
+        Get the appropriate AMI type based on the Kubernetes version and whether it's a GPU node group.
+
+        Args:
+            gpu_node_group: Whether this is a GPU-enabled node group (default: False)
+
+        Returns:
+            The AMI type string
+        """
+
+        # Determine AMI type based on Kubernetes version and GPU requirement
+        k8s_version_numeric = float(self.k8s_version)
+        logger.info("Determining AMI type for Kubernetes version: %s", self.k8s_version)
+        if k8s_version_numeric < 1.33:
+            # For Kubernetes versions < 1.33, use AL2_x86_64 for non-GPU and AL2_x86_64_GPU for GPU
+            if gpu_node_group:
+                return "AL2_x86_64_GPU"
+            else:
+                return "AL2_x86_64"
+        else:
+            # For Kubernetes versions >= 1.33, use AL2023_x86_64_NVIDIA for GPU and AL2023_x86_64 for non-GPU
+            if gpu_node_group:
+                return "AL2023_x86_64_NVIDIA"
+            else:
+                return "AL2023_x86_64_STANDARD"

--- a/modules/python/tests/clients/test_eks_client.py
+++ b/modules/python/tests/clients/test_eks_client.py
@@ -66,7 +66,7 @@ class TestEKSClient(unittest.TestCase):
         # Mock cluster list and describe responses
         self.mock_eks.list_clusters.return_value = {"clusters": ["test-cluster-123"]}
         self.mock_eks.describe_cluster.return_value = {
-            "cluster": {"tags": {"run_id": "test-run-123"}}
+            "cluster": {"tags": {"run_id": "test-run-123"}, "version": "1.29"}
         }
 
         # Mock subnets response
@@ -1469,6 +1469,78 @@ class TestEKSClient(unittest.TestCase):
         self.assertEqual(lt_tags["capacity_type"], "CAPACITY_BLOCK")
         self.assertEqual(lt_tags["capacity_reservation_id"], "cr-gpu-123456789")
         self.assertEqual(lt_tags["instance_type"], "p3.2xlarge")
+
+    def test_get_ami_type_with_k8s_version_old_non_gpu(self):
+        """Test AMI type selection for old Kubernetes version (< 1.33) with non-GPU"""
+        # Setup
+        eks_client = EKSClient()
+        eks_client.k8s_version = "1.29"
+        
+        # Execute
+        ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
+        
+        # Verify
+        self.assertEqual(ami_type, "AL2_x86_64")
+
+    def test_get_ami_type_with_k8s_version_old_gpu(self):
+        """Test AMI type selection for old Kubernetes version (< 1.33) with GPU"""
+        # Setup
+        eks_client = EKSClient()
+        eks_client.k8s_version = "1.32"
+        
+        # Execute
+        ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
+        
+        # Verify
+        self.assertEqual(ami_type, "AL2_x86_64_GPU")
+
+    def test_get_ami_type_with_k8s_version_new_non_gpu(self):
+        """Test AMI type selection for new Kubernetes version (>= 1.33) with non-GPU"""
+        # Setup
+        eks_client = EKSClient()
+        eks_client.k8s_version = "1.33"
+        
+        # Execute
+        ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
+        
+        # Verify
+        self.assertEqual(ami_type, "AL2023_x86_64_STANDARD")
+
+    def test_get_ami_type_with_k8s_version_new_gpu(self):
+        """Test AMI type selection for new Kubernetes version (>= 1.33) with GPU"""
+        # Setup
+        eks_client = EKSClient()
+        eks_client.k8s_version = "1.34"
+        
+        # Execute
+        ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
+        
+        # Verify
+        self.assertEqual(ami_type, "AL2023_x86_64_NVIDIA")
+
+    def test_get_ami_type_with_k8s_version_boundary_case(self):
+        """Test AMI type selection at the boundary version 1.33"""
+        # Setup
+        eks_client = EKSClient()
+        eks_client.k8s_version = "1.33"
+        
+        # Execute - Test both GPU and non-GPU for boundary case
+        ami_type_non_gpu = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
+        ami_type_gpu = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
+        
+        # Verify
+        self.assertEqual(ami_type_non_gpu, "AL2023_x86_64_STANDARD")
+        self.assertEqual(ami_type_gpu, "AL2023_x86_64_NVIDIA")
+
+    def test_get_ami_type_with_k8s_version_none_fallback(self):
+        """Test AMI type selection when k8s_version is None (should handle gracefully)"""
+        # Setup
+        eks_client = EKSClient()
+        eks_client.k8s_version = None
+        
+        # Execute and verify it raises an appropriate error
+        with self.assertRaises(TypeError):
+            eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
 
     # ... existing tests ...
 

--- a/modules/python/tests/clients/test_eks_client.py
+++ b/modules/python/tests/clients/test_eks_client.py
@@ -1475,10 +1475,10 @@ class TestEKSClient(unittest.TestCase):
         # Setup
         eks_client = EKSClient()
         eks_client.k8s_version = "1.29"
-        
+
         # Execute
         ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
-        
+
         # Verify
         self.assertEqual(ami_type, "AL2_x86_64")
 
@@ -1487,10 +1487,10 @@ class TestEKSClient(unittest.TestCase):
         # Setup
         eks_client = EKSClient()
         eks_client.k8s_version = "1.32"
-        
+
         # Execute
         ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
-        
+
         # Verify
         self.assertEqual(ami_type, "AL2_x86_64_GPU")
 
@@ -1499,10 +1499,10 @@ class TestEKSClient(unittest.TestCase):
         # Setup
         eks_client = EKSClient()
         eks_client.k8s_version = "1.33"
-        
+
         # Execute
         ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
-        
+
         # Verify
         self.assertEqual(ami_type, "AL2023_x86_64_STANDARD")
 
@@ -1511,10 +1511,10 @@ class TestEKSClient(unittest.TestCase):
         # Setup
         eks_client = EKSClient()
         eks_client.k8s_version = "1.34"
-        
+
         # Execute
         ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
-        
+
         # Verify
         self.assertEqual(ami_type, "AL2023_x86_64_NVIDIA")
 
@@ -1523,11 +1523,13 @@ class TestEKSClient(unittest.TestCase):
         # Setup
         eks_client = EKSClient()
         eks_client.k8s_version = "1.33"
-        
+
         # Execute - Test both GPU and non-GPU for boundary case
-        ami_type_non_gpu = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
+        ami_type_non_gpu = eks_client.get_AMI_type_with_k8s_version(
+            gpu_node_group=False
+        )
         ami_type_gpu = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
-        
+
         # Verify
         self.assertEqual(ami_type_non_gpu, "AL2023_x86_64_STANDARD")
         self.assertEqual(ami_type_gpu, "AL2023_x86_64_NVIDIA")
@@ -1537,11 +1539,11 @@ class TestEKSClient(unittest.TestCase):
         # Setup
         eks_client = EKSClient()
         eks_client.k8s_version = None
-        
+
         # Execute and verify it raises an appropriate error
         with self.assertRaises(ValueError) as context:
             eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
-        
+
         # Verify the error message is informative
         self.assertIn("Kubernetes version is not set", str(context.exception))
 
@@ -1550,11 +1552,11 @@ class TestEKSClient(unittest.TestCase):
         # Setup
         eks_client = EKSClient()
         eks_client.k8s_version = "invalid-version"
-        
+
         # Execute and verify it raises an appropriate error
         with self.assertRaises(ValueError) as context:
             eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
-        
+
         # Verify the error message mentions the invalid format
         self.assertIn("Invalid Kubernetes version format", str(context.exception))
         self.assertIn("invalid-version", str(context.exception))
@@ -1564,17 +1566,19 @@ class TestEKSClient(unittest.TestCase):
         # Setup
         eks_client = EKSClient()
         eks_client.k8s_version = "1.30"
-        
-        with self.assertLogs('clients.eks_client', level='INFO') as log:
+
+        with self.assertLogs("clients.eks_client", level="INFO") as log:
             # Execute
             ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
-            
+
             # Verify result
             self.assertEqual(ami_type, "AL2_x86_64_GPU")
-            
+
             # Verify logging
-            log_messages = ' '.join(log.output)
-            self.assertIn("Determining AMI type for Kubernetes version: 1.30", log_messages)
+            log_messages = " ".join(log.output)
+            self.assertIn(
+                "Determining AMI type for Kubernetes version: 1.30", log_messages
+            )
             self.assertIn("Selected AMI type: AL2_x86_64_GPU", log_messages)
 
 

--- a/modules/python/tests/clients/test_eks_client.py
+++ b/modules/python/tests/clients/test_eks_client.py
@@ -1477,7 +1477,7 @@ class TestEKSClient(unittest.TestCase):
         eks_client.k8s_version = "1.29"
 
         # Execute
-        ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
+        ami_type = eks_client.get_ami_type_with_k8s_version(gpu_node_group=False)
 
         # Verify
         self.assertEqual(ami_type, "AL2_x86_64")
@@ -1489,7 +1489,7 @@ class TestEKSClient(unittest.TestCase):
         eks_client.k8s_version = "1.32"
 
         # Execute
-        ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
+        ami_type = eks_client.get_ami_type_with_k8s_version(gpu_node_group=True)
 
         # Verify
         self.assertEqual(ami_type, "AL2_x86_64_GPU")
@@ -1501,7 +1501,7 @@ class TestEKSClient(unittest.TestCase):
         eks_client.k8s_version = "1.33"
 
         # Execute
-        ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
+        ami_type = eks_client.get_ami_type_with_k8s_version(gpu_node_group=False)
 
         # Verify
         self.assertEqual(ami_type, "AL2023_x86_64_STANDARD")
@@ -1513,7 +1513,7 @@ class TestEKSClient(unittest.TestCase):
         eks_client.k8s_version = "1.34"
 
         # Execute
-        ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
+        ami_type = eks_client.get_ami_type_with_k8s_version(gpu_node_group=True)
 
         # Verify
         self.assertEqual(ami_type, "AL2023_x86_64_NVIDIA")
@@ -1525,10 +1525,10 @@ class TestEKSClient(unittest.TestCase):
         eks_client.k8s_version = "1.33"
 
         # Execute - Test both GPU and non-GPU for boundary case
-        ami_type_non_gpu = eks_client.get_AMI_type_with_k8s_version(
+        ami_type_non_gpu = eks_client.get_ami_type_with_k8s_version(
             gpu_node_group=False
         )
-        ami_type_gpu = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
+        ami_type_gpu = eks_client.get_ami_type_with_k8s_version(gpu_node_group=True)
 
         # Verify
         self.assertEqual(ami_type_non_gpu, "AL2023_x86_64_STANDARD")
@@ -1542,7 +1542,7 @@ class TestEKSClient(unittest.TestCase):
 
         # Execute and verify it raises an appropriate error
         with self.assertRaises(ValueError) as context:
-            eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
+            eks_client.get_ami_type_with_k8s_version(gpu_node_group=False)
 
         # Verify the error message is informative
         self.assertIn("Kubernetes version is not set", str(context.exception))
@@ -1555,7 +1555,7 @@ class TestEKSClient(unittest.TestCase):
 
         # Execute and verify it raises an appropriate error
         with self.assertRaises(ValueError) as context:
-            eks_client.get_AMI_type_with_k8s_version(gpu_node_group=False)
+            eks_client.get_ami_type_with_k8s_version(gpu_node_group=False)
 
         # Verify the error message mentions the invalid format
         self.assertIn("Invalid Kubernetes version format", str(context.exception))
@@ -1569,7 +1569,7 @@ class TestEKSClient(unittest.TestCase):
 
         with self.assertLogs("clients.eks_client", level="INFO") as log:
             # Execute
-            ami_type = eks_client.get_AMI_type_with_k8s_version(gpu_node_group=True)
+            ami_type = eks_client.get_ami_type_with_k8s_version(gpu_node_group=True)
 
             # Verify result
             self.assertEqual(ami_type, "AL2_x86_64_GPU")

--- a/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
@@ -75,7 +75,7 @@ eks_config_list = [{
   eks_managed_node_groups = [
     {
       name           = "default-ng"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m5.large"]
       min_size       = 2
       max_size       = 2


### PR DESCRIPTION
This pull request introduces enhancements to the `EKSClient` class, focusing on Kubernetes version handling and AMI type selection logic. It also adds extensive unit tests to ensure the reliability of these changes. The most important updates include introducing a method to determine AMI types based on Kubernetes versions, modifying node group creation logic to use this method, and updating test cases to validate the new functionality.

### Enhancements to Kubernetes Version Handling:

- **`modules/python/clients/eks_client.py`:** Added a new `k8s_version` attribute to the `EKSClient` class and logic to set this value based on cluster details. This enables dynamic handling of Kubernetes version-specific configurations. [[1]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6R98) [[2]](diffhunk://#diff-306a61f6a63fca6333d22d7960129c6f0dd542d13189de926c352ca7b5c307d6R152-R154)

### AMI Type Selection Logic:

- **`modules/python/clients/eks_client.py`:** Introduced the `get_ami_type_with_k8s_version` method to determine the appropriate AMI type based on Kubernetes version and GPU requirements. This method supports backward compatibility for older Kubernetes versions (< 1.33) and introduces new AMI types for versions >= 1.33.
- **`modules/python/clients/eks_client.py`:** Updated the `create_node_group` method to use the new `get_ami_type_with_k8s_version` method for selecting AMI types dynamically.

### Unit Test Additions:

- **`modules/python/tests/clients/test_eks_client.py`:** Added comprehensive test cases for the `get_ami_type_with_k8s_version` method, covering scenarios such as old and new Kubernetes versions, GPU and non-GPU configurations, invalid version formats, and boundary cases. Logging behavior is also validated.

### Configuration Updates:

- **`scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars`:** Updated the default AMI type for managed node groups to `AL2023_x86_64_STANDARD` to align with the new AMI type selection logic for Kubernetes versions >= 1.33.