### PR TITLE
feat: add containerd metrics to pod slo tests

### DIFF
--- a/modules/python/clusterloader2/cri/config/config.yaml
+++ b/modules/python/clusterloader2/cri/config/config.yaml
@@ -20,6 +20,7 @@ name: resource-consumer
 {{$provider := DefaultParam .CL2_PROVIDER "aks"}}
 {{$osType := DefaultParam .CL2_OS_TYPE "linux"}}
 {{$scrapeKubelets := DefaultParam .CL2_SCRAPE_KUBELETS false}}
+{{$scrapeContainerd := DefaultParam .CL2_SCRAPE_CONTAINERD false}}
 {{$hostNetwork := DefaultParam .CL2_HOST_NETWORK "true"}}
 
 namespace:
@@ -63,6 +64,13 @@ steps:
   {{if $scrapeKubelets}}
   - module:
       path: /kubelet-measurement.yaml
+      params:
+        action: start
+  {{end}}
+
+  {{if $scrapeContainerd}}
+  - module:
+      path: /containerd-measurement.yaml
       params:
         action: start
   {{end}}
@@ -137,6 +145,13 @@ steps:
   {{if $scrapeKubelets}}
   - module:
       path: /kubelet-measurement.yaml
+      params:
+        action: gather
+  {{end}}
+
+  {{if $scrapeContainerd}}
+  - module:
+      path: /containerd-measurement.yaml
       params:
         action: gather
   {{end}}

--- a/modules/python/clusterloader2/cri/config/containerd-measurement.yaml
+++ b/modules/python/clusterloader2/cri/config/containerd-measurement.yaml
@@ -1,0 +1,67 @@
+{{$action := .action}} # start, gather
+
+steps:
+  - name: {{$action}} Containerd Measurements
+    measurements:
+    - Identifier: ContainerdCriSandboxCreateNetwork
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: ContainerdCriSandboxCreateNetwork
+        metricVersion: v1
+        unit: s
+        queries:
+        - name: Perc100
+          query: histogram_quantile(1, sum(rate(containerd_cri_sandbox_create_network_seconds_bucket[5m])) by (le))
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(containerd_cri_sandbox_create_network_seconds_bucket[5m])) by (le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(containerd_cri_sandbox_create_network_seconds_bucket[5m])) by (le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(containerd_cri_sandbox_create_network_seconds_bucket[5m])) by (le))
+        - name: Sum
+          query: sum(containerd_cri_sandbox_create_network_seconds_sum)
+        - name: Count
+          query: sum(containerd_cri_sandbox_create_network_seconds_count)
+    - Identifier: ContainerdCriSandboxDeleteNetwork
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: ContainerdCriSandboxDeleteNetwork
+        metricVersion: v1
+        unit: s
+        queries:
+        - name: Perc100
+          query: histogram_quantile(1, sum(rate(containerd_cri_sandbox_delete_network_seconds_bucket[5m])) by (le))
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(containerd_cri_sandbox_delete_network_seconds_bucke}[5m])) by (le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(containerd_cri_sandbox_delete_network_seconds_bucket[5m])) by (le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(containerd_cri_sandbox_delete_network_seconds_bucket[5m])) by (le))
+        - name: Sum
+          query: sum(containerd_cri_sandbox_delete_network_seconds_sum)
+        - name: Count
+          query: sum(containerd_cri_sandbox_delete_network_seconds_count)
+    - Identifier: ContainerdCriNetworkPluginOperations
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: ContainerdCriNetworkPluginOperations
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - operation_type
+        queries:
+        - name: Perc100
+          query: histogram_quantile(1, sum(rate(containerd_cri_network_plugin_operations_duration_seconds_seconds_bucket[5m])) by (operation_type, le))
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(containerd_cri_network_plugin_operations_duration_seconds_seconds_bucket[5m])) by (operation_type, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(containerd_cri_network_plugin_operations_duration_seconds_seconds_bucket[5m])) by (operation_type, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(containerd_cri_network_plugin_operations_duration_seconds_seconds_bucket[5m])) by (operation_type, le))
+        - name: Sum
+          query: sum(containerd_cri_network_plugin_operations_duration_seconds_seconds_sum) by (operation_type)
+        - name: Count
+          query: sum(containerd_cri_network_plugin_operations_duration_seconds_seconds_count) by (operation_type)

