### PR TITLE
Fix error: null value from template result, causing table creation to fail

### DIFF
--- a/modules/python/clusterloader2/job_controller/job_controller.py
+++ b/modules/python/clusterloader2/job_controller/job_controller.py
@@ -186,6 +186,7 @@ class JobController(ClusterLoader2Base):
         parser.add_argument(
             "--test_type",
             type=str,
+            nargs="?",
             default="default-config",
             help="Description of test type",
         )

--- a/modules/python/clusterloader2/job_controller/job_controller.py
+++ b/modules/python/clusterloader2/job_controller/job_controller.py
@@ -39,7 +39,6 @@ class JobController(ClusterLoader2Base):
     run_url: str = ""
     result_file: str = ""
     test_type: str = "default-config"
-    start_timestamp: str = ""
 
     def configure_clusterloader2(self):
         config = {
@@ -94,7 +93,6 @@ class JobController(ClusterLoader2Base):
             "run_id": self.run_id,
             "run_url": self.run_url,
             "test_type": self.test_type,
-            "start_timestamp": self.start_timestamp,
             "job_count": self.job_count,
             "job_throughput": self.job_throughput,
             "provider": provider,
@@ -188,11 +186,9 @@ class JobController(ClusterLoader2Base):
         parser.add_argument(
             "--test_type",
             type=str,
-            nargs="?",
             default="default-config",
             help="Description of test type",
         )
-        parser.add_argument("--start_timestamp", type=str, help="Test start timestamp")
         parser.add_argument(
             "--job_count", type=int, default=1000, help="Number of jobs to run"
         )

--- a/modules/python/clusterloader2/utils.py
+++ b/modules/python/clusterloader2/utils.py
@@ -108,7 +108,7 @@ def process_cl2_reports(cl2_report_dir, template):
             measurement, group_name = get_measurement(file_path)
             if not measurement:
                 continue
-            logger.info(measurement, group_name)
+            logger.info(f"Measurement: {measurement}, Group Name: {group_name}")
             data = json.loads(file.read())
 
             if "dataItems" in data:

--- a/modules/python/tests/test_job_controller.py
+++ b/modules/python/tests/test_job_controller.py
@@ -87,7 +87,6 @@ class TestJobControllerBenchmark(unittest.TestCase):
                 run_url="http://example.com/run123",
                 result_file=tmp_path,
                 test_type="unit-test",
-                start_timestamp="2024-06-11T12:00:00Z",
                 node_count=3,
                 job_count=1000,
                 job_throughput=50,
@@ -153,7 +152,6 @@ class TestJobControllerParser(unittest.TestCase):
         self.assertIn("run_url", collect_args)
         self.assertIn("result_file", collect_args)
         self.assertIn("test_type", collect_args)
-        self.assertIn("start_timestamp", collect_args)
         self.assertIn("job_count", collect_args)
         self.assertIn("job_throughput", collect_args)
 

--- a/steps/engine/clusterloader2/job_controller/collect.yml
+++ b/steps/engine/clusterloader2/job_controller/collect.yml
@@ -23,8 +23,7 @@ steps:
         --cloud_info "$CLOUD_INFO" \
         --run_id $RUN_ID \
         --run_url $RUN_URL \
-        --result_file $TEST_RESULTS_FILE \
-        --test_type $TEST_TYPE
+        --result_file $TEST_RESULTS_FILE
     workingDirectory: modules/python
     env:
       CLOUD: ${{ parameters.cloud }}


### PR DESCRIPTION
This PR resolves an issue where null values in the template results caused table creation to fail.
- Ensure the result template does not store null values
- Remove start_timestamp (not needed)
- Fix logger format for consistency