### PR TITLE
Add apply_manifest_from_file method to KubernetesClient for manifest application from file

### DIFF
--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -685,6 +685,32 @@ class KubernetesClient:
         except Exception as e:
             raise Exception(f"Error applying manifest from {manifest_url}: {str(e)}") from e
 
+    def apply_manifest_from_file(self, manifest_path: str = None, manifest_dict: dict = None):
+        """
+        Apply a Kubernetes manifest from file path or dictionary.
+        
+        :param manifest_path: NoPath to YAML manifest file
+        :param manifest_dict: Dictionary containing the manifest
+        :return: None
+        """
+        try:
+            # Load manifest
+            if manifest_path:
+                with open(manifest_path, 'r', encoding='utf-8') as file:
+                    manifest = yaml.safe_load(file)
+            elif manifest_dict:
+                manifest = manifest_dict
+            else:
+                raise ValueError("Either manifest_path or manifest_dict must be provided")
+
+            self._apply_single_manifest(manifest=manifest)
+
+            logger.info("Successfully applied manifest from %s", manifest_path)
+
+        except Exception as e:
+            logger.error(f"Error applying manifest: {str(e)}")
+            raise e
+
     def _apply_single_manifest(self, manifest):
         """
         Apply a single Kubernetes manifest using the appropriate API client.

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,25 +1,23 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: cluster-automatic
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: azure_eastus2
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml # must keep as is
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
+          cloud: azure
+          regions:
+            - eastus2
+          topology: cluster-automatic
+          engine: aks-store-demo
+          engine_input:
+            wait_duration_seconds: 60 # optional, default is 3600 seconds (1 hour)
+          max_parallel: 2 # required
           credential_type: service_connection # required
           ssh_key_enabled: false
           timeout_in_minutes: 60 # if not specified, default is 60

--- a/steps/topology/cluster-automatic/collect-aks-store-demo.yml
+++ b/steps/topology/cluster-automatic/collect-aks-store-demo.yml
@@ -1,0 +1,10 @@
+parameters:
+- name: cloud
+  type: string
+  default: ''
+- name: engine_input
+  type: object
+  default: {}
+- name: regions
+  type: object
+  default: {}

--- a/steps/topology/cluster-automatic/execute-aks-store-demo.yml
+++ b/steps/topology/cluster-automatic/execute-aks-store-demo.yml
@@ -1,0 +1,10 @@
+parameters:
+- name: cloud
+  type: string
+  default: ''
+- name: engine_input
+  type: object
+  default: {}
+- name: regions
+  type: object
+  default: {}

--- a/steps/topology/cluster-automatic/validate-resources.yml
+++ b/steps/topology/cluster-automatic/validate-resources.yml
@@ -1,0 +1,13 @@
+parameters:
+- name: cloud
+  type: string
+- name: engine
+  type: string
+- name: regions
+  type: object
+
+steps:
+- template: /steps/cloud/${{ parameters.cloud }}/update-kubeconfig.yml
+  parameters:
+    role: cas
+    region: ${{ parameters.regions[0] }}


### PR DESCRIPTION
This pull request introduces new functionality for handling Kubernetes manifests in the Python client.

### Kubernetes Client Enhancements:

* Added `apply_manifest_from_file` method in `modules/python/clients/kubernetes_client.py` to apply Kubernetes manifests from file paths or dictionaries, with error handling for missing parameters, file not found, YAML parsing issues, and unsupported resource types.

* Added comprehensive unit tests in `modules/python/tests/clients/test_kubernetes_client.py` to validate the functionality of `apply_manifest_from_file`, including success cases for various resources (e.g., Service, Deployment, ConfigMap, Secret, Namespace, ClusterRole), and error handling for API exceptions and unsupported resources.

