### PR TITLE
Increase kwok controller concurrency

### DIFF
--- a/jobs/competitive-test.yml
+++ b/jobs/competitive-test.yml
@@ -98,10 +98,10 @@ jobs:
       regions: ${{ parameters.regions }}
       engine_input: ${{ parameters.engine_input }}
       credential_type: ${{ parameters.credential_type }}
-  # - template: /steps/cleanup-resources.yml
-  #   parameters:
-  #     cloud: ${{ parameters.cloud }}
-  #     regions: ${{ parameters.regions }}
-  #     terraform_arguments: ${{ parameters.terraform_arguments }}
-  #     retry_attempt_count: ${{ parameters.retry_attempt_count }}
-  #     credential_type: ${{ parameters.credential_type }}
+  - template: /steps/cleanup-resources.yml
+    parameters:
+      cloud: ${{ parameters.cloud }}
+      regions: ${{ parameters.regions }}
+      terraform_arguments: ${{ parameters.terraform_arguments }}
+      retry_attempt_count: ${{ parameters.retry_attempt_count }}
+      credential_type: ${{ parameters.credential_type }}

--- a/jobs/competitive-test.yml
+++ b/jobs/competitive-test.yml
@@ -98,10 +98,10 @@ jobs:
       regions: ${{ parameters.regions }}
       engine_input: ${{ parameters.engine_input }}
       credential_type: ${{ parameters.credential_type }}
-  - template: /steps/cleanup-resources.yml
-    parameters:
-      cloud: ${{ parameters.cloud }}
-      regions: ${{ parameters.regions }}
-      terraform_arguments: ${{ parameters.terraform_arguments }}
-      retry_attempt_count: ${{ parameters.retry_attempt_count }}
-      credential_type: ${{ parameters.credential_type }}
+  # - template: /steps/cleanup-resources.yml
+  #   parameters:
+  #     cloud: ${{ parameters.cloud }}
+  #     regions: ${{ parameters.regions }}
+  #     terraform_arguments: ${{ parameters.terraform_arguments }}
+  #     retry_attempt_count: ${{ parameters.retry_attempt_count }}
+  #     credential_type: ${{ parameters.credential_type }}

--- a/modules/python/kwok/config/kwok-config.yaml
+++ b/modules/python/kwok/config/kwok-config.yaml
@@ -4,7 +4,8 @@ kind: ConfigMap
 metadata:
   name: kwok
   namespace: kube-system
-  labels: app: kwok-controller
+  labels:
+    app: kwok-controller
 data:
   kwok.yaml: |
     apiVersion: config.kwok.x-k8s.io/v1alpha1

--- a/modules/python/kwok/config/kwok-config.yaml
+++ b/modules/python/kwok/config/kwok-config.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kwok
+  namespace: kube-system
+  labels: app: kwok-controller
+data:
+  kwok.yaml: |
+    apiVersion: config.kwok.x-k8s.io/v1alpha1
+    kind: KwokConfiguration
+    options:
+      enableProfilingHandler: false
+      enableContentionProfiling: false
+      enablePodsOnNodeSyncListPager: false
+      enablePodsOnNodeSyncStreamWatch: true
+      nodeLeaseParallelism: 4
+      podPlayStageParallelism: 64
+      nodePlayStageParallelism: 4
+      nodePort: 10247
+      cidr: 10.0.0.1/24
+      manageAllNodes: false
+      manageNodesWithAnnotationSelector: 'kwok.x-k8s.io/node=fake'
+      manageNodesWithLabelSelector: ''
+      manageSingleNode: ''
+      nodeLeaseDurationSeconds: 40
+      enableCRDs:
+      - Stage
+      - Metric
+      - Attach
+      - ClusterAttach
+      - Exec
+      - ClusterExec
+      - Logs
+      - ClusterLogs
+      - PortForward
+      - ClusterPortForward
+      - ResourceUsage
+      - ClusterResourceUsage

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -42,11 +42,16 @@ class KWOK(ABC):
             self.k8s_client.apply_manifest_from_url,
             stage_fast_yaml_url
         )
-        # Apply KWOK configuration configmap
+        # Replace KWOK configuration configmap
+        execute_with_retries(
+            self.k8s_client.delete_manifest_from_file,
+            "kwok/config/kwok-config.yaml"
+        )
         execute_with_retries(
             self.k8s_client.apply_manifest_from_file,
             "kwok/config/kwok-config.yaml"
         )
