### PR TITLE
Update Subnet Zone for AWS CRUD test Scenario

### DIFF
--- a/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/aws.tfvars
@@ -19,7 +19,7 @@ network_config_list = [
       {
         name                    = "gpu-subnet-2"
         cidr_block              = "10.1.0.0/17"
-        zone_suffix             = "b"
+        zone_suffix             = "f"
         map_public_ip_on_launch = true
       },
       {


### PR DESCRIPTION
This pull request makes a small update to the subnet configuration in the AWS Terraform variables file. The change updates the availability zone suffix for the `gpu-subnet-2` subnet.

* Changed the `zone_suffix` for `gpu-subnet-2` from `"b"` to `"f"` in `aws.tfvars`, which will deploy this subnet in a different availability zone.