### PR TITLE
Enhance kwok validation

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -41,21 +41,8 @@ jobs:
           else
             pylint $file_changes
           fi
-      - name: Install kwokctl
-        if: always()
-        run: |
-          curl -LO https://github.com/kubernetes-sigs/kwok/releases/latest/download/kwokctl-linux-amd64
-          chmod +x kwokctl-linux-amd64
-          sudo mv kwokctl-linux-amd64 /usr/local/bin/kwokctl
-
-      - name: Create KWOK cluster
-        if: always()
-        run: kwokctl create cluster --name kwok-test
       - name: Run Python Tests with Coverage
         if: always()
         working-directory: ${{ env.PYTHON_MODULES_DIR }}
         # TODO: Update Validation to check 80% coverage for each test file
         run: pytest --cov=. --cov-report=term-missing --cov-fail-under=80
-      - name: Delete KWOK cluster
-        if: always()
-        run: kwokctl delete cluster --name kwok-test

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -21,7 +21,7 @@ pushd modules/python
 # Install dependencies
 pip install -r requirements.txt
 
-# Run tests with coverage (minimum 70% required)
+# Run tests with coverage (minimum 80% required)
 pytest --cov=. --cov-report=term-missing --cov-fail-under=80
 
 # Run specific test module

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -12,17 +12,14 @@
 
 ```bash
 # Create and activate virtual environment
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 
 # Navigate to Python modules directory
 pushd modules/python
 
 # Install dependencies
 pip install -r requirements.txt
-
-# Create kwok cluster for kwok tests
-kwokctl create cluster --name kwok-test
 
 # Run tests with coverage (minimum 70% required)
 pytest --cov=. --cov-report=term-missing --cov-fail-under=70
@@ -34,9 +31,6 @@ pytest tests/clients/test_aks_client.py -v
 pytest tests/clients/ -v  # Client tests
 pytest tests/crud/ -v     # CRUD operation tests
 pytest tests/iperf3/ -v   # Network performance tests
-
-# Delete kwok cluster
-kwokctl delete cluster --name kwok-test
 
 # Go back to root directory
 popd

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -22,7 +22,7 @@ pushd modules/python
 pip install -r requirements.txt
 
 # Run tests with coverage (minimum 70% required)
-pytest --cov=. --cov-report=term-missing --cov-fail-under=70
+pytest --cov=. --cov-report=term-missing --cov-fail-under=80
 
 # Run specific test module
 pytest tests/clients/test_aks_client.py -v
@@ -36,7 +36,7 @@ pytest tests/iperf3/ -v   # Network performance tests
 popd
 
 # Run lint
- pylint --rcfile=.pylintrc --ignore=site-packages modules/python
+pylint --rcfile=.pylintrc --ignore=site-packages modules/python
 
 # Deactivate virtual environment
 deactivate

--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -1517,6 +1517,28 @@ class KubernetesClient:
         logger.error("NVIDIA GPU device plugin verification timed out.")
         return False
 
+    def get_deployment(self, name, namespace):
+        """
+        Get a deployment by name from the specified namespace.
+
+        :param name: Name of the deployment to retrieve
+        :param namespace: Namespace where the deployment is located
+        :return: Deployment object if found, None if not found
+        """
+        try:
+            deployment = self.app.read_namespaced_deployment(name=name, namespace=namespace)
+            logger.info(f"Retrieved deployment '{name}' from namespace '{namespace}'")
+            return deployment
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                logger.info(f"Deployment '{name}' not found in namespace '{namespace}'")
+                return None
+            logger.error(f"Error getting deployment '{name}' from namespace '{namespace}': {str(e)}")
+            raise Exception(f"Error getting deployment '{name}' from namespace '{namespace}': {str(e)}") from e
+        except Exception as e:
+            logger.error(f"Unexpected error getting deployment '{name}' from namespace '{namespace}': {str(e)}")
+            raise Exception(f"Unexpected error getting deployment '{name}' from namespace '{namespace}': {str(e)}") from e
+
     def patch_deployment(self, name, namespace, node_selector=None, tolerations=None):
         """
         Patch a deployment with node selector and tolerations.

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -155,9 +155,37 @@ class Node(KWOK):
             raise RuntimeError(f"Failed to create nodes: {e}") from e
 
     def validate(self):
-        ready_nodes = execute_with_retries(
-            self.k8s_client.get_nodes
+        execute_with_retries(
+            self._validate_kwok_controller
         )
+
+        execute_with_retries(
+            self._validate_kwok_nodes
+        )
+
+    def _validate_kwok_controller(self):
+        """Validate that kwok-controller deployment is running with 1 available replica."""
+        deployment = self.k8s_client.get_deployment(
+            "kwok-controller",
+            "kube-system"
+        )
+
+        if not deployment:
+            raise RuntimeError("kwok-controller deployment not found in kube-system namespace")
+
+        available_replicas = deployment.status.available_replicas or 0
+        if available_replicas != 1:
+            raise RuntimeError(
+                f"kwok-controller deployment validation failed: "
+                f"Expected 1 available replica, but found {available_replicas}"
+            )
+
+        print("kwok-controller deployment is running with 1 available replica.")
+
+
+    def _validate_kwok_nodes(self):
+        ready_nodes = self.k8s_client.get_nodes()
+
         kwok_nodes = [
             node
             for node in ready_nodes

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -156,7 +156,8 @@ class Node(KWOK):
 
     def validate(self):
         execute_with_retries(
-            self._validate_kwok_controller
+            self._validate_kwok_controller,
+            max_retries=10,
         )
 
         execute_with_retries(

--- a/modules/python/tests/aks_store_demo/test_aks_store_demo.py
+++ b/modules/python/tests/aks_store_demo/test_aks_store_demo.py
@@ -228,7 +228,7 @@ class TestAllInOneAKSStoreDemo(unittest.TestCase):
         assert manifests == expected
 
     @patch('aks_store_demo.aks_store_demo.KubernetesClient')
-    def test_get_manifest_urls_with_custom_tag(self, mock_k8s_client):
+    def test_get_manifest_urls_with_custom_tag(self, mock_k8s_client): #pylint: disable=unused-argument
         """Test that get_manifest_urls uses custom tag correctly."""
         demo_with_custom_tag = AllInOneAKSStoreDemo(tag="1.5.0")
         manifests = demo_with_custom_tag.get_manifest_urls()

--- a/modules/python/tests/aks_store_demo/test_aks_store_demo.py
+++ b/modules/python/tests/aks_store_demo/test_aks_store_demo.py
@@ -4,8 +4,10 @@ from dataclasses import dataclass
 import unittest
 from unittest.mock import Mock, patch, call
 
-from aks_store_demo.aks_store_demo import AKSStoreDemo, AllInOneAKSStoreDemo, main
-from clients.kubernetes_client import KubernetesClient
+# Mock kubernetes config before importing
+with patch('kubernetes.config.load_kube_config'):
+    from aks_store_demo.aks_store_demo import AKSStoreDemo, AllInOneAKSStoreDemo, main
+    from clients.kubernetes_client import KubernetesClient
 
 
 class TestAKSStoreDemo(unittest.TestCase):
@@ -217,7 +219,7 @@ class TestAllInOneAKSStoreDemo(unittest.TestCase):
             {
                 "url": "https://raw.githubusercontent.com/Azure-Samples/aks-store-demo/2.0.0/aks-store-all-in-one.yaml",
                 "wait_condition_type": "available",
-                "resource_type": "deployment", 
+                "resource_type": "deployment",
                 "resource_name": None,
                 "timeout": 1200
             }
@@ -225,7 +227,8 @@ class TestAllInOneAKSStoreDemo(unittest.TestCase):
 
         assert manifests == expected
 
-    def test_get_manifest_urls_with_custom_tag(self):
+    @patch('aks_store_demo.aks_store_demo.KubernetesClient')
+    def test_get_manifest_urls_with_custom_tag(self, mock_k8s_client):
         """Test that get_manifest_urls uses custom tag correctly."""
         demo_with_custom_tag = AllInOneAKSStoreDemo(tag="1.5.0")
         manifests = demo_with_custom_tag.get_manifest_urls()
@@ -234,7 +237,7 @@ class TestAllInOneAKSStoreDemo(unittest.TestCase):
             {
                 "url": "https://raw.githubusercontent.com/Azure-Samples/aks-store-demo/1.5.0/aks-store-all-in-one.yaml",
                 "wait_condition_type": "available",
-                "resource_type": "deployment", 
+                "resource_type": "deployment",
                 "resource_name": None,
                 "timeout": 1200
             }

--- a/modules/python/tests/clients/test_kubernetes_client.py
+++ b/modules/python/tests/clients/test_kubernetes_client.py
@@ -4996,7 +4996,6 @@ spec:
         # Setup
         deployment_name = "test-deployment"
         namespace = "test-namespace"
-        
         # Create mock deployment
         mock_deployment = V1Deployment(
             metadata=V1ObjectMeta(
@@ -5090,7 +5089,6 @@ spec:
         # Setup - simulating kwok-controller deployment
         deployment_name = "kwok-controller"
         namespace = "kube-system"
-        
         # Create mock kwok-controller deployment
         mock_deployment = V1Deployment(
             metadata=V1ObjectMeta(
@@ -5125,7 +5123,6 @@ spec:
         # Setup
         deployment_name = "no-status-deployment"
         namespace = "test-namespace"
-        
         # Create mock deployment without status
         mock_deployment = V1Deployment(
             metadata=V1ObjectMeta(

--- a/modules/python/tests/clients/test_kubernetes_client.py
+++ b/modules/python/tests/clients/test_kubernetes_client.py
@@ -14,7 +14,7 @@ from kubernetes.client.models import (
     V1VolumeAttachment, V1VolumeAttachmentStatus, V1VolumeAttachmentSpec, V1VolumeAttachmentSource,
     V1PodStatus, V1Pod, V1PodSpec, V1Namespace, V1PodCondition,
     V1Service, V1ServiceStatus, V1LoadBalancerStatus, V1LoadBalancerIngress, V1NodeSystemInfo,
-    V1PodList
+    V1PodList, V1Deployment, V1DeploymentStatus
 )
 from kubernetes.client.rest import ApiException
 
@@ -4989,6 +4989,161 @@ spec:
 
         self.assertIn("Error deleting Deployment/test-deployment", str(context.exception))
         self.assertIn("Deployment requires a namespace", str(context.exception))
+
+    @patch('kubernetes.client.AppsV1Api.read_namespaced_deployment')
+    def test_get_deployment_success(self, mock_read_deployment):
+        """Test get_deployment method successfully retrieves a deployment."""
+        # Setup
+        deployment_name = "test-deployment"
+        namespace = "test-namespace"
+        
+        # Create mock deployment
+        mock_deployment = V1Deployment(
+            metadata=V1ObjectMeta(
+                name=deployment_name,
+                namespace=namespace
+            ),
+            status=V1DeploymentStatus(
+                available_replicas=1,
+                ready_replicas=1,
+                replicas=1
+            )
+        )
+        mock_read_deployment.return_value = mock_deployment
+
+        # Execute
+        result = self.client.get_deployment(deployment_name, namespace)
+
+        # Verify
+        mock_read_deployment.assert_called_once_with(name=deployment_name, namespace=namespace)
+        self.assertEqual(result, mock_deployment)
+        self.assertEqual(result.metadata.name, deployment_name)
+        self.assertEqual(result.metadata.namespace, namespace)
+        self.assertEqual(result.status.available_replicas, 1)
+
+    @patch('kubernetes.client.AppsV1Api.read_namespaced_deployment')
+    def test_get_deployment_not_found(self, mock_read_deployment):
+        """Test get_deployment method when deployment is not found (404 error)."""
+        # Setup
+        deployment_name = "nonexistent-deployment"
+        namespace = "test-namespace"
+
+        # Mock 404 exception
+        mock_read_deployment.side_effect = client.rest.ApiException(
+            status=404,
+            reason="Not Found"
+        )
+
+        # Execute
+        result = self.client.get_deployment(deployment_name, namespace)
+
+        # Verify
+        mock_read_deployment.assert_called_once_with(name=deployment_name, namespace=namespace)
+        self.assertIsNone(result)
+
+    @patch('kubernetes.client.AppsV1Api.read_namespaced_deployment')
+    def test_get_deployment_other_api_exception(self, mock_read_deployment):
+        """Test get_deployment method when API exception other than 404 occurs."""
+        # Setup
+        deployment_name = "forbidden-deployment"
+        namespace = "test-namespace"
+
+        # Mock 403 forbidden exception
+        api_exception = client.rest.ApiException(
+            status=403,
+            reason="Forbidden"
+        )
+        mock_read_deployment.side_effect = api_exception
+
+        # Execute & Verify
+        with self.assertRaises(Exception) as context:
+            self.client.get_deployment(deployment_name, namespace)
+
+        # Verify exception message and cause
+        self.assertIn(f"Error getting deployment '{deployment_name}' from namespace '{namespace}'", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, client.rest.ApiException)
+        self.assertEqual(context.exception.__cause__.status, 403)
+        mock_read_deployment.assert_called_once_with(name=deployment_name, namespace=namespace)
+
+    @patch('kubernetes.client.AppsV1Api.read_namespaced_deployment')
+    def test_get_deployment_unexpected_exception(self, mock_read_deployment):
+        """Test get_deployment method when unexpected exception occurs."""
+        # Setup
+        deployment_name = "error-deployment"
+        namespace = "test-namespace"
+
+        # Mock unexpected exception
+        mock_read_deployment.side_effect = ValueError("Unexpected error")
+
+        # Execute & Verify
+        with self.assertRaises(Exception) as context:
+            self.client.get_deployment(deployment_name, namespace)
+
+        # Verify exception message and cause
+        self.assertIn(f"Unexpected error getting deployment '{deployment_name}' from namespace '{namespace}'", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, ValueError)
+        mock_read_deployment.assert_called_once_with(name=deployment_name, namespace=namespace)
+
+    @patch('kubernetes.client.AppsV1Api.read_namespaced_deployment')
+    def test_get_deployment_kwok_controller_scenario(self, mock_read_deployment):
+        """Test get_deployment method specifically for kwok-controller deployment scenario."""
+        # Setup - simulating kwok-controller deployment
+        deployment_name = "kwok-controller"
+        namespace = "kube-system"
+        
+        # Create mock kwok-controller deployment
+        mock_deployment = V1Deployment(
+            metadata=V1ObjectMeta(
+                name=deployment_name,
+                namespace=namespace,
+                labels={"app": "kwok-controller"}
+            ),
+            status=V1DeploymentStatus(
+                available_replicas=1,
+                ready_replicas=1,
+                replicas=1,
+                updated_replicas=1
+            )
+        )
+        mock_read_deployment.return_value = mock_deployment
+
+        # Execute
+        result = self.client.get_deployment(deployment_name, namespace)
+
+        # Verify
+        mock_read_deployment.assert_called_once_with(name=deployment_name, namespace=namespace)
+        self.assertEqual(result, mock_deployment)
+        self.assertEqual(result.metadata.name, "kwok-controller")
+        self.assertEqual(result.metadata.namespace, "kube-system")
+        self.assertEqual(result.status.available_replicas, 1)
+        self.assertEqual(result.status.ready_replicas, 1)
+        self.assertEqual(result.status.replicas, 1)
+
+    @patch('kubernetes.client.AppsV1Api.read_namespaced_deployment')
+    def test_get_deployment_empty_status(self, mock_read_deployment):
+        """Test get_deployment method with deployment that has no status."""
+        # Setup
+        deployment_name = "no-status-deployment"
+        namespace = "test-namespace"
+        
+        # Create mock deployment without status
+        mock_deployment = V1Deployment(
+            metadata=V1ObjectMeta(
+                name=deployment_name,
+                namespace=namespace
+            ),
+            status=None  # No status
+        )
+        mock_read_deployment.return_value = mock_deployment
+
+        # Execute
+        result = self.client.get_deployment(deployment_name, namespace)
+
+        # Verify
+        mock_read_deployment.assert_called_once_with(name=deployment_name, namespace=namespace)
+        self.assertEqual(result, mock_deployment)
+        self.assertEqual(result.metadata.name, deployment_name)
+        self.assertIsNone(result.status)
 
     @patch('kubernetes.client.AppsV1Api.patch_namespaced_deployment')
     def test_patch_deployment_with_node_selector_only(self, mock_patch_deployment):

--- a/modules/python/tests/gpu/test_gpu.py
+++ b/modules/python/tests/gpu/test_gpu.py
@@ -7,19 +7,21 @@ import os
 import tempfile
 from unittest.mock import patch, MagicMock, mock_open, call
 import requests
-from gpu.gpu import (
-    _install_operator,
-    _verify_rdma,
-    install_network_operator,
-    install_gpu_operator,
-    install_mpi_operator,
-    configure,
-    _create_topology_configmap,
-    execute,
-    _parse_nccl_test_results,
-    collect,
-    main,
-)
+# Mock kubernetes config before importing
+with patch('kubernetes.config.load_kube_config'):
+    from gpu.gpu import (
+        _install_operator,
+        _verify_rdma,
+        install_network_operator,
+        install_gpu_operator,
+        install_mpi_operator,
+        configure,
+        _create_topology_configmap,
+        execute,
+        _parse_nccl_test_results,
+        collect,
+        main,
+    )
 from utils.logger_config import setup_logging, get_logger
 
 # Configure logging

--- a/modules/python/tests/test_fio.py
+++ b/modules/python/tests/test_fio.py
@@ -2,7 +2,9 @@ import unittest
 import json
 from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock, mock_open
-from fio.fio import validate, execute, collect, main
+# Mock kubernetes config before importing
+with patch('kubernetes.config.load_kube_config'):
+    from fio.fio import validate, execute, collect, main
 
 class TestFio(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This pull request refactors the KWOK integration and validation logic, improves Kubernetes client functionality, and enhances the corresponding test coverage. The main changes include removing direct KWOK cluster management from CI, introducing a new method for retrieving deployments in the Kubernetes client, updating KWOK validation to check for the controller deployment, and improving test isolation and coverage for KWOK and Kubernetes client modules.

**KWOK integration and validation improvements:**
* Removed KWOK cluster creation and deletion steps from the CI workflow (`.github/workflows/python-validation.yml`) and corresponding documentation, simplifying the validation process and reducing external dependencies. [[1]](diffhunk://#diff-0dbadba4800b6743680bb7eefc04fe8a086d7c7721d8743cd1b43bd4334746dcL44-L61) [[2]](diffhunk://#diff-ae98534d6afffc904ca94cc8203bc5d92d26805733490b2999ccc6b412d0c8dbL15-L26) [[3]](diffhunk://#diff-ae98534d6afffc904ca94cc8203bc5d92d26805733490b2999ccc6b412d0c8dbL38-L40)
* Refactored `kwok.py` validation logic to explicitly check that the `kwok-controller` deployment is running with one available replica, using the new `get_deployment` method.

**Kubernetes client enhancements:**
* Added a new `get_deployment` method to `KubernetesClient` for robust retrieval of deployments by name and namespace, with detailed error handling for not found, API exceptions, and unexpected errors.

**Test coverage and isolation improvements:**
* Added comprehensive unit tests for the new `get_deployment` method, covering success, not found, API errors, unexpected exceptions, and KWOK controller scenarios (`test_kubernetes_client.py`). [[1]](diffhunk://#diff-c5ebb20adc6849720c544d8951af800b85f4b3b2dc2aee88b7791df56961ab41R4993-R5147) [[2]](diffhunk://#diff-c5ebb20adc6849720c544d8951af800b85f4b3b2dc2aee88b7791df56961ab41L17-R17)
* Updated KWOK node integration tests to mock Kubernetes config loading, improve isolation, and verify DRA (Device Resource Assignment) related calls for node creation and teardown. [[1]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820L6-R7) [[2]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820L41-L84) [[3]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820L94-R76) [[4]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820R86-R105) [[5]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820R124-R142) [[6]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820R157-R158) [[7]](diffhunk://#diff-9223ae510a2cbbc754e764f424245a78df2d8305633fe5fbd71a437042294820L164-R187)
* Applied similar config mocking for GPU and AKS store demo tests to prevent unwanted cluster config loading during test runs. [[1]](diffhunk://#diff-6bd17a66460a6eb0c065f7e69f42ecd0a629852da56ec64013cb34779e906b74R10-R11) [[2]](diffhunk://#diff-1dc256853a2ec9af78942c40094948f657efa483df1961d72cbf14040504004bR7-R8) [[3]](diffhunk://#diff-1dc256853a2ec9af78942c40094948f657efa483df1961d72cbf14040504004bL228-R231)

These changes collectively improve reliability, maintainability, and testability of the KWOK and Kubernetes client integration.