### PR TITLE
Add DRA enabled argument to JobController and update related tests and collect script

### DIFF
--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -1584,3 +1584,24 @@ class KubernetesClient:
         except Exception as e:
             logger.error(f"Unexpected error patching deployment {name}: {str(e)}")
             raise Exception(f"Unexpected error patching deployment {name}: {str(e)}") from e
+
+    def get_config_map(self, name, namespace):
+        """
+        Get a ConfigMap by name from the specified namespace.
+
+        :param name: Name of the ConfigMap to retrieve
+        :param namespace: Namespace where the ConfigMap is located
+        :return: ConfigMap object if found, None if not found
+        """
+        try:
+            config_map = self.api.read_namespaced_config_map(name=name, namespace=namespace)
+            return config_map
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                logger.info(f"ConfigMap '{name}' not found in namespace '{namespace}'")
+                return None
+            logger.error(f"Error getting ConfigMap '{name}' from namespace '{namespace}': {str(e)}")
+            raise Exception(f"Error getting ConfigMap '{name}' from namespace '{namespace}': {str(e)}") from e
+        except Exception as e:
+            logger.error(f"Unexpected error getting ConfigMap '{name}' from namespace '{namespace}': {str(e)}")
+            raise Exception(f"Unexpected error getting ConfigMap '{name}' from namespace '{namespace}': {str(e)}") from e

--- a/modules/python/clusterloader2/job_controller/job_controller.py
+++ b/modules/python/clusterloader2/job_controller/job_controller.py
@@ -147,7 +147,7 @@ class JobController(ClusterLoader2Base):
             "--job_gpu", type=int, default=0, help="Number of GPUs per job"
         )
         parser.add_argument(
-            "--dra-enabled",
+            "--dra_enabled",
             type=str2bool,
             choices=[True, False],
             default=False,
@@ -177,7 +177,7 @@ class JobController(ClusterLoader2Base):
             help="Node label selectors to filter nodes (e.g., 'kubernetes.io/role=worker')",
         )
         parser.add_argument(
-            "--dra-enabled",
+            "--dra_enabled",
             type=str2bool,
             choices=[True, False],
             default=False,
@@ -244,7 +244,7 @@ class JobController(ClusterLoader2Base):
             "--job_gpu", type=int, default=0, help="Number of GPUs per job"
         )
         parser.add_argument(
-            "--dra-enabled",
+            "--dra_enabled",
             type=str2bool,
             choices=[True, False],
             default=False,

--- a/modules/python/clusterloader2/job_controller/job_controller.py
+++ b/modules/python/clusterloader2/job_controller/job_controller.py
@@ -176,6 +176,13 @@ class JobController(ClusterLoader2Base):
             default=None,
             help="Node label selectors to filter nodes (e.g., 'kubernetes.io/role=worker')",
         )
+        parser.add_argument(
+            "--dra-enabled",
+            type=str2bool,
+            choices=[True, False],
+            default=False,
+            help="Whether to enable DRA. Must be either True or False",
+        )
 
     @staticmethod
     def add_execute_subparser_arguments(parser):
