### PR TITLE
Update K8s version for API server 100 pods test

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml
@@ -54,10 +54,12 @@ stages:
               flowcontrol: "workload-low:1000"
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
+              kubernetes_version: "1.32"
             exempt:
               flowcontrol: "exempt:5"
               extra_benchmark_subcmd_args: ""
               disable_warmup: "true"
+              kubernetes_version: "1.32"
           engine_input:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node10_job1_pod100


### PR DESCRIPTION
This pull request introduces a minor update to the `apiserver-benchmark-virtualnodes10-pods100.yml` configuration file to include the Kubernetes version for benchmarking. The addition ensures consistency in the benchmark environment.

### Configuration update:
* [`pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes10-pods100.yml`](diffhunk://#diff-b94aa7dfcfe00ceeeac64ae283cdb69376cc05c53319ee95be2472b06bfa7e67R57-R62): Added the `kubernetes_version` field with the value `"1.32"` to both `workload-low` and `exempt` stages.