### PR TITLE
Update Terraform Provider version

### DIFF
--- a/modules/terraform/aws/versions.tf
+++ b/modules/terraform/aws/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "<= 6.2.0"
+      version = "<= 6.11.0"
     }
   }
 }

--- a/modules/terraform/azure/versions.tf
+++ b/modules/terraform/azure/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "<= 4.35.0"
+      version = "<= 4.42.0"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the maximum allowed versions of the AWS and Azure Terraform providers in their respective modules to support newer releases.

Provider version updates:

* Increased the maximum allowed version of the `aws` provider to `<= 6.11.0` in `modules/terraform/aws/versions.tf`
* Increased the maximum allowed version of the `azurerm` provider to `<= 4.42.0` in `modules/terraform/azure/versions.tf`