### PR TITLE
Deploy Metrics Server addon deployment with manifest for EKS Auto Mode

### DIFF
--- a/modules/terraform/aws/eks/main.tf
+++ b/modules/terraform/aws/eks/main.tf
@@ -695,7 +695,7 @@ resource "terraform_data" "apply_metrics_server_addon" {
   }
 
   depends_on = [
-    terraform_data.apply_nodepool_system_custom, 
+    terraform_data.apply_nodepool_system_custom,
     terraform_data.apply_nodepool_general_custom
   ]
 }

--- a/modules/terraform/aws/eks/output.tf
+++ b/modules/terraform/aws/eks/output.tf
@@ -58,3 +58,8 @@ output "node_pool_policy" {
   description = "EKS access policy association for Auto Mode node pools. Used for unit tests"
   value       = var.eks_config.auto_mode && (var.eks_config.node_pool_system || var.eks_config.node_pool_general_purpose) ? aws_eks_access_policy_association.node_pool_policy : []
 }
+
+output "apply_metrics_server_addon" {
+  description = "Terraform data resource for metrics-server manifest application. Used for unit tests"
+  value       = terraform_data.apply_metrics_server_addon
+}

--- a/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
@@ -77,7 +77,7 @@ variables {
     node_pool_system          = true
     policy_arns               = ["AmazonEKS_CNI_Policy"]
     eks_managed_node_groups   = []
-    eks_addons                = [{
+    eks_addons = [{
       name = "metrics-server"
     }]
   }]

--- a/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
@@ -68,6 +68,18 @@ variables {
     policy_arns             = ["AmazonEKS_CNI_Policy"]
     eks_managed_node_groups = []
     eks_addons              = []
+    }, {
+    role                      = "my-role"
+    eks_name                  = "auto_mode_with_metrics_addon"
+    vpc_name                  = "my-vpc"
+    auto_mode                 = true
+    node_pool_general_purpose = true
+    node_pool_system          = true
+    policy_arns               = ["AmazonEKS_CNI_Policy"]
+    eks_managed_node_groups   = []
+    eks_addons                = [{
+      name = "metrics-server"
+    }]
   }]
 }
 
@@ -102,16 +114,16 @@ run "eks_auto_mode_enabled" {
     error_message = "EKS Auto Mode should enable elastic load balancing"
   }
 
-  # Test that metrics-server addon is created when Auto Mode is enabled
+  # Test that metrics-server is deployed via terraform_data resource when Auto Mode is enabled and metrics-server addon is not configured
   assert {
-    condition     = contains(keys(module.eks["auto_mode_true"].eks_addon.after_compute), "metrics-server")
-    error_message = "EKS Auto Mode should create metrics-server addon"
+    condition     = length(module.eks["auto_mode_true"].apply_metrics_server_addon) == 1
+    error_message = "EKS Auto Mode should deploy metrics-server via manifest when addon is not configured"
   }
 