+
         # Patch kwok-controller deployment with node selector and toleration
         node_selector = {"kwok": "true"}
         tolerations = [{
@@ -61,6 +66,7 @@ class KWOK(ABC):
             node_selector,
             tolerations
         )
+
         if enable_metrics:
             metrics_usage_url = (f"https://github.com/{self.kwok_repo}/releases/"
                                f"download/{kwok_release}/metrics-usage.yaml")

--- a/modules/python/tests/clients/test_kubernetes_client.py
+++ b/modules/python/tests/clients/test_kubernetes_client.py
@@ -2807,7 +2807,7 @@ spec:
 
             # Verify warning was logged
             mock_logger.warning.assert_called_once_with(
-                "Unsupported resource kind: %s. Skipping...", 
+                "Unsupported resource kind: %s. Skipping...",
                 "UnsupportedResource"
             )
 
@@ -3072,7 +3072,7 @@ spec:
         """Test wait_for_condition with various valid condition types"""
         valid_conditions = [
             "available",
-            "ready", 
+            "ready",
             "progressing",
             "replicafailure"
         ]
@@ -3106,7 +3106,7 @@ spec:
         """Test wait_for_condition with different case conditions"""
         case_variations = [
             "Available",
-            "AVAILABLE", 
+            "AVAILABLE",
             "available",
             "aVaiLaBle"
         ]
@@ -4088,6 +4088,323 @@ spec:
             self.client._load_manifests_from_sources()
 
         self.assertIn("At least one of manifest_path or manifest_dict must be provided", str(context.exception))
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_with_node_selector_only(self, mock_patch_deployment):
+        """Test patching deployment with node selector only."""
+        # Setup
+        deployment_name = "test-deployment"
+        namespace = "test-namespace"
+        node_selector = {"kwok": "true", "zone": "us-west-1"}
+
+        # Execute
+        self.client.patch_deployment(
+            name=deployment_name,
+            namespace=namespace,
+            node_selector=node_selector
+        )
+
+        # Verify
+        expected_patch_body = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "nodeSelector": node_selector
+                    }
+                }
+            }
+        }
+        mock_patch_deployment.assert_called_once_with(
+            name=deployment_name,
+            namespace=namespace,
+            body=expected_patch_body
+        )
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_with_tolerations_only(self, mock_patch_deployment):
+        """Test patching deployment with tolerations only."""
+        # Setup
+        deployment_name = "test-deployment"
+        namespace = "test-namespace"
+        tolerations = [
+            {
+                "key": "kwok",
+                "operator": "Equal",
+                "value": "true",
+                "effect": "NoSchedule"
+            },
+            {
+                "key": "example.com/special",
+                "operator": "Exists",
+                "effect": "NoExecute"
+            }
+        ]
+
+        # Execute
+        self.client.patch_deployment(
+            name=deployment_name,
+            namespace=namespace,
+            tolerations=tolerations
+        )
+
+        # Verify
+        expected_patch_body = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "tolerations": tolerations
+                    }
+                }
+            }
+        }
+        mock_patch_deployment.assert_called_once_with(
+            name=deployment_name,
+            namespace=namespace,
+            body=expected_patch_body
+        )
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_with_both_node_selector_and_tolerations(self, mock_patch_deployment):
+        """Test patching deployment with both node selector and tolerations."""
+        # Setup
+        deployment_name = "test-deployment"
+        namespace = "test-namespace"
+        node_selector = {"environment": "production", "instance-type": "large"}
+        tolerations = [
+            {
+                "key": "dedicated",
+                "operator": "Equal",
+                "value": "production",
+                "effect": "NoSchedule"
+            }
+        ]
+
+        # Execute
+        self.client.patch_deployment(
+            name=deployment_name,
+            namespace=namespace,
+            node_selector=node_selector,
+            tolerations=tolerations
+        )
+
+        # Verify
+        expected_patch_body = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "nodeSelector": node_selector,
+                        "tolerations": tolerations
+                    }
+                }
+            }
+        }
+        mock_patch_deployment.assert_called_once_with(
+            name=deployment_name,
+            namespace=namespace,
+            body=expected_patch_body
+        )
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_with_neither_node_selector_nor_tolerations(self, mock_patch_deployment):
+        """Test patching deployment with neither node selector nor tolerations."""
+        # Setup
+        deployment_name = "test-deployment"
+        namespace = "test-namespace"
+
+        # Execute
+        self.client.patch_deployment(
+            name=deployment_name,
+            namespace=namespace
+        )
+
+        # Verify - should still patch with empty spec
+        expected_patch_body = {
+            "spec": {
+                "template": {
+                    "spec": {}
+                }
+            }
+        }
+        mock_patch_deployment.assert_called_once_with(
+            name=deployment_name,
+            namespace=namespace,
+            body=expected_patch_body
+        )
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_api_exception(self, mock_patch_deployment):
+        """Test patch_deployment when API exception occurs."""
+        # Setup
+        deployment_name = "failing-deployment"
+        namespace = "test-namespace"
+        node_selector = {"kwok": "true"}
+
+        # Mock API exception
+        api_exception = client.rest.ApiException(
+            status=403,
+            reason="Forbidden"
+        )
+        mock_patch_deployment.side_effect = api_exception
+
+        # Execute & Verify
+        with self.assertRaises(Exception) as context:
+            self.client.patch_deployment(
+                name=deployment_name,
+                namespace=namespace,
+                node_selector=node_selector
+            )
+
+        # Verify exception message
+        self.assertIn(f"Error patching deployment {deployment_name}", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, client.rest.ApiException)
+        self.assertEqual(context.exception.__cause__.status, 403)
+
+        # Verify API was called
+        mock_patch_deployment.assert_called_once()
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_unexpected_exception(self, mock_patch_deployment):
+        """Test patch_deployment when unexpected exception occurs."""
+        # Setup
+        deployment_name = "error-deployment"
+        namespace = "test-namespace"
+        tolerations = [{"key": "test", "operator": "Exists"}]
+
+        # Mock unexpected exception
+        mock_patch_deployment.side_effect = ValueError("Unexpected error")
+
+        # Execute & Verify
+        with self.assertRaises(Exception) as context:
+            self.client.patch_deployment(
+                name=deployment_name,
+                namespace=namespace,
+                tolerations=tolerations
+            )
+
+        # Verify exception message
+        self.assertIn(f"Unexpected error patching deployment {deployment_name}", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, ValueError)
+
+        # Verify API was called
+        mock_patch_deployment.assert_called_once()
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_success_with_complex_tolerations(self, mock_patch_deployment):
+        """Test patch_deployment success with complex tolerations."""
+        # Setup
+        deployment_name = "complex-deployment"
+        namespace = "kube-system"
+        node_selector = {"node-role.kubernetes.io/master": ""}
+        tolerations = [
+            {
+                "key": "node-role.kubernetes.io/master",
+                "operator": "Exists",
+                "effect": "NoSchedule"
+            },
+            {
+                "key": "node.kubernetes.io/not-ready",
+                "operator": "Exists",
+                "effect": "NoExecute",
+                "tolerationSeconds": 300
+            },
+            {
+                "key": "node.kubernetes.io/unreachable",
+                "operator": "Exists",
+                "effect": "NoExecute",
+                "tolerationSeconds": 300
+            }
+        ]
+
+        # Execute
+        self.client.patch_deployment(
+            name=deployment_name,
+            namespace=namespace,
+            node_selector=node_selector,
+            tolerations=tolerations
+        )
+
+        # Verify
+        expected_patch_body = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "nodeSelector": node_selector,
+                        "tolerations": tolerations
+                    }
+                }
+            }
+        }
+        mock_patch_deployment.assert_called_once_with(
+            name=deployment_name,
+            namespace=namespace,
+            body=expected_patch_body
+        )
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_empty_node_selector(self, mock_patch_deployment):
+        """Test patch_deployment with empty node selector."""
+        # Setup
+        deployment_name = "test-deployment"
+        namespace = "test-namespace"
+        node_selector = {}  # Empty dict
+        tolerations = [{"key": "test", "operator": "Exists"}]
+
+        # Execute
+        self.client.patch_deployment(
+            name=deployment_name,
+            namespace=namespace,
+            node_selector=node_selector,
+            tolerations=tolerations
+        )
+
+        # Verify - empty node selector should NOT be included (falsy value)
+        expected_patch_body = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "tolerations": tolerations
+                    }
+                }
+            }
+        }
+        mock_patch_deployment.assert_called_once_with(
+            name=deployment_name,
+            namespace=namespace,
+            body=expected_patch_body
+        )
+
+    @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
+    def test_patch_deployment_empty_tolerations(self, mock_patch_deployment):
+        """Test patch_deployment with empty tolerations list."""
+        # Setup
+        deployment_name = "test-deployment"
+        namespace = "test-namespace"
+        node_selector = {"kwok": "true"}
+        tolerations = []  # Empty list
+
+        # Execute
+        self.client.patch_deployment(
+            name=deployment_name,
+            namespace=namespace,
+            node_selector=node_selector,
+            tolerations=tolerations
+        )
+
+        # Verify - empty tolerations should NOT be included (falsy value)
+        expected_patch_body = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "nodeSelector": node_selector
+                    }
+                }
+            }
+        }
+        mock_patch_deployment.assert_called_once_with(
+            name=deployment_name,
+            namespace=namespace,
+            body=expected_patch_body
+        )
 
 
 if __name__ == '__main__':

