### PR TITLE
add gpu support for kwok node

### DIFF
--- a/modules/python/kwok/config/kwok-node.yaml
+++ b/modules/python/kwok/config/kwok-node.yaml
@@ -25,13 +25,15 @@ status:
     - type: InternalIP
       address: {{node_ip}}
   allocatable:
-    cpu: 32
-    memory: 256Gi
-    pods: 110
+    cpu: {{node_cpu}}
+    memory: {{node_memory}}
+    pods: {{node_pods}}
+    nvidia.com/gpu: {{node_gpu}}
   capacity:
-    cpu: 32
-    memory: 256Gi
-    pods: 110
+    cpu: {{node_cpu}}
+    memory: {{node_memory}}
+    pods: {{node_pods}}
+    nvidia.com/gpu: {{node_gpu}}
   conditions:
     - type: "Ready"
       status: "True"

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -68,6 +68,10 @@ class Node(KWOK):
     """KWOK Node implementation for creating and managing virtual Kubernetes nodes."""
     node_manifest_path: str = "kwok/config/kwok-node.yaml"
     node_count: int = 1
+    node_cpu: str = "32"
+    node_memory: str = "256Gi"
+    node_pods: str = "110"
+    node_gpu: str = "0"
 
     def create(self):
         try:
@@ -77,8 +81,14 @@ class Node(KWOK):
             self.apply_kwok_manifests(self.kwok_release, self.enable_metrics)
 
             for i in range(self.node_count):
-                node_ip = self._generate_node_ip(i)
-                replacements = {"node_name": f"kwok-node-{i}", "node_ip": node_ip}
+                replacements = {
+                    "node_name": f"kwok-node-{i}",
+                    "node_ip": self._generate_node_ip(i),
+                    "node_cpu": self.node_cpu,
+                    "node_memory": self.node_memory,
+                    "node_pods": self.node_pods,
+                    "node_gpu": self.node_gpu
+                }
                 kwok_template = self.k8s_client.create_template(
                     self.node_manifest_path, replacements
                 )