-  # Test that metrics-server addon has correct timeout configuration
+  # Test that metrics-server addon resource is NOT created when using manifest deployment
   assert {
-    condition     = module.eks["auto_mode_true"].eks_addon.after_compute["metrics-server"].timeouts.create == "5m"
-    error_message = "EKS Auto Mode metrics-server addon should have create timeout set to 5m"
+    condition     = !contains(keys(module.eks["auto_mode_true"].eks_addon.after_compute), "metrics-server")
+    error_message = "EKS Auto Mode should not create metrics-server addon when using manifest deployment"
   }
 
   assert {
@@ -164,6 +176,12 @@ run "eks_auto_mode_disabled" {
     error_message = "EKS Auto Mode should not enable block storage when disabled"
   }
 
+  # Test that metrics-server manifest deployment is not created when Auto Mode is disabled
+  assert {
+    condition     = length(module.eks["auto_mode_false"].apply_metrics_server_addon) == 0
+    error_message = "EKS Auto Mode should not deploy metrics-server via manifest when disabled"
+  }
+
   # Test that metrics-server addon is not created when Auto Mode is disabled
   assert {
     condition     = !contains(keys(module.eks["auto_mode_false"].eks_addon.after_compute), "metrics-server")
@@ -186,6 +204,24 @@ run "eks_auto_mode_disabled" {
   assert {
     condition     = !alltrue([for item in ["AmazonEKSBlockStoragePolicy", "AmazonEKSComputePolicy", "AmazonEKSLoadBalancingPolicy"] : contains(keys(module.eks["auto_mode_false"].eks_role_policy_attachments), item)])
     error_message = "Auto Mode specific policies should not be attached when auto mode is disabled"
+  }
+
+  expect_failures = [check.deletion_due_time]
+}
+
+run "eks_auto_mode_with_metrics_addon" {
+  command = plan
+
+  # Test that metrics-server manifest deployment is NOT created when metrics-server addon is explicitly configured
+  assert {
+    condition     = length(module.eks["auto_mode_with_metrics_addon"].apply_metrics_server_addon) == 0
+    error_message = "EKS Auto Mode should not deploy metrics-server via manifest when metrics-server addon is explicitly configured"
+  }
+
+  # Test that metrics-server addon IS created when explicitly configured in eks_addons
+  assert {
+    condition     = contains(keys(module.eks["auto_mode_with_metrics_addon"].eks_addon.after_compute), "metrics-server")
+    error_message = "EKS Auto Mode should create metrics-server addon when explicitly configured in eks_addons"
   }
 
   expect_failures = [check.deletion_due_time]

--- a/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
@@ -108,6 +108,12 @@ run "eks_auto_mode_enabled" {
     error_message = "EKS Auto Mode should create metrics-server addon"
   }
 
+  # Test that metrics-server addon has correct timeout configuration
+  assert {
+    condition     = module.eks["auto_mode_true"].eks_addon.after_compute["metrics-server"].timeouts.create == "5m"
+    error_message = "EKS Auto Mode metrics-server addon should have create timeout set to 5m"
+  }
+
   assert {
     condition     = alltrue([for item in ["AmazonEKSBlockStoragePolicy", "AmazonEKSComputePolicy", "AmazonEKSLoadBalancingPolicy", "AmazonEKSWorkerNodeMinimalPolicy", "AmazonEKSNetworkingPolicy"] : contains(keys(module.eks["auto_mode_true"].eks_role_policy_attachments), item)])
     error_message = "EKS Auto Mode should attach the required Auto Mode policies: AmazonEKSBlockStoragePolicy, AmazonEKSComputePolicy, AmazonEKSLoadBalancingPolicy, AmazonEKSWorkerNodeMinimalPolicy and AmazonEKSNetworkingPolicy"


### PR DESCRIPTION
Deploy Metrics Server addon deployment with manifest for EKS Auto Mode to prevent deployment issues


### Enhancements to Metrics Server Addon Handling:
- **Manifest-based Deployment**: Added a `terraform_data` resource to deploy the Metrics Server addon using a Kubernetes manifest when EKS Auto Mode is enabled but the addon is not explicitly configured. This ensures faster readiness compared to the official EKS addon.
- **Explicit Addon Configuration**: Updated logic to exclude the Metrics Server addon from the `_eks_addons_map` when deploying via manifest, preventing conflicts.

### Improvements to Addon Configuration:
- **Dynamic Timeouts**: Introduced dynamic timeout settings for addon creation, update, and deletion, allowing greater flexibility in resource operations.
- **Conflict Resolution**: Added `resolve_conflicts_on_create` with the "OVERWRITE" strategy to handle potential conflicts during addon creation.

### Updates to Unit Tests:
- **Validation of Manifest Deployment**: Added test cases to ensure Metrics Server is deployed via manifest when Auto Mode is enabled and the addon is not explicitly configured, and that it is not deployed when Auto Mode is disabled. [[1]](diffhunk://#diff-90ba4574efdc1b59287ec73a6fba7282bc726d7c3358ddebd2b373669f1833b1L105-R126) [[2]](diffhunk://#diff-90ba4574efdc1b59287ec73a6fba7282bc726d7c3358ddebd2b373669f1833b1R179-R184)
- **Explicit Addon Testing**: Added tests to confirm the Metrics Server addon is created when explicitly configured in `eks_addons`, and not deployed via manifest in such cases.

### Outputs for Unit Testing:
- **New Output**: Added `apply_metrics_server_addon` to expose the manifest-based Metrics Server deployment resource for unit tests.