--- a/scenarios/perf-eval/job-scheduling/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/job-scheduling/terraform-inputs/aws.tfvars
@@ -74,18 +74,6 @@ eks_config_list = [{
       }
     },
     {
-      name           = "prompool"
-      ami_type       = "AL2023_x86_64_STANDARD"
-      instance_types = ["m4.16xlarge"]
-      min_size       = 1
-      max_size       = 1
-      desired_size   = 1
-      capacity_type  = "ON_DEMAND"
-      labels = {
-        "prometheus" = "true"
-      }
-    },
-    {
       name           = "kwokpool"
       ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.16xlarge"]
@@ -96,6 +84,13 @@ eks_config_list = [{
       labels = {
         "kwok" = "true"
       }
+      taints = [
+        {
+          key    = "kwok"
+          value  = "true"
+          effect = "NoSchedule"
+        }
+      ]
     }
   ]
 

--- a/scenarios/perf-eval/job-scheduling/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/job-scheduling/terraform-inputs/azure.tfvars
@@ -25,20 +25,13 @@ aks_config_list = [
     }
     extra_node_pool = [
       {
-        name                 = "prompool"
-        node_count           = 1
-        auto_scaling_enabled = false
-        vm_size              = "Standard_D64_v3"
-        max_pods             = 110
-        node_labels          = { "prometheus" = "true" }
-      },
-      {
         name                 = "kwokpool"
         node_count           = 1
         auto_scaling_enabled = false
         vm_size              = "Standard_D64_v3"
         max_pods             = 110
         node_labels          = { "kwok" = "true" }
+        node_taints          = ["kwok=true:NoSchedule"]
       }
     ]
     kubernetes_version = "1.33"


### PR DESCRIPTION
This pull request introduces a new capability to patch Kubernetes deployments with node selectors and tolerations, updates configurations for KWOK, and modifies infrastructure configurations for job scheduling scenarios. The key changes include the addition of a `patch_deployment` method, updates to KWOK configuration and manifests, and adjustments to Terraform configurations for AWS and Azure.

### Kubernetes Client Enhancements:
* Added a new method `patch_deployment` in `kubernetes_client.py` to allow patching deployments with node selectors and tolerations. This includes error handling for API and unexpected exceptions.
* Added comprehensive unit tests for `patch_deployment`, covering various scenarios such as node selector only, tolerations only, both, and error cases.

### KWOK Configuration and Deployment:
* Introduced a new KWOK configuration `ConfigMap` in `kwok-config.yaml` with options for profiling, node management, and CRD enablement.
* Updated `apply_kwok_manifests` in `kwok.py` to replace the KWOK configuration `ConfigMap` and patch the `kwok-controller` deployment with a node selector and tolerations.

### Infrastructure Configuration Updates:
* Removed the `prompool` node pool from AWS (`aws.tfvars`) and Azure (`azure.tfvars`) configurations. [[1]](diffhunk://#diff-b4fc10de8ca4aeac63e55b26f960f193dc36e04ad0ef82bfd79b64ecbe41f1aaL76-L87) [[2]](diffhunk://#diff-8f663bc2d4a3d7919e6b608a520737101462e1770ce2d576d77bab96fa78a8faL27-R34)
* Added taints to the `kwokpool` node pool in AWS and Azure configurations to ensure proper scheduling behavior. [[1]](diffhunk://#diff-b4fc10de8ca4aeac63e55b26f960f193dc36e04ad0ef82bfd79b64ecbe41f1aaR87-R93) [[2]](diffhunk://#diff-8f663bc2d4a3d7919e6b608a520737101462e1770ce2d576d77bab96fa78a8faL27-R34)