@@ -235,6 +242,13 @@ class JobController(ClusterLoader2Base):
         )
         parser.add_argument(
             "--job_gpu", type=int, default=0, help="Number of GPUs per job"
+        )
+        parser.add_argument(
+            "--dra-enabled",
+            type=str2bool,
+            choices=[True, False],
+            default=False,
+            help="Whether to enable DRA. Must be either True or False",
         )
 
 

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -157,7 +157,7 @@ class Node(KWOK):
     def validate(self):
         execute_with_retries(
             self._validate_kwok_controller,
-            max_retries=10,
+            max_retries=30,
         )
 
         execute_with_retries(

--- a/modules/python/tests/clients/test_kubernetes_client.py
+++ b/modules/python/tests/clients/test_kubernetes_client.py
@@ -14,7 +14,7 @@ from kubernetes.client.models import (
     V1VolumeAttachment, V1VolumeAttachmentStatus, V1VolumeAttachmentSpec, V1VolumeAttachmentSource,
     V1PodStatus, V1Pod, V1PodSpec, V1Namespace, V1PodCondition,
     V1Service, V1ServiceStatus, V1LoadBalancerStatus, V1LoadBalancerIngress, V1NodeSystemInfo,
-    V1PodList, V1Deployment, V1DeploymentStatus
+    V1PodList, V1Deployment, V1DeploymentStatus, V1ConfigMap
 )
 from kubernetes.client.rest import ApiException
 
@@ -5737,6 +5737,181 @@ spec:
         call_args = mock_delete_custom_object.call_args
         delete_options = call_args[1]['body']
         self.assertIsInstance(delete_options, client.V1DeleteOptions)
+
+    @patch('kubernetes.client.CoreV1Api.read_namespaced_config_map')
+    def test_get_config_map_success(self, mock_read_config_map):
+        """Test successful retrieval of a ConfigMap."""
+        # Setup
+        config_map_name = "test-config"
+        namespace = "test-namespace"
+
+        # Create mock ConfigMap
+        mock_config_map = V1ConfigMap(
+            metadata=V1ObjectMeta(
+                name=config_map_name,
+                namespace=namespace
+            ),
+            data={
+                "config.yaml": "key: value",
+                "app.properties": "setting=enabled"
+            }
+        )
+        mock_read_config_map.return_value = mock_config_map
+
+        # Execute
+        result = self.client.get_config_map(config_map_name, namespace)
+
+        # Verify
+        mock_read_config_map.assert_called_once_with(name=config_map_name, namespace=namespace)
+        self.assertEqual(result, mock_config_map)
+        self.assertEqual(result.metadata.name, config_map_name)
+        self.assertEqual(result.metadata.namespace, namespace)
+        self.assertEqual(result.data["config.yaml"], "key: value")
+
+    @patch('kubernetes.client.CoreV1Api.read_namespaced_config_map')
+    def test_get_config_map_not_found(self, mock_read_config_map):
+        """Test get_config_map when ConfigMap is not found (404 error)."""
+        # Setup
+        config_map_name = "nonexistent-config"
+        namespace = "test-namespace"
+
+        # Mock 404 exception
+        mock_read_config_map.side_effect = client.rest.ApiException(
+            status=404,
+            reason="Not Found"
+        )
+
+        # Execute
+        result = self.client.get_config_map(config_map_name, namespace)
+
+        # Verify
+        mock_read_config_map.assert_called_once_with(name=config_map_name, namespace=namespace)
+        self.assertIsNone(result)
+
+    @patch('kubernetes.client.CoreV1Api.read_namespaced_config_map')
+    def test_get_config_map_api_exception_403(self, mock_read_config_map):
+        """Test get_config_map when API exception other than 404 occurs (403 Forbidden)."""
+        # Setup
+        config_map_name = "forbidden-config"
+        namespace = "test-namespace"
+
+        # Mock 403 forbidden exception
+        api_exception = client.rest.ApiException(
+            status=403,
+            reason="Forbidden"
+        )
+        mock_read_config_map.side_effect = api_exception
+
+        # Execute & Verify
+        with self.assertRaises(Exception) as context:
+            self.client.get_config_map(config_map_name, namespace)
+
+        # Verify exception message and cause
+        self.assertIn(f"Error getting ConfigMap '{config_map_name}' from namespace '{namespace}'", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, client.rest.ApiException)
+        self.assertEqual(context.exception.__cause__.status, 403)
+        mock_read_config_map.assert_called_once_with(name=config_map_name, namespace=namespace)
+
+    @patch('kubernetes.client.CoreV1Api.read_namespaced_config_map')
+    def test_get_config_map_api_exception_500(self, mock_read_config_map):
+        """Test get_config_map when API exception 500 occurs."""
+        # Setup
+        config_map_name = "error-config"
+        namespace = "test-namespace"
+
+        # Mock 500 internal server error exception
+        api_exception = client.rest.ApiException(
+            status=500,
+            reason="Internal Server Error"
+        )
+        mock_read_config_map.side_effect = api_exception
+
+        # Execute & Verify
+        with self.assertRaises(Exception) as context:
+            self.client.get_config_map(config_map_name, namespace)
+
+        # Verify exception message and cause
+        self.assertIn(f"Error getting ConfigMap '{config_map_name}' from namespace '{namespace}'", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, client.rest.ApiException)
+        self.assertEqual(context.exception.__cause__.status, 500)
+        mock_read_config_map.assert_called_once_with(name=config_map_name, namespace=namespace)
+
+    @patch('kubernetes.client.CoreV1Api.read_namespaced_config_map')
+    def test_get_config_map_unexpected_exception(self, mock_read_config_map):
+        """Test get_config_map when unexpected exception occurs."""
+        # Setup
+        config_map_name = "error-config"
+        namespace = "test-namespace"
+
+        # Mock unexpected exception
+        mock_read_config_map.side_effect = ValueError("Unexpected error")
+
+        # Execute & Verify
+        with self.assertRaises(Exception) as context:
+            self.client.get_config_map(config_map_name, namespace)
+
+        # Verify exception message and cause
+        self.assertIn(f"Unexpected error getting ConfigMap '{config_map_name}' from namespace '{namespace}'", str(context.exception))
+        self.assertIsInstance(context.exception.__cause__, ValueError)
+        mock_read_config_map.assert_called_once_with(name=config_map_name, namespace=namespace)
+
+    @patch('kubernetes.client.CoreV1Api.read_namespaced_config_map')
+    def test_get_config_map_with_empty_data(self, mock_read_config_map):
+        """Test get_config_map with ConfigMap that has empty data."""
+        # Setup
+        config_map_name = "empty-config"
+        namespace = "test-namespace"
+
+        # Create mock ConfigMap with empty data
+        mock_config_map = V1ConfigMap(
+            metadata=V1ObjectMeta(
+                name=config_map_name,
+                namespace=namespace
+            ),
+            data={}
+        )
+        mock_read_config_map.return_value = mock_config_map
+
+        # Execute
+        result = self.client.get_config_map(config_map_name, namespace)
+
+        # Verify
+        mock_read_config_map.assert_called_once_with(name=config_map_name, namespace=namespace)
+        self.assertEqual(result, mock_config_map)
+        self.assertEqual(result.metadata.name, config_map_name)
+        self.assertEqual(result.data, {})
+
+    @patch('kubernetes.client.CoreV1Api.read_namespaced_config_map')
+    def test_get_config_map_with_labels_and_annotations(self, mock_read_config_map):
+        """Test get_config_map with ConfigMap that has labels and annotations."""
+        # Setup
+        config_map_name = "labeled-config"
+        namespace = "test-namespace"
+
+        # Create mock ConfigMap with labels and annotations
+        mock_config_map = V1ConfigMap(
+            metadata=V1ObjectMeta(
+                name=config_map_name,
+                namespace=namespace,
+                labels={"app": "test-app", "version": "1.0"},
+                annotations={"description": "Test configuration"}
+            ),
+            data={
+                "database.url": "mysql://localhost:3306/testdb",
+                "cache.enabled": "true"
+            }
+        )
+        mock_read_config_map.return_value = mock_config_map
+
+        # Execute
+        result = self.client.get_config_map(config_map_name, namespace)
+
+        # Verify
+        mock_read_config_map.assert_called_once_with(name=config_map_name, namespace=namespace)
+        self.assertEqual(result, mock_config_map)
+        self.assertEqual(result.metadata.labels["app"], "test-app")
+        self.assertEqual(result.metadata.annotations["description"], "Test configuration")
+        self.assertEqual(result.data["database.url"], "mysql://localhost:3306/testdb")
 
 
 if __name__ == '__main__':

--- a/modules/python/tests/test_job_controller.py
+++ b/modules/python/tests/test_job_controller.py
@@ -41,6 +41,7 @@ class TestJobControllerBenchmark(unittest.TestCase):
             node_count=2,
             operation_timeout_in_minutes=600,
             node_label="role=worker",
+            dra_enabled=True,
         )
         benchmark.validate_clusterloader2()
         mock_kube_client_class.assert_called_once()
