### PR TITLE
Update GPU scheduling benchmark with custom configuration

### DIFF
--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-scheduling.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-scheduling.yml
@@ -109,8 +109,6 @@ stages:
 
 - stage: azure_eastus2_dra_small
   dependsOn: []
-  variables:
-  - group: DRA-Enabled
   condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 AM daily (small scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml
@@ -139,8 +137,6 @@ stages:
 
 - stage: azure_eastus2_dra_medium
   dependsOn: []
-  variables:
-  - group: DRA-Enabled
   condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 PM on Mondays and Wednesday (medium scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml
@@ -169,8 +165,6 @@ stages:
 
 - stage: azure_eastus2_dra_high
   dependsOn: []
-  variables:
-  - group: DRA-Enabled
   condition: or(and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.CronSchedule.DisplayName'], '4:00 PM on Thursdays (high scale)')), eq(variables['Build.Reason'], 'Manual'))
   jobs:
   - template: /jobs/competitive-test.yml

--- a/scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars
@@ -7,7 +7,7 @@ aks_cli_config_list = [
   {
     role                          = "client"
     aks_name                      = "gpi-scheduling"
-    sku_tier                      = "standard"
+    sku_tier                      = "Standard"
     kubernetes_version            = "1.33"
     use_aks_preview_private_build = true
     use_custom_configurations     = true

--- a/scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars
@@ -3,37 +3,49 @@ scenario_name  = "k8s-gpu-scheduling"
 deletion_delay = "2h"
 owner          = "aks"
 
-aks_config_list = [
+aks_cli_config_list = [
   {
-    role        = "client"
-    aks_name    = "gpu-scheduling"
-    dns_prefix  = "gpu-scheduling"
-    subnet_name = "aks-network"
-    sku_tier    = "Standard"
-    network_profile = {
-      network_plugin      = "azure"
-      network_plugin_mode = "overlay"
-    }
+    role                          = "client"
+    aks_name                      = "gpi-scheduling"
+    sku_tier                      = "standard"
+    kubernetes_version            = "1.33"
+    use_aks_preview_private_build = true
+    use_custom_configurations     = true
     default_node_pool = {
-      name                         = "default"
-      node_count                   = 2
-      vm_size                      = "Standard_D8ds_v6"
-      os_disk_type                 = "Managed"
-      only_critical_addons_enabled = true
-      temporary_name_for_rotation  = "defaulttmp"
-      node_labels                  = { "default" = "true" }
+      name       = "default"
+      node_count = 2
+      vm_size    = "Standard_D8_v3"
     }
     extra_node_pool = [
       {
-        name                 = "kwokpool"
-        node_count           = 1
-        auto_scaling_enabled = false
-        vm_size              = "Standard_D64ds_v6"
-        max_pods             = 110
-        node_labels          = { "kwok" = "true" }
-        node_taints          = ["kwok=true:NoSchedule"]
+        name       = "kwokpool"
+        node_count = 1
+        vm_size    = "Standard_D64_v3"
+        optional_parameters = [
+          {
+            name  = "labels"
+            value = "kwok=true"
+          },
+          {
+            name  = "node-taints"
+            value = "kwok=true:NoSchedule"
+          },
+        ]
+      },
+    ]
+    optional_parameters = [
+      {
+        name  = "network-plugin"
+        value = "azure"
+      },
+      {
+        name  = "network-plugin-mode"
+        value = "overlay"
+      },
+      {
+        name  = "nodepool-labels"
+        value = "default=true"
       }
     ]
-    kubernetes_version = "1.33"
   }
 ]


### PR DESCRIPTION
This pull request updates the configuration for the Kubernetes GPU scheduling performance evaluation scenario, focusing on simplifying pipeline stage variables and modernizing the AKS cluster configuration. The main changes involve removing redundant variable groups from pipeline stages and refactoring the AKS cluster input variables to use new naming conventions and updated configuration structures.

Pipeline configuration simplification:
* Removed the `DRA-Enabled` variable group from the `azure_eastus2_dra_small`, `azure_eastus2_dra_medium`, and `azure_eastus2_dra_high` stages in `k8s-gpu-scheduling.yml`, streamlining the pipeline stage definitions. [[1]](diffhunk://#diff-6b3e64d2e29d9600717393e8d42ced5d74e403a58b3d10fe3454b4433f7d5f9cL112-L113) [[2]](diffhunk://#diff-6b3e64d2e29d9600717393e8d42ced5d74e403a58b3d10fe3454b4433f7d5f9cL142-L143) [[3]](diffhunk://#diff-6b3e64d2e29d9600717393e8d42ced5d74e403a58b3d10fe3454b4433f7d5f9cL172-L173)

AKS cluster configuration modernization:
* Renamed `aks_config_list` to `aks_cli_config_list` and updated the structure in `azure.tfvars` to use new configuration keys, including `use_aks_preview_private_build`, `use_custom_configurations`, and `optional_parameters`.
* Updated AKS cluster and node pool properties: changed cluster and node pool names, VM sizes, and added support for custom parameters such as network plugin settings and node labels/taints via the `optional_parameters` field.