### PR TITLE
Disable Scheduled runs for A100 GPU CRUD test

### DIFF
--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -7,12 +7,12 @@ schedules:
       include:
         - main
     always: true
-  - cron: "30 */6 * * *"
-    displayName: "At 30 minute past every 6th hour"
-    branches:
-      include:
-        - main
-    always: true
+  # - cron: "30 */6 * * *"
+  #   displayName: "At 30 minute past every 6th hour"
+  #   branches:
+  #     include:
+  #       - main
+  #   always: true
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-gpu-cluster-crud


### PR DESCRIPTION
This pull request makes a small change to the `k8s-gpu-cluster-crud.yml` pipeline schedule configuration by commenting out a scheduled cron job that previously ran every 6 hours. This disables the job but preserves the configuration for potential future use.