### PR TITLE
update sku for gpu scheduling test

### DIFF
--- a/scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars
@@ -14,13 +14,13 @@ aks_cli_config_list = [
     default_node_pool = {
       name       = "default"
       node_count = 2
-      vm_size    = "Standard_D8_v3"
+      vm_size    = "Standard_D8s_v3"
     }
     extra_node_pool = [
       {
         name       = "kwokpool"
         node_count = 1
-        vm_size    = "Standard_D64_v3"
+        vm_size    = "Standard_D64s_v3"
         optional_parameters = [
           {
             name  = "labels"


### PR DESCRIPTION
This pull request makes a minor update to the AKS node pool VM sizes in the `azure.tfvars` configuration file. The VM size types for both the default and extra node pools have been updated from the non-`s` to the `s` variants, which typically offer premium storage support.

- Updated the `vm_size` for the `default_node_pool` from `Standard_D8_v3` to `Standard_D8s_v3` and for the `kwokpool` in `extra_node_pool` from `Standard_D64_v3` to `Standard_D64s_v3` in `azure.tfvars`.