### PR TITLE
Handle Failure Operations & Update AWS Schedule

### DIFF
--- a/modules/python/clients/eks_client.py
+++ b/modules/python/clients/eks_client.py
@@ -400,6 +400,7 @@ class EKSClient:
                             instance_type,
                             self.subnet_azs,
                         )
+                        sys.exit(1)  # Exit if no reservation found
 
                 # Update create_params with the filtered subnets
                 create_params["subnets"] = filtered_subnets

--- a/modules/python/crud/aws/node_pool_crud.py
+++ b/modules/python/crud/aws/node_pool_crud.py
@@ -8,6 +8,7 @@ both direct and progressive scaling operations and handles GPU-enabled node grou
 
 import logging
 import time
+import sys
 
 from clients.eks_client import EKSClient
 from utils.logger_config import get_logger, setup_logging
@@ -80,6 +81,7 @@ class NodePoolCRUD:
             return result
         except Exception as e:
             logger.error(f"Failed to create node group '{node_pool_name}': {str(e)}")
+            sys.exit(1)  # Exit with error code
             return False
 
     def scale_node_pool(

--- a/modules/python/crud/aws/node_pool_crud.py
+++ b/modules/python/crud/aws/node_pool_crud.py
@@ -8,7 +8,6 @@ both direct and progressive scaling operations and handles GPU-enabled node grou
 
 import logging
 import time
-import sys
 
 from clients.eks_client import EKSClient
 from utils.logger_config import get_logger, setup_logging
@@ -81,7 +80,6 @@ class NodePoolCRUD:
             return result
         except Exception as e:
             logger.error(f"Failed to create node group '{node_pool_name}': {str(e)}")
-            sys.exit(1)  # Exit with error code
             return False
 
     def scale_node_pool(

--- a/modules/python/crud/main.py
+++ b/modules/python/crud/main.py
@@ -445,7 +445,6 @@ def main():
             logger.info("Operation completed successfully")
         else:
             logger.error(f"Operation failed with exit code: {exit_code}")
-            sys.exit(exit_code)
 
     except ImportError as import_error:
         error_msg = f"Import Error: {import_error}"

--- a/modules/python/tests/clients/test_eks_client.py
+++ b/modules/python/tests/clients/test_eks_client.py
@@ -1639,7 +1639,7 @@ class TestEKSClient(unittest.TestCase):
         self.assertEqual(create_call["subnets"], ["subnet-123"])
 
     def test_capacity_reservation_subnet_filtering_no_reservation(self):
-        """Test that all subnets are used when no capacity reservation is found"""
+        """Test that system exits when no capacity reservation is found for CAPACITY_BLOCK"""
         # Setup
         eks_client = EKSClient()
 
@@ -1656,23 +1656,18 @@ class TestEKSClient(unittest.TestCase):
         self.mock_eks.get_waiter.return_value.wait = mock.MagicMock()
         self.mock_k8s.wait_for_nodes_ready.return_value = ["node1"]
 
-        # Execute
-        result = eks_client.create_node_group(
-            node_group_name="test-no-reservation-ng",
-            instance_type="p3.2xlarge",
-            node_count=1,
-            gpu_node_group=True,
-            capacity_type="CAPACITY_BLOCK",
-        )
+        # Execute and expect SystemExit
+        with self.assertRaises(SystemExit) as context:
+            eks_client.create_node_group(
+                node_group_name="test-no-reservation-ng",
+                instance_type="p3.2xlarge",
+                node_count=1,
+                gpu_node_group=True,
+                capacity_type="CAPACITY_BLOCK",
+            )
 
-        # Verify
-        self.assertTrue(result)
-
-        # Check that node group was created with all subnets
-        create_call = self.mock_eks.create_nodegroup.call_args[1]
-        self.assertIn("subnets", create_call)
-        # Should contain both subnets when no reservation is found
-        self.assertEqual(create_call["subnets"], ["subnet-123", "subnet-456"])
+        # Verify it exits with code 1
+        self.assertEqual(context.exception.code, 1)
 
     def test_capacity_reservation_subnet_filtering_no_matching_subnet(self):
         """Test error when capacity reservation AZ has no matching subnet"""

--- a/modules/python/tests/crud/test_main.py
+++ b/modules/python/tests/crud/test_main.py
@@ -647,7 +647,6 @@ class TestMainFunctionIntegration(unittest.TestCase):
 
         # Operation should complete successfully (no exit call in normal flow)
 
-    @mock.patch("sys.exit")
     @mock.patch("crud.main.logger")
     @mock.patch("crud.main.OperationContext")
     @mock.patch("crud.main.AzureNodePoolCRUD")
@@ -656,7 +655,6 @@ class TestMainFunctionIntegration(unittest.TestCase):
         mock_azure_crud_class,
         mock_operation_context,  # pylint: disable=unused-argument
         mock_logger,  # pylint: disable=unused-argument
-        mock_exit,
     ):
         """Test main function when operation returns False"""
         # Setup
@@ -680,9 +678,8 @@ class TestMainFunctionIntegration(unittest.TestCase):
         with mock.patch("sys.argv", test_args):
             main()  # Use the imported main function
 
-        # Verify error is logged and sys.exit is called with code 1
+        # Verify error is logged but sys.exit is not called
         mock_logger.error.assert_called_with("Operation failed with exit code: 1")
-        mock_exit.assert_called_with(1)
 
     @mock.patch("sys.exit")
     @mock.patch("crud.main.logger")
@@ -1248,11 +1245,10 @@ class TestMainErrorHandlingEdgeCases(unittest.TestCase):
         """Clean up after tests"""
         shutil.rmtree(self.test_dir)
 
-    @mock.patch("sys.exit")
     @mock.patch("crud.main.logger")
     @mock.patch("crud.main.AzureNodePoolCRUD")
     def test_main_operation_returns_explicit_exit_code(
-        self, mock_azure_crud_class, mock_logger, mock_exit
+        self, mock_azure_crud_class, mock_logger
     ):
         """Test main function when operation returns explicit exit code"""
         # Setup - simulate function returning explicit exit code (integer)
@@ -1281,9 +1277,8 @@ class TestMainErrorHandlingEdgeCases(unittest.TestCase):
             ):
                 main()
 
