### PR TITLE
Add job template path as input argument

### DIFF
--- a/modules/python/clusterloader2/job_controller/config/config.yaml
+++ b/modules/python/clusterloader2/job_controller/config/config.yaml
@@ -5,6 +5,7 @@ name: job-scheduling
 {{$qps := DefaultParam .CL2_LOAD_TEST_THROUGHPUT 100}}
 {{$replicas_per_namespace := DivideInt $jobs $namespaces}}
 {{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "60s"}}
+{{$jobTemplatePath := DefaultParam .CL2_JOB_TEMPLATE_PATH job_template.yaml}}
 
 namespace:
   number: {{$namespaces}}
@@ -51,7 +52,7 @@ steps:
       tuningSet: Uniform{{$qps}}qps
       objectBundle:
       - basename: test
-        objectTemplatePath: job_template.yaml
+        objectTemplatePath: {{$jobTemplatePath}}
         templateFillMap:
           Group: job-scheduling
 

--- a/modules/python/clusterloader2/job_controller/job_controller.py
+++ b/modules/python/clusterloader2/job_controller/job_controller.py
@@ -25,6 +25,7 @@ class JobController(ClusterLoader2Base):
     cl2_override_file: str = ""
     job_count: int = 1000
     job_throughput: int = -1
+    job_template_path: str = ""
     node_label: str = ""
     cl2_image: str = ""
     cl2_config_dir: str = ""
@@ -46,6 +47,7 @@ class JobController(ClusterLoader2Base):
             "CL2_OPERATION_TIMEOUT": self.operation_timeout,
             "CL2_JOBS": self.job_count,
             "CL2_LOAD_TEST_THROUGHPUT": self.job_throughput,
+            "CL2_JOB_TEMPLATE_PATH": self.job_template_path,
         }
         if self.prometheus_enabled:
             config["CL2_PROMETHEUS_TOLERATE_MASTER"] = True
@@ -101,6 +103,7 @@ class JobController(ClusterLoader2Base):
             "test_type": self.test_type,
             "job_count": self.job_count,
             "job_throughput": self.job_throughput,
+            "job_template_path": self.job_template_path,
             "provider": provider,
         }
 
@@ -130,6 +133,9 @@ class JobController(ClusterLoader2Base):
         )
         parser.add_argument(
             "--job_throughput", type=int, default=-1, help="Job throughput"
+        )
+        parser.add_argument(
+            "--job_template_path", type=str, default="job_template.yaml", help="Job template path"
         )
         parser.add_argument(
             "--prometheus_enabled",
@@ -207,6 +213,9 @@ class JobController(ClusterLoader2Base):
         )
         parser.add_argument(
             "--job_throughput", type=int, default=-1, help="Job throughput"
+        )
+        parser.add_argument(
+            "--job_template_path", type=str, default="job_template.yaml", help="Job template path"
         )
 
 


### PR DESCRIPTION
This pull request introduces support for specifying a custom job template path in the job scheduling configuration for ClusterLoader2. The changes include updates to the configuration file and the `JobController` class to enable this functionality.

### Configuration Updates:
* Added a new parameter `CL2_JOB_TEMPLATE_PATH` in `config.yaml` to allow dynamic specification of the job template path. This replaces the hardcoded `job_template.yaml` with a configurable variable. [[1]](diffhunk://#diff-32d7c7aa04c396050091f23dc67d01e43f0e4e64bc60a43a8ea4b6da0fe9d976R8) [[2]](diffhunk://#diff-32d7c7aa04c396050091f23dc67d01e43f0e4e64bc60a43a8ea4b6da0fe9d976L54-R55)

### Updates to `JobController`:
* Introduced a new attribute `job_template_path` in the `JobController` class to store the job template path.
* Updated the `configure_clusterloader2` method to pass the `job_template_path` as an environment variable (`CL2_JOB_TEMPLATE_PATH`).
* Modified the `collect_clusterloader2` method to include `job_template_path` in the collected test metadata.
* Added a `--job_template_path` argument to both the `configure` and `collect` subparser methods, allowing users to specify the job template path via the command line. The default value is set to `job_template.yaml`. [[1]](diffhunk://#diff-25d8b8518f689030ebd0698a0d65ec64a5d8d7fe1e1d42e5645b5e0526b047c3R137-R139) [[2]](diffhunk://#diff-25d8b8518f689030ebd0698a0d65ec64a5d8d7fe1e1d42e5645b5e0526b047c3R217-R219)