--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -16,7 +16,7 @@ MEMORY_SCALE_FACTOR = 0.95 # 95% of the total allocatable memory to account for 
 def override_config_clusterloader2(
     node_count, node_per_step, max_pods, repeats, operation_timeout,
     load_type, scale_enabled, pod_startup_latency_threshold, provider,
-    os_type, scrape_kubelets, host_network, override_file):
+    os_type, scrape_kubelets, scrape_containerd, host_network, override_file):
     client = KubernetesClient(os.path.expanduser("~/.kube/config"))
     nodes = client.get_nodes(label_selector="cri-resource-consume=true")
     if len(nodes) == 0:
@@ -65,7 +65,7 @@ def override_config_clusterloader2(
     steps = node_count // node_per_step
     logger.info(
         f"Scaled enabled: {scale_enabled}, node per step: {node_per_step}, steps: {steps}, "
-        f"scrape kubelets: {scrape_kubelets}, host network: {host_network}"
+        f"scrape kubelets: {scrape_kubelets}, scrape containerd: {scrape_containerd}, host network: {host_network}"
     )
 
     with open(override_file, 'w', encoding='utf-8') as file:
@@ -89,13 +89,16 @@ def override_config_clusterloader2(
         file.write(f"CL2_PROVIDER: {provider}\n")
         file.write(f"CL2_OS_TYPE: {os_type}\n")
         file.write(f"CL2_SCRAPE_KUBELETS: {str(scrape_kubelets).lower()}\n")
+        if scrape_containerd:
+            file.write(f"CL2_SCRAPE_CONTAINERD: {str(scrape_containerd).lower()}\n")
+            file.write("CONTAINERD_SCRAPE_INTERVAL: 5m\n")
         file.write(f"CL2_HOST_NETWORK: {str(host_network).lower()}\n")
 
     file.close()
 
-def execute_clusterloader2(cl2_image, cl2_config_dir, cl2_report_dir, kubeconfig, provider, scrape_kubelets):
+def execute_clusterloader2(cl2_image, cl2_config_dir, cl2_report_dir, kubeconfig, provider, scrape_kubelets, scrape_containerd):
     run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, overrides=True, enable_prometheus=True,
-                    tear_down_prometheus=False, scrape_kubelets=scrape_kubelets)
+                    tear_down_prometheus=False, scrape_kubelets=scrape_kubelets, scrape_containerd=scrape_containerd)
 
 def verify_measurement():
     client = KubernetesClient(os.path.expanduser("~/.kube/config"))
@@ -140,10 +143,15 @@ def collect_clusterloader2(
     run_id,
     run_url,
     result_file,
-    scrape_kubelets
+    scrape_kubelets,
+    scrape_containerd
 ):
     if scrape_kubelets:
         verify_measurement()
+
+    if scrape_containerd:
+        # TODO: Add verification for containerd metrics
+        pass
 
     details = parse_xml_to_json(os.path.join(cl2_report_dir, "junit.xml"), indent = 2)
     json_data = json.loads(details)
@@ -258,6 +266,13 @@ def main():
         help="Whether to scrape kubelets",
     )
     parser_override.add_argument(
+        "--scrape_containerd",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape containerd",
+    )
+    parser_override.add_argument(
         "--host_network",
         type=str2bool,
         choices=[True, False],
@@ -289,6 +304,13 @@ def main():
         choices=[True, False],
         default=False,
         help="Whether to scrape kubelets",
+    )
+    parser_execute.add_argument(
+        "--scrape_containerd",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape containerd",
     )
 
     # Sub-command for collect_clusterloader2
@@ -327,6 +349,13 @@ def main():
         default=False,
         help="Whether to scrape kubelets",
     )
+    parser_collect.add_argument(
+        "--scrape_containerd",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape containerd",
+    )
 
     args = parser.parse_args()
 
@@ -343,6 +372,7 @@ def main():
             args.provider,
             args.os_type,
             args.scrape_kubelets,
+            args.scrape_containerd,
             args.host_network,
             args.cl2_override_file,
         )
@@ -354,6 +384,7 @@ def main():
             args.kubeconfig,
             args.provider,
             args.scrape_kubelets,
+            args.scrape_containerd,
         )
     elif args.command == "collect":
         collect_clusterloader2(
@@ -367,6 +398,7 @@ def main():
             args.run_url,
             args.result_file,
             args.scrape_kubelets,
+            args.scrape_containerd,
         )
 
 if __name__ == "__main__":

--- a/modules/python/tests/test_cri.py
+++ b/modules/python/tests/test_cri.py
@@ -62,6 +62,7 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
             provider="aks",
             os_type="linux",
             scrape_kubelets=True,