-        # Should log error with the specific exit code and call sys.exit
+        # Should log error with the specific exit code but not call sys.exit
         mock_logger.error.assert_called_with("Operation failed with exit code: 42")
-        mock_exit.assert_called_with(42)
 
     @mock.patch("crud.main.logger")
     @mock.patch("crud.main.AzureNodePoolCRUD")
@@ -1318,10 +1313,9 @@ class TestMainErrorHandlingEdgeCases(unittest.TestCase):
         # Should log success
         mock_logger.info.assert_called_with("Operation completed successfully")
 
-    @mock.patch("sys.exit")
     @mock.patch("crud.main.logger")
     @mock.patch("crud.main.AzureNodePoolCRUD")
-    def test_main_operation_returns_false(self, mock_azure_crud_class, mock_logger, mock_exit):
+    def test_main_operation_returns_false(self, mock_azure_crud_class, mock_logger):
         """Test main function when operation returns False (failure)"""
         # Setup
         mock_node_pool_crud = mock.MagicMock()
@@ -1349,9 +1343,8 @@ class TestMainErrorHandlingEdgeCases(unittest.TestCase):
             ):
                 main()
 
-        # Should log error and call sys.exit
+        # Should log error but not call sys.exit
         mock_logger.error.assert_called_with("Operation failed with exit code: 1")
-        mock_exit.assert_called_with(1)
 
 
 if __name__ == "__main__":

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -21,7 +21,7 @@ schedules:
         - main
     always: true
   - cron: "0 0-12 21 * *"
-    displayName: "21th of every month for every 1 hr"
+    displayName: "21st of every month for every 1 hr"
     branches:
       include:
         - main
@@ -96,7 +96,7 @@ stages:
     condition: |
       or(
         eq(variables['Build.CronSchedule.DisplayName'], '20th of every month for every 1 hr'),
-        eq(variables['Build.CronSchedule.DisplayName'], '21th of every month for every 1 hr'),
+        eq(variables['Build.CronSchedule.DisplayName'], '21st of every month for every 1 hr'),
         eq(variables['Build.Reason'], 'Manual')
       )
     jobs:
@@ -128,7 +128,7 @@ stages:
     condition: |
       or(
         eq(variables['Build.CronSchedule.DisplayName'], '20th of every month for every 1 hr'),
-        eq(variables['Build.CronSchedule.DisplayName'], '21th of every month for every 1 hr'),
+        eq(variables['Build.CronSchedule.DisplayName'], '21st of every month for every 1 hr'),
         eq(variables['Build.Reason'], 'Manual')
       )
     jobs:

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -13,6 +13,13 @@ schedules:
       include:
         - main
     always: true
