### PR TITLE
Refactor functions to be used in GPU test

### DIFF
--- a/modules/python/clusterloader2/cri/cri.py
+++ b/modules/python/clusterloader2/cri/cri.py
@@ -4,9 +4,10 @@ import argparse
 import math
 
 from datetime import datetime, timezone
-from clusterloader2.utils import parse_xml_to_json, run_cl2_command, get_measurement, str2bool
+from clusterloader2.utils import parse_xml_to_json, run_cl2_command, get_measurement
 from clients.kubernetes_client import KubernetesClient, client as k8s_client
 from utils.logger_config import get_logger, setup_logging
+from utils.common import str2bool
 
 setup_logging()
 logger = get_logger(__name__)

--- a/modules/python/clusterloader2/job_controller/job_controller.py
+++ b/modules/python/clusterloader2/job_controller/job_controller.py
@@ -9,9 +9,9 @@ from clusterloader2.utils import (
     parse_xml_to_json,
     process_cl2_reports,
     run_cl2_command,
-    str2bool,
 )
 from utils.logger_config import get_logger, setup_logging
+from utils.common import str2bool
 
 setup_logging()
 logger = get_logger(__name__)

--- a/modules/python/clusterloader2/network-load/network_load.py
+++ b/modules/python/clusterloader2/network-load/network_load.py
@@ -3,7 +3,8 @@ import os
 import argparse
 
 from datetime import datetime, timezone
-from clusterloader2.utils import str2bool, parse_xml_to_json, run_cl2_command, get_measurement
+from clusterloader2.utils import parse_xml_to_json, run_cl2_command, get_measurement
+from utils.common import str2bool
 
 DEFAULT_NODES_PER_NAMESPACE = 100
 CPU_REQUEST_LIMIT_MILLI = 1

--- a/modules/python/clusterloader2/slo/network_policy_scale.py
+++ b/modules/python/clusterloader2/slo/network_policy_scale.py
@@ -3,7 +3,8 @@ import os
 import argparse
 
 from datetime import datetime, timezone