+            scrape_containerd=True,
             host_network=True,
             override_file="/mock/override.yaml"
         )
@@ -116,6 +117,7 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
             provider="aks",
             os_type="linux",
             scrape_kubelets=False,
+            scrape_containerd=False,
             host_network=False,
             override_file="/mock/override.yaml"
         )
@@ -135,13 +137,14 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
             cl2_report_dir="/mock/report",
             kubeconfig="/mock/kubeconfig",
             provider="aks",
-            scrape_kubelets=True
+            scrape_kubelets=True,
+            scrape_containerd=False
         )
 
         # Verify the command execution
         mock_run_cl2_command.assert_called_once_with(
             "/mock/kubeconfig", "mock-image", "/mock/config", "/mock/report", "aks",
-            overrides=True, enable_prometheus=True, tear_down_prometheus=False, scrape_kubelets=True
+            overrides=True, enable_prometheus=True, tear_down_prometheus=False, scrape_kubelets=True, scrape_containerd=False
         )
 
     @patch('clusterloader2.cri.cri.KubernetesClient')
@@ -185,7 +188,8 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
             run_id="12345",
             run_url="http://example.com",
             result_file=result_file,
-            scrape_kubelets=False
+            scrape_kubelets=False,
+            scrape_containerd=False
         )
 
         self.assertTrue(os.path.exists(result_file))
@@ -210,7 +214,8 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
                 run_id="12345",
                 run_url="http://example.com",
                 result_file="/mock/result.json",
-                scrape_kubelets=False
+                scrape_kubelets=False,
+                scrape_containerd=False
             )
 
         self.assertIn("No testsuites found in the report", str(context.exception))
@@ -230,13 +235,14 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
             "--provider", "aws", 
             "--os_type", "linux", 
             "--scrape_kubelets", "False", 
+            "--scrape_containerd", "False",
             "--host_network", "False",
             "--cl2_override_file", "/tmp/override.yaml"
         ]
         with patch.object(sys, 'argv', test_args):
             main()
             mock_override.assert_called_once_with(
-                5, 1, 110, 3, "2m", "cpu", True, "10s", "aws", "linux", False, False, "/tmp/override.yaml"
+                5, 1, 110, 3, "2m", "cpu", True, "10s", "aws", "linux", False, False, False, "/tmp/override.yaml"
             )
 
     @patch("clusterloader2.cri.cri.override_config_clusterloader2")
@@ -255,12 +261,13 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
             "--provider", "aws", 
             "--os_type", "linux", 
             "--scrape_kubelets", "False", 
+            "--scrape_containerd", "False",
             "--cl2_override_file", "/tmp/override.yaml"
         ]
         with patch.object(sys, 'argv', test_args):
             main()
             mock_override.assert_called_once_with(
-                5, 1, 110, 3, "2m", "cpu", True, "10s", "aws", "linux", False, True, "/tmp/override.yaml"
+                5, 1, 110, 3, "2m", "cpu", True, "10s", "aws", "linux", False, False, True, "/tmp/override.yaml"
             )
 
     @patch("clusterloader2.cri.cri.execute_clusterloader2")
@@ -272,13 +279,14 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
             "--cl2_report_dir", "/reports",
             "--kubeconfig", "/home/user/.kube/config", 
             "--provider", "gcp", 
-            "--scrape_kubelets", "True"
+            "--scrape_kubelets", "True",
+            "--scrape_containerd", "False"
         ]
         with patch.object(sys, 'argv', test_args):
             main()
             mock_execute.assert_called_once_with(
                 "gcr.io/cl2:latest", "/configs", "/reports",
-                "/home/user/.kube/config", "gcp", True
+                "/home/user/.kube/config", "gcp", True, False
             )
 
     @patch("clusterloader2.cri.cri.collect_clusterloader2")
@@ -294,13 +302,14 @@ class TestCRIClusterLoaderFunctions(unittest.TestCase):
             "--run_id", "run-123", 
             "--run_url", "https://run.url", 
             "--result_file", "/tmp/results.json", 
-            "--scrape_kubelets", "False"
+            "--scrape_kubelets", "False",
+            "--scrape_containerd", "False"
         ]
         with patch.object(sys, 'argv', test_args):
             main()
             mock_collect.assert_called_once_with(
                 3, 100, 5, "memory", "/reports", "gcp-zone", "run-123",
-                "https://run.url", "/tmp/results.json", False
+                "https://run.url", "/tmp/results.json", False, False
             )
 
 if __name__ == '__main__':