+    # AWS GPU Cluster CRUD Test
+  - cron: "30 0-23/1 20 * *"
+    displayName: "20th of every month for every 1 hr"
+    branches:
+      include:
+        - main
+    always: true
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-gpu-cluster-crud
@@ -80,7 +87,11 @@ stages:
 
   - stage: aws_H100_gpu_test
     dependsOn: []
-    condition: and(eq(variables['Build.Reason'], 'Manual'), eq(variables['RUN_AWS'], 'true'))
+    condition: |
+      or(
+        eq(variables['Build.CronSchedule.DisplayName'], '20th of every month for every 1 hr'),
+        eq(variables['Build.Reason'], 'Manual')
+      )
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:
@@ -107,7 +118,11 @@ stages:
 
   - stage: aws_A100_gpu_test
     dependsOn: []
-    condition: and(eq(variables['Build.Reason'], 'Manual'), eq(variables['RUN_AWS'], 'true'))
+    condition: |
+      or(
+        eq(variables['Build.CronSchedule.DisplayName'], '20th of every month for every 1 hr'),
+        eq(variables['Build.Reason'], 'Manual')
+      )
     jobs:
       - template: /jobs/competitive-test.yml
         parameters:

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -25,7 +25,7 @@ schedules:
     branches:
       include:
         - main
-    always: true    
+    always: true
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-gpu-cluster-crud

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -13,13 +13,19 @@ schedules:
       include:
         - main
     always: true
-    # AWS GPU Cluster CRUD Test
-  - cron: "30 0-23/1 20 * *"
+    # AWS GPU Cluster CRUD Test (20th 8:00 AM EST to 21st 8:00 AM EST)Based on Capacity Reservation time slot
+  - cron: "0 13-23 20 * *"
     displayName: "20th of every month for every 1 hr"
     branches:
       include:
         - main
     always: true
+  - cron: "0 0-12 21 * *"
+    displayName: "21th of every month for every 1 hr"
+    branches:
+      include:
+        - main
+    always: true    
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-gpu-cluster-crud
@@ -90,6 +96,7 @@ stages:
     condition: |
       or(
         eq(variables['Build.CronSchedule.DisplayName'], '20th of every month for every 1 hr'),
+        eq(variables['Build.CronSchedule.DisplayName'], '21th of every month for every 1 hr'),
         eq(variables['Build.Reason'], 'Manual')
       )
     jobs:
@@ -121,6 +128,7 @@ stages:
     condition: |
       or(
         eq(variables['Build.CronSchedule.DisplayName'], '20th of every month for every 1 hr'),
+        eq(variables['Build.CronSchedule.DisplayName'], '21th of every month for every 1 hr'),
         eq(variables['Build.Reason'], 'Manual')
       )
     jobs:


### PR DESCRIPTION
This pull request introduces improvements to the AWS GPU cluster CRUD pipeline scheduling and execution logic, as well as minor error handling changes in the Python client and CRUD scripts. The main focus is on enabling automated GPU test stages to run during specific monthly time windows, aligning with AWS capacity reservation periods.

**Pipeline scheduling and execution:**

* Added two new cron schedules to `k8s-gpu-cluster-crud.yml` to run the pipeline hourly on the 20th and 21st of each month, matching AWS GPU cluster capacity reservation windows.
* Updated the `aws_H100_gpu_test` and `aws_A100_gpu_test` stage conditions to allow execution during these new scheduled windows or when manually triggered, instead of only running on manual builds with a specific variable. [[1]](diffhunk://#diff-c6228a595aaaedad723b7fd0d72c07d3625e8435afd42d07986385b84473cf1cL83-R101) [[2]](diffhunk://#diff-c6228a595aaaedad723b7fd0d72c07d3625e8435afd42d07986385b84473cf1cL110-R133)

**Error handling:**

* In `eks_client.py`, added an explicit `sys.exit(1)` if no AWS reservation is found during node group creation, ensuring the process terminates on this error.
* In `main.py`, removed a redundant `sys.exit(exit_code)` call after logging operation failure, likely to improve error propagation or logging.