@@ -199,6 +209,30 @@ def main():
         help="Path to the node manifest YAML template.",
     )
     parser.add_argument(
+        "--node-cpu",
+        type=str,
+        default="32",
+        help="CPU capacity and allocatable for each node (default: 32).",
+    )
+    parser.add_argument(
+        "--node-memory",
+        type=str,
+        default="256Gi",
+        help="Memory capacity and allocatable for each node (default: 256Gi).",
+    )
+    parser.add_argument(
+        "--node-pods",
+        type=str,
+        default="110",
+        help="Pod capacity and allocatable for each node (default: 110).",
+    )
+    parser.add_argument(
+        "--node-gpu",
+        type=str,
+        default="0",
+        help="GPU (nvidia.com/gpu) capacity and allocatable for each node (default: 0).",
+    )
+    parser.add_argument(
         "--kwok-release",
         type=str,
         default="",
@@ -221,6 +255,10 @@ def main():
     node = Node(
         node_manifest_path=args.node_manifest_path,
         node_count=args.node_count,
+        node_cpu=args.node_cpu,
+        node_memory=args.node_memory,
+        node_pods=args.node_pods,
+        node_gpu=args.node_gpu,
         kwok_release=args.kwok_release,
         enable_metrics=args.enable_metrics,
     )

--- a/modules/python/tests/kwok/test_kwok_node.py
+++ b/modules/python/tests/kwok/test_kwok_node.py
@@ -172,8 +172,8 @@ class TestNodeIntegration(unittest.TestCase):
                 make_mock_node(
                     name=f"kwok-node-{i}",
                     ready=True,
-                    allocatable={"cpu": "2", "memory": "4Gi"},
-                    capacity={"cpu": "2", "memory": "4Gi"},
+                    allocatable={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
+                    capacity={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
                 )
                 for i in range(2)
             ]
@@ -193,8 +193,8 @@ class TestNodeIntegration(unittest.TestCase):
                 make_mock_node(
                     name=f"kwok-node-{i}",
                     ready=True,
-                    allocatable={"cpu": "2", "memory": "4Gi"},
-                    capacity={"cpu": "2", "memory": "4Gi"},
+                    allocatable={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
+                    capacity={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
                 )
                 for i in range(1)  # Only one node, but node_count=2
             ]
@@ -212,14 +212,14 @@ class TestNodeIntegration(unittest.TestCase):
                 make_mock_node(
                     name="kwok-node-0",
                     ready=False,
-                    allocatable={"cpu": "2", "memory": "4Gi"},
-                    capacity={"cpu": "2", "memory": "4Gi"},
+                    allocatable={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
+                    capacity={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
                 ),
                 make_mock_node(
                     name="kwok-node-1",
                     ready=True,
-                    allocatable={"cpu": "2", "memory": "4Gi"},
-                    capacity={"cpu": "2", "memory": "4Gi"},
+                    allocatable={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
+                    capacity={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
                 ),
             ]
             self.mock_k8s_client.get_nodes.return_value = mock_nodes
@@ -241,8 +241,8 @@ class TestNodeIntegration(unittest.TestCase):
                 make_mock_node(
                     name="kwok-node-1",
                     ready=True,
-                    allocatable={"cpu": "2", "memory": "4Gi"},
-                    capacity={"cpu": "2", "memory": "4Gi"},
+                    allocatable={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
+                    capacity={"cpu": "96", "memory": "1Ti", "pods": "250", "nvidia.com/gpu": "8"},
                 ),
             ]
             self.mock_k8s_client.get_nodes.return_value = mock_nodes


### PR DESCRIPTION
This pull request introduces enhancements to the KWOK Node implementation, enabling dynamic configuration of node resources (CPU, memory, pods, and GPU) and updating corresponding tests to reflect these changes. The most important changes include the addition of new configurable parameters, updates to the node manifest template, and modifications to test cases to validate these updates.

### Enhancements to KWOK Node Configuration:
* Added new configurable parameters (`node_cpu`, `node_memory`, `node_pods`, and `node_gpu`) to the `Node` class and `main()` function, allowing dynamic specification of node resources. Default values are provided for each parameter. (`modules/python/kwok/kwok.py`: [[1]](diffhunk://#diff-71f990df6abb0adebb7ce8f36384b59023f21c340e526ecf931b82f18a289d7cR71-R74) [[2]](diffhunk://#diff-71f990df6abb0adebb7ce8f36384b59023f21c340e526ecf931b82f18a289d7cR211-R234) [[3]](diffhunk://#diff-71f990df6abb0adebb7ce8f36384b59023f21c340e526ecf931b82f18a289d7cR258-R261)
* Updated the `create` method to pass these new parameters as replacements in the node manifest template. (`modules/python/kwok/kwok.py`: [modules/python/kwok/kwok.pyL80-R91](diffhunk://#diff-71f990df6abb0adebb7ce8f36384b59023f21c340e526ecf931b82f18a289d7cL80-R91))

### Updates to Node Manifest Template:
* Modified the `kwok-node.yaml` template to use placeholders (`{{node_cpu}}`, `{{node_memory}}`, `{{node_pods}}`, and `{{node_gpu}}`) for resource configuration, replacing hardcoded values. (`modules/python/kwok/config/kwok-node.yaml`: [modules/python/kwok/config/kwok-node.yamlL28-R36](diffhunk://#diff-4849889ac7db4804e79c6900d469cdeace2ea97b8a92ab0b3ca43712c4b5bd4cL28-R36))

### Test Case Updates:
* Updated test cases to reflect the new resource configuration by increasing resource values (e.g., CPU, memory, pods, and GPU) in mock nodes. This ensures that the changes are validated under various scenarios. (`modules/python/tests/kwok/test_kwok_node.py`: [[1]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820L175-R176) [[2]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820L196-R197) [[3]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820L215-R222) [[4]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820L244-R245)