### PR TITLE
Update GPU Tests to avoid generating test json files

### DIFF
--- a/modules/python/tests/crud/test_main.py
+++ b/modules/python/tests/crud/test_main.py
@@ -1191,8 +1191,9 @@ class TestMainParameterValidation(unittest.TestCase):
         mock_logger.critical.assert_called()
         mock_exit.assert_called_with(1)
 
+    @mock.patch("crud.main.OperationContext")
     @mock.patch("crud.main.AWSNodePoolCRUD")
-    def test_main_k8s_client_not_available_aws(self, mock_aws_crud_class):
+    def test_main_k8s_client_not_available_aws(self, mock_aws_crud_class, mock_operation_context):
         """Test main function when k8s client is not available for AWS GPU setup"""
         # Setup
         mock_node_pool_crud = mock.MagicMock()
@@ -1202,6 +1203,12 @@ class TestMainParameterValidation(unittest.TestCase):
 
         mock_aws_crud_class.return_value = mock_node_pool_crud
         mock_node_pool_crud.create_node_pool.return_value = True
+
+        # Setup operation context mock to prevent file generation - use a no-op context manager
+        mock_context_manager = mock.MagicMock()
+        mock_context_manager.__enter__ = mock.MagicMock(return_value=mock_context_manager)
+        mock_context_manager.__exit__ = mock.MagicMock(return_value=None)
+        mock_operation_context.return_value = mock_context_manager
 
         test_args = [
             "crud.py",


### PR DESCRIPTION
This pull request updates the test suite for the `main` module to improve test reliability and prevent unintended side effects. The changes primarily involve mocking the `OperationContext` to ensure no file generation occurs during the tests.

### Test suite improvements:

* [`modules/python/tests/crud/test_main.py`](diffhunk://#diff-9ab5c20c048e9313af0623d82ac8c2d0b13a76c2079d32cb333aafb332868d44R1194-R1196): Added a mock for `OperationContext` in the `test_main_k8s_client_not_available_aws` test to prevent file generation by using a no-op context manager. This ensures the test runs in isolation without creating side effects. [[1]](diffhunk://#diff-9ab5c20c048e9313af0623d82ac8c2d0b13a76c2079d32cb333aafb332868d44R1194-R1196) [[2]](diffhunk://#diff-9ab5c20c048e9313af0623d82ac8c2d0b13a76c2079d32cb333aafb332868d44R1207-R1212)