-from clusterloader2.utils import parse_xml_to_json, get_measurement,run_cl2_command, str2bool
+from clusterloader2.utils import parse_xml_to_json, get_measurement,run_cl2_command
+from utils.common import str2bool
 
 def configure_clusterloader2(
     number_of_groups,

--- a/modules/python/clusterloader2/slo/slo.py
+++ b/modules/python/clusterloader2/slo/slo.py
@@ -4,8 +4,9 @@ import argparse
 import time
 
 from datetime import datetime, timezone
-from clusterloader2.utils import parse_xml_to_json, run_cl2_command, get_measurement, str2bool
+from clusterloader2.utils import parse_xml_to_json, run_cl2_command, get_measurement
 from clients.kubernetes_client import KubernetesClient
+from utils.common import str2bool
 
 DEFAULT_PODS_PER_NODE = 40
 

--- a/modules/python/clusterloader2/utils.py
+++ b/modules/python/clusterloader2/utils.py
@@ -1,7 +1,6 @@
 from xml.dom import minidom
 import json
 import os
-import argparse
 import docker
 from clients.docker_client import DockerClient
 from utils.logger_config import get_logger, setup_logging
@@ -193,13 +192,3 @@ def parse_xml_to_json(file_path, indent=0):
     # Convert the result dictionary to JSON
     json_result = json.dumps(result, indent=indent)
     return json_result
-
-
-def str2bool(val):
-    if isinstance(val, bool):
-        return val
-    if val.lower() in ("true", "yes", "1"):
-        return True
-    if val.lower() in ("false", "no", "0"):
-        return False
-    raise argparse.ArgumentTypeError("Boolean value expected.")

--- a/modules/python/gpu/gpu.py
+++ b/modules/python/gpu/gpu.py
@@ -91,10 +91,10 @@ def install_network_operator(
         config_dir=config_dir,
     )
     execute_with_retries(
-        KUBERNETES_CLIENT.wait_for_labeled_pods_ready,
+        KUBERNETES_CLIENT.wait_for_pods_ready,
         label_selector="app.kubernetes.io/instance=network-operator",
         namespace="network-operator",
-        timeout_in_minutes=5,
+        operation_timeout_in_minutes=5,
     )
 
     nfd_file = f"{config_dir}/network-operator/node-feature-discovery.yaml"
@@ -102,16 +102,16 @@ def install_network_operator(
     nic_file = f"{config_dir}/network-operator/nic-cluster-policy.yaml"
     KUBERNETES_CLIENT.apply_manifest_from_file(nic_file)
     execute_with_retries(
-        KUBERNETES_CLIENT.wait_for_labeled_pods_ready,
+        KUBERNETES_CLIENT.wait_for_pods_ready,
         label_selector="nvidia.com/ofed-driver=",
         namespace="network-operator",
-        timeout_in_minutes=5,
+        operation_timeout_in_minutes=5,
     )
     execute_with_retries(
-        KUBERNETES_CLIENT.wait_for_labeled_pods_ready,
+        KUBERNETES_CLIENT.wait_for_pods_ready,
         label_selector="app=rdma-shared-dp",
         namespace="network-operator",
-        timeout_in_minutes=5,
+        operation_timeout_in_minutes=5,
     )
     _verify_rdma()
 
@@ -131,16 +131,16 @@ def install_gpu_operator(
         chart_version=chart_version, operator_name="gpu-operator", config_dir=config_dir
     )
     execute_with_retries(
-        KUBERNETES_CLIENT.wait_for_labeled_pods_ready,
+        KUBERNETES_CLIENT.wait_for_pods_ready,
         label_selector="app.kubernetes.io/managed-by=gpu-operator",
         namespace="gpu-operator",
-        timeout_in_minutes=10,
+        operation_timeout_in_minutes=10,
     )
     execute_with_retries(
-        KUBERNETES_CLIENT.wait_for_labeled_pods_ready,
+        KUBERNETES_CLIENT.wait_for_pods_ready,
         label_selector="app.kubernetes.io/component=nvidia-driver",
         namespace="gpu-operator",
-        timeout_in_minutes=10,
+        operation_timeout_in_minutes=10,
     )
     execute_with_retries(
         KUBERNETES_CLIENT.wait_for_pods_completed,
@@ -162,10 +162,10 @@ def install_mpi_operator(
     mpi_file = f"https://raw.githubusercontent.com/kubeflow/mpi-operator/{chart_version}/deploy/v2beta1/mpi-operator.yaml"
     KUBERNETES_CLIENT.apply_manifest_from_url(mpi_file)
     execute_with_retries(
-        KUBERNETES_CLIENT.wait_for_labeled_pods_ready,
+        KUBERNETES_CLIENT.wait_for_pods_ready,
         label_selector="app.kubernetes.io/name=mpi-operator",
         namespace="mpi-operator",
-        timeout_in_minutes=5,
+        operation_timeout_in_minutes=5,
     )
 
 

--- a/modules/python/utils/common.py
+++ b/modules/python/utils/common.py
@@ -1,6 +1,7 @@
 import re
 import os
 import json
+import argparse
 from utils.logger_config import get_logger, setup_logging
 
 # Configure logging
@@ -61,3 +62,12 @@ def get_env_vars(name: str):
     if var is None:
         raise RuntimeError(f"Environment variable `{name}` not set")
     return var
+
+def str2bool(val):
+    if isinstance(val, bool):
+        return val
+    if val.lower() in ("true", "yes", "1"):
+        return True
+    if val.lower() in ("false", "no", "0"):
+        return False
+    raise argparse.ArgumentTypeError("Boolean value expected.")


### PR DESCRIPTION
This pull request refactors the handling of boolean argument parsing and improves the flexibility and robustness of the `wait_for_pods_ready` method in the Kubernetes client. The main changes include moving the `str2bool` utility to a more appropriate location, updating all imports accordingly, and enhancing the `wait_for_pods_ready` method to support dynamic pod counts. Additionally, related test cases and function calls have been updated to match the new interface.

**Refactoring and code organization:**

* Moved the `str2bool` utility function from `clusterloader2/utils.py` to `utils/common.py`, and updated all relevant imports in modules such as `cri.py`, `job_controller.py`, `network_load.py`, `network_policy_scale.py`, and `slo.py` to import `str2bool` from the new location. [[1]](diffhunk://#diff-97db04680354c69b105b2b5991eb78993027db07b934ec8ef2ad2b4d5911a75fL7-R10) [[2]](diffhunk://#diff-25d8b8518f689030ebd0698a0d65ec64a5d8d7fe1e1d42e5645b5e0526b047c3L12-R14) [[3]](diffhunk://#diff-5c051e121bfbce1fb877fea57978c3bd1e950cc9b7603f75dc71381c3aafedf1L6-R7) [[4]](diffhunk://#diff-2469a04726832705d88cb4b73de7adf9b1938531009dd629af17a7fcfd3272c8L6-R7) [[5]](diffhunk://#diff-2594888ced631a2698e425dee445068b1b8480a8761e0250ca693e842ddb1d30L7-R9) [[6]](diffhunk://#diff-e46631a8b31a54a4e3cb7da1eecbe362f53499f958d8dbd20fb8652e2b0b7d38L196-L205) [[7]](diffhunk://#diff-e46631a8b31a54a4e3cb7da1eecbe362f53499f958d8dbd20fb8652e2b0b7d38L4)

**Enhancements to Kubernetes client pod readiness logic:**

* Refactored the `wait_for_pods_ready` method in `kubernetes_client.py` to allow `pod_count` to be optional. If not provided, the method dynamically determines the expected pod count based on the current number of matching pods, improving flexibility for dynamic environments. The method now also returns the list of ready pods instead of `None`.

* Updated all usages of `wait_for_labeled_pods_ready` in `gpu.py` to use the improved `wait_for_pods_ready` method, and adjusted argument names for consistency. [[1]](diffhunk://#diff-f0ca02b82ccf087197ba09f9bf4d3b6cd4fcfa483835db6db49ce5be15dbfda4L94-R114) [[2]](diffhunk://#diff-f0ca02b82ccf087197ba09f9bf4d3b6cd4fcfa483835db6db49ce5be15dbfda4L134-R143) [[3]](diffhunk://#diff-f0ca02b82ccf087197ba09f9bf4d3b6cd4fcfa483835db6db49ce5be15dbfda4L165-R168)

**Testing improvements:**

* Enhanced the unit tests for `wait_for_pods_ready` in `test_kubernetes_client.py` to mock the new dynamic pod count behavior and ensure correct function and exception handling.