--- a/pipelines/perf-eval/CNI Benchmark/cni-ab-testing.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cni-ab-testing.yml
@@ -24,7 +24,7 @@ stages:
             - swedencentral
           engine: clusterloader2
           engine_input:
-            image: "ghcr.io/azure/clusterloader2:v20241016"
+            image: "ghcr.io/azure/clusterloader2:v20250513"
           topology: cri-resource-consume
           matrix:
             n10-p300-memory:
@@ -34,6 +34,7 @@ stages:
               operation_timeout: 3m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
             n10-p700-memory:
               node_count: 10
@@ -42,6 +43,7 @@ stages:
               operation_timeout: 7m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
             n10-p1100-memory:
               node_count: 10
@@ -50,6 +52,7 @@ stages:
               operation_timeout: 11m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
           max_parallel: 3
           timeout_in_minutes: 120
@@ -66,7 +69,7 @@ stages:
             - swedencentral
           engine: clusterloader2
           engine_input:
-            image: "ghcr.io/azure/clusterloader2:v20241016"
+            image: "ghcr.io/azure/clusterloader2:v20250513"
           topology: cri-resource-consume
           matrix:
             n10-p300-memory:
@@ -76,6 +79,7 @@ stages:
               operation_timeout: 3m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
             n10-p700-memory:
               node_count: 10
@@ -84,6 +88,7 @@ stages:
               operation_timeout: 7m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
             n10-p1100-memory:
               node_count: 10
@@ -92,6 +97,7 @@ stages:
               operation_timeout: 11m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
           max_parallel: 3
           timeout_in_minutes: 120
@@ -108,7 +114,7 @@ stages:
             - eu-west-1
           engine: clusterloader2
           engine_input:
-            image: "ghcr.io/azure/clusterloader2:v20241016"
+            image: "ghcr.io/azure/clusterloader2:v20250513"
           topology: cri-resource-consume
           matrix:
             n10-p300-memory:
@@ -118,6 +124,7 @@ stages:
               operation_timeout: 3m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
             n10-p700-memory:
               node_count: 10
@@ -126,6 +133,7 @@ stages:
               operation_timeout: 7m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
             n10-p1100-memory:
               node_count: 10
@@ -134,6 +142,7 @@ stages:
               operation_timeout: 11m
               load_type: memory
               scrape_kubelets: True
+              scrape_containerd: True
               host_network: False
           max_parallel: 3
           timeout_in_minutes: 120

--- a/steps/engine/clusterloader2/cri/collect.yml
+++ b/steps/engine/clusterloader2/cri/collect.yml
@@ -25,7 +25,8 @@ steps:
         --run_id $RUN_ID \
         --run_url $RUN_URL \
         --result_file $TEST_RESULTS_FILE \
-        --scrape_kubelets ${SCRAPE_KUBELETS:-False}
+        --scrape_kubelets ${SCRAPE_KUBELETS:-False} \
+        --scrape_containerd ${SCRAPE_CONTAINERD:-False}
     workingDirectory: modules/python
     env:
       CLOUD: ${{ parameters.cloud }}

--- a/steps/engine/clusterloader2/cri/execute.yml
+++ b/steps/engine/clusterloader2/cri/execute.yml
@@ -24,6 +24,7 @@ steps:
         --provider $CLOUD \
         --os_type ${OS_TYPE:-linux} \
         --scrape_kubelets ${SCRAPE_KUBELETS:-False} \
+        --scrape_containerd ${SCRAPE_CONTAINERD:-False} \
         --host_network ${HOST_NETWORK:-True} \
         --cl2_override_file ${CL2_CONFIG_DIR}/overrides.yaml
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \
@@ -32,7 +33,8 @@ steps:
         --cl2_report_dir $CL2_REPORT_DIR \
         --kubeconfig ${HOME}/.kube/config \
         --provider $CLOUD \
-        --scrape_kubelets ${SCRAPE_KUBELETS:-False}
+        --scrape_kubelets ${SCRAPE_KUBELETS:-False} \
+        --scrape_containerd ${SCRAPE_CONTAINERD:-False}
     workingDirectory: modules/python
     env:
       ${{ if eq(parameters.cloud, 'azure') }}:


### PR DESCRIPTION
to capture granular CNI invocation latency as measured by containerd

containerd metric collection can be seen occuring here: https://dev.azure.com/akstelescope/telescope/_build/results?buildId=31371&view=logs&j=a0a6cafc-0d48-509a-6124-e27fd97b3757&t=d5aa99fe-d00f-5192-5a67-b1b4a85db24b&l=3898