@@ -133,6 +134,7 @@ class TestJobControllerParser(unittest.TestCase):
         self.assertIn("node_count", validate_args)
         self.assertIn("operation_timeout_in_minutes", validate_args)
         self.assertIn("node_label", validate_args)
+        self.assertIn("dra_enabled", validate_args)
 
         # Test that execute subparser has expected arguments
         execute_parser = subparsers_action.choices["execute"]
@@ -158,6 +160,7 @@ class TestJobControllerParser(unittest.TestCase):
         self.assertIn("test_type", collect_args)
         self.assertIn("job_count", collect_args)
         self.assertIn("job_throughput", collect_args)
+        self.assertIn("dra_enabled", collect_args)
 
 
 if __name__ == "__main__":

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-scheduling.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-scheduling.yml
@@ -133,6 +133,7 @@ stages:
           scale_timeout: "30m"
           cl2_config_file: config.yaml
           node_gpu: 8
+          job_gpu: 8
           enable_dra: true
           job_template_path: dra/job_template.yaml
       max_parallel: 1
@@ -163,6 +164,7 @@ stages:
           scale_timeout: "45m"
           cl2_config_file: config.yaml
           node_gpu: 8
+          job_gpu: 8
           enable_dra: true
           job_template_path: dra/job_template.yaml
       max_parallel: 1
