### PR TITLE
fix build schedule for job scheduling benchmark

### DIFF
--- a/pipelines/perf-eval/Scheduler Benchmark/job-scheduling.yml
+++ b/pipelines/perf-eval/Scheduler Benchmark/job-scheduling.yml
@@ -25,7 +25,7 @@ variables:
 stages:
 - stage: azure_northeurope_small
   dependsOn: []
-  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.ScheduleName'], '4:00 AM daily (small scale)')), eq(variables['Build.Reason'], 'Manual'))
+  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 AM daily (small scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml
     parameters:
@@ -50,7 +50,7 @@ stages:
 
 - stage: azure_northeurope_medium
   dependsOn: []
-  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.ScheduleName'], '4:00 PM on Mondays and Wenesday (medium scale)')), eq(variables['Build.Reason'], 'Manual'))
+  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 PM on Mondays and Wenesday (medium scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml
     parameters:
@@ -75,7 +75,7 @@ stages:
 
 - stage: azure_northeurope_high
   dependsOn: []
-  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.ScheduleName'], '4:00 PM on Thursdays (high scale)')), eq(variables['Build.Reason'], 'Manual'))
+  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 PM on Thursdays (high scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml
     parameters:
@@ -100,7 +100,7 @@ stages:
 
 - stage: aws_euwest1_small
   dependsOn: []
-  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.ScheduleName'], '4:00 AM daily (small scale)')), eq(variables['Build.Reason'], 'Manual'))
+  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 AM daily (small scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml
     parameters:
@@ -125,7 +125,7 @@ stages:
 
 - stage: aws_euwest1_medium
   dependsOn: []
-  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.ScheduleName'], '4:00 PM on Mondays and Wenesday (medium scale)')), eq(variables['Build.Reason'], 'Manual'))
+  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 PM on Mondays and Wenesday (medium scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml
     parameters:
@@ -150,7 +150,7 @@ stages:
 
 - stage: aws_euwest1_high
   dependsOn: []
-  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.ScheduleName'], '4:00 PM on Thursdays (high scale)')), eq(variables['Build.Reason'], 'Manual'))
+  condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 PM on Thursdays (high scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml
     parameters:


### PR DESCRIPTION
This pull request updates the pipeline configuration in `pipelines/perf-eval/Scheduler Benchmark/job-scheduling.yml` to use the `Build.CronSchedule.DisplayName` variable instead of `Build.ScheduleName` for determining scheduled build conditions. This change ensures the pipeline stages correctly reference the updated variable for schedule-based triggers.

Updates to scheduled build conditions:

* All stages (`azure_northeurope_small`, `azure_northeurope_medium`, `azure_northeurope_high`, `aws_euwest1_small`, `aws_euwest1_medium`, `aws_euwest1_high`) now use `Build.CronSchedule.DisplayName` for schedule matching in their `condition` expressions, replacing the previous `Build.ScheduleName` variable. [[1]](diffhunk://#diff-8dbc07f2464bbe5d1d1be0e8ee69af4bbad5366ac1206933515f7a6e62dd64d9L28-R28) [[2]](diffhunk://#diff-8dbc07f2464bbe5d1d1be0e8ee69af4bbad5366ac1206933515f7a6e62dd64d9L53-R53) [[3]](diffhunk://#diff-8dbc07f2464bbe5d1d1be0e8ee69af4bbad5366ac1206933515f7a6e62dd64d9L78-R78) [[4]](diffhunk://#diff-8dbc07f2464bbe5d1d1be0e8ee69af4bbad5366ac1206933515f7a6e62dd64d9L103-R103) [[5]](diffhunk://#diff-8dbc07f2464bbe5d1d1be0e8ee69af4bbad5366ac1206933515f7a6e62dd64d9L128-R128) [[6]](diffhunk://#diff-8dbc07f2464bbe5d1d1be0e8ee69af4bbad5366ac1206933515f7a6e62dd64d9L153-R153)