@@ -193,6 +195,7 @@ stages:
           scale_timeout: "1h"
           cl2_config_file: config.yaml
           node_gpu: 8
+          job_gpu: 8
           enable_dra: true
           job_template_path: dra/job_template.yaml
       max_parallel: 1

--- a/steps/engine/clusterloader2/job_controller/collect.yml
+++ b/steps/engine/clusterloader2/job_controller/collect.yml
@@ -19,13 +19,13 @@ steps:
         --node_count $NODE_COUNT \
         --job_throughput $JOB_THROUGHPUT \
         --job_count $JOB_COUNT \
+        --dra_enabled ${ENABLE_DRA:-False} \
+        --job_gpu ${JOB_GPU:-0} \
         --cl2_report_dir $CL2_REPORT_DIR \
         --cloud_info "$CLOUD_INFO" \
         --run_id $RUN_ID \
         --run_url $RUN_URL \
-        --result_file $TEST_RESULTS_FILE \
-        --dra-enabled $ENABLE_DRA \
-        --job-gpu $JOB_GPU
+        --result_file $TEST_RESULTS_FILE
     workingDirectory: modules/python
     env:
       CLOUD: ${{ parameters.cloud }}

--- a/steps/engine/clusterloader2/job_controller/collect.yml
+++ b/steps/engine/clusterloader2/job_controller/collect.yml
@@ -24,7 +24,8 @@ steps:
         --run_id $RUN_ID \
         --run_url $RUN_URL \
         --result_file $TEST_RESULTS_FILE \
-        --dra-enabled $ENABLE_DRA
+        --dra-enabled $ENABLE_DRA \
+        --job-gpu $JOB_GPU
     workingDirectory: modules/python
     env:
       CLOUD: ${{ parameters.cloud }}

--- a/steps/engine/clusterloader2/job_controller/collect.yml
+++ b/steps/engine/clusterloader2/job_controller/collect.yml
@@ -23,7 +23,8 @@ steps:
         --cloud_info "$CLOUD_INFO" \
         --run_id $RUN_ID \
         --run_url $RUN_URL \
-        --result_file $TEST_RESULTS_FILE
+        --result_file $TEST_RESULTS_FILE \
+        --dra-enabled $ENABLE_DRA
     workingDirectory: modules/python
     env:
       CLOUD: ${{ parameters.cloud }}

--- a/steps/engine/clusterloader2/job_controller/execute.yml
+++ b/steps/engine/clusterloader2/job_controller/execute.yml
@@ -18,7 +18,8 @@ steps:
         --job_template_path ${JOB_TEMPLATE_PATH:-job_template.yaml} \
         --operation_timeout $SCALE_TIMEOUT \
         --prometheus_enabled ${PROMETHEUS_ENABLED:-False} \
-        --dra-enabled ${ENABLE_DRA:-False} \
+        --dra_enabled ${ENABLE_DRA:-False} \
+        --job_gpu ${JOB_GPU:-0} \
         --cl2_override_file ${CL2_CONFIG_DIR}/overrides.yaml
 
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \


### PR DESCRIPTION
This pull request adds support for a new `--dra-enabled` argument to the `clusterloader2` job controller, allowing users to enable or disable DRA (Dynamic Resource Allocation) via command-line flags. The changes ensure this option is available and tested across relevant subparsers and workflow steps.

### Argument and CLI Integration

* Added a `--dra-enabled` argument to the `validate` and `collect` subparsers in `job_controller.py`, allowing users to specify DRA support as either True or False. [[1]](diffhunk://#diff-25d8b8518f689030ebd0698a0d65ec64a5d8d7fe1e1d42e5645b5e0526b047c3R179-R185) [[2]](diffhunk://#diff-25d8b8518f689030ebd0698a0d65ec64a5d8d7fe1e1d42e5645b5e0526b047c3R246-R252)
* Updated the workflow step in `collect.yml` to pass the `--dra-enabled` flag using the `$ENABLE_DRA` environment variable.

### Test Coverage

* Updated tests to include and check for the new `dra_enabled` argument in both the `validate` and `collect` subparsers, ensuring parser correctness. [[1]](diffhunk://#diff-ce7d17d855b1865dbc7559fbc4cd707f73f900c88844175a05604edf2ff7a945R137) [[2]](diffhunk://#diff-ce7d17d855b1865dbc7559fbc4cd707f73f900c88844175a05604edf2ff7a945R163)
* Modified the `test_validate_clusterloader2` test to set `dra_enabled=True` and verify correct behavior when DRA is enabled.