### PR TITLE
Remove managed identity usage

### DIFF
--- a/jobs/competitive-test.yml
+++ b/jobs/competitive-test.yml
@@ -76,7 +76,6 @@ jobs:
       terraform_arguments: ${{ parameters.terraform_arguments }}
       terraform_input_varibles: ${{ parameters.terraform_input_varibles }}
       retry_attempt_count: ${{ parameters.retry_attempt_count }}
-      credential_type: ${{ parameters.credential_type }}
   - template: /steps/validate-resources.yml
     parameters:
       cloud: ${{ parameters.cloud }}
@@ -104,4 +103,3 @@ jobs:
       regions: ${{ parameters.regions }}
       terraform_arguments: ${{ parameters.terraform_arguments }}
       retry_attempt_count: ${{ parameters.retry_attempt_count }}
-      credential_type: ${{ parameters.credential_type }}

--- a/jobs/competitive-test.yml
+++ b/jobs/competitive-test.yml
@@ -41,9 +41,8 @@ parameters:
   default: 3
 - name: credential_type
   type: string
-  default: managed_identity
+  default: service_connection
   values:
-  - managed_identity
   - service_connection
   - variable_group
 - name: ssh_key_enabled

--- a/steps/cleanup-resources.yml
+++ b/steps/cleanup-resources.yml
@@ -10,9 +10,6 @@ parameters:
 - name: retry_attempt_count
   type: number
   default: 3
-- name: credential_type
-  type: string
-  default: service_connection
 
 steps:
 - template: /steps/terraform/run-command.yml
@@ -22,7 +19,6 @@ steps:
     regions: ${{ parameters.regions }}
     cloud: ${{ parameters.cloud }}
     retry_attempt_count: ${{ parameters.retry_attempt_count }}
-    credential_type: ${{ parameters.credential_type }}
     skip_resource_deletion: "${SKIP_RESOURCE_DELETION}"
 
 - script: |

--- a/steps/cleanup-resources.yml
+++ b/steps/cleanup-resources.yml
@@ -12,7 +12,7 @@ parameters:
   default: 3
 - name: credential_type
   type: string
-  default: managed_identity
+  default: service_connection
 
 steps:
 - template: /steps/terraform/run-command.yml

--- a/steps/cloud/azure/install-kubelogin.yml
+++ b/steps/cloud/azure/install-kubelogin.yml
@@ -6,7 +6,7 @@ parameters:
 
 steps:
 # Refresh credentials
-- template: /steps/cloud/${{ parameters.cloud }}/login.yml
+- template: /steps/cloud/azure/login.yml
   parameters:
     region: ${{ parameters.region }}
     credential_type: service_connection

--- a/steps/cloud/azure/login.yml
+++ b/steps/cloud/azure/login.yml
@@ -9,45 +9,28 @@ parameters:
   type: string
 
 steps:
-- ${{ if eq(parameters.credential_type, 'managed_identity') }}:
-  - bash: |
-      set -eu
+- task: AzureCLI@2
+  inputs:
+    azureSubscription: $(AZURE_SERVICE_CONNECTION)
+    scriptType: 'bash'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      echo "##vso[task.setvariable variable=SP_CLIENT_ID;issecret=true]$servicePrincipalId"
+      echo "##vso[task.setvariable variable=SP_ID_TOKEN;issecret=true]$idToken"
+      echo "##vso[task.setvariable variable=TENANT_ID;issecret=true]$tenantId"
+    addSpnToEnvironment: true
+  displayName: 'Get login credentials'
+  condition: always()
+- bash: |
+    set -eu
 
-      echo "login to Azure in $REGION"
-      az login --identity --client-id $AZURE_MI_ID
-      az account set --subscription "${AZURE_MI_SUBSCRIPTION_ID}"
-      az config set defaults.location="$REGION"
-      az account show
-    displayName: "Azure Login"
-    condition: always()
-    env:
-      AZURE_MI_ID: $(AZURE_MI_CLIENT_ID)
-      AZURE_MI_SUBSCRIPTION_ID: ${{ parameters.subscription }}
-      REGION: ${{ parameters.region }}
-
-- ${{ if or(eq(parameters.credential_type, 'service_connection'), eq(parameters.credential_type, 'variable_group')) }}:
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: $(AZURE_SERVICE_CONNECTION)
-      scriptType: 'bash'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        echo "##vso[task.setvariable variable=SP_CLIENT_ID;issecret=true]$servicePrincipalId"
-        echo "##vso[task.setvariable variable=SP_ID_TOKEN;issecret=true]$idToken"
-        echo "##vso[task.setvariable variable=TENANT_ID;issecret=true]$tenantId"
-      addSpnToEnvironment: true
-    displayName: 'Get login credentials'
-    condition: always()
-  - bash: |
-      set -eu
-
-      echo "login to Azure in $REGION"
-      az login --service-principal --tenant $(TENANT_ID) -u $(SP_CLIENT_ID) --federated-token $(SP_ID_TOKEN) --allow-no-subscriptions
-      az account set --subscription "${AZURE_SP_SUBSCRIPTION_ID}"
-      az config set defaults.location="$REGION"
-      az account show
-    displayName: "Azure Login"
-    condition: always()
-    env:
-      AZURE_SP_SUBSCRIPTION_ID: ${{ parameters.subscription }}
-      REGION: ${{ parameters.region }}
+    echo "login to Azure in $REGION"
+    az login --service-principal --tenant $(TENANT_ID) -u $(SP_CLIENT_ID) --federated-token $(SP_ID_TOKEN) --allow-no-subscriptions
+    az account set --subscription "${AZURE_SP_SUBSCRIPTION_ID}"
+    az config set defaults.location="$REGION"
+    az account show
+  displayName: "Azure Login"
+  condition: always()
+  env:
+    AZURE_SP_SUBSCRIPTION_ID: ${{ parameters.subscription }}
+    REGION: ${{ parameters.region }}

--- a/steps/cloud/azure/upload-storage-account.yml
+++ b/steps/cloud/azure/upload-storage-account.yml
@@ -9,7 +9,7 @@ parameters:
   upload_type: "Test Results"
 
 steps:
-- ${{ if or(ne(parameters.cloud, 'azure'), eq(parameters.credential_type, 'service_connection')) }}:
+- ${{ if ne(parameters.cloud, 'azure') }}:
   - template: /steps/cloud/azure/login.yml
     parameters:
       region: eastus

--- a/steps/provision-resources.yml
+++ b/steps/provision-resources.yml
@@ -20,9 +20,6 @@ parameters:
 - name: retry_attempt_count
   type: number
   default: 3
-- name: credential_type
-  type: string
-  default: service_connection
 
 steps:
 - template: /steps/terraform/set-working-directory.yml
@@ -76,13 +73,11 @@ steps:
   parameters:
     command: version
     retry_attempt_count: ${{ parameters.retry_attempt_count }}
-    credential_type: ${{ parameters.credential_type }}
 
 - template: /steps/terraform/run-command.yml
   parameters:
     command: init
     retry_attempt_count: ${{ parameters.retry_attempt_count }}
-    credential_type: ${{ parameters.credential_type }}
 
 - template: /steps/terraform/run-command.yml
   parameters:
@@ -91,4 +86,3 @@ steps:
     regions: ${{ parameters.regions }}
     cloud: ${{ parameters.cloud }}
     retry_attempt_count: ${{ parameters.retry_attempt_count }}
-    credential_type: ${{ parameters.credential_type }}

--- a/steps/provision-resources.yml
+++ b/steps/provision-resources.yml
@@ -22,7 +22,7 @@ parameters:
   default: 3
 - name: credential_type
   type: string
-  default: managed_identity
+  default: service_connection
 
 steps:
 - template: /steps/terraform/set-working-directory.yml

--- a/steps/terraform/run-command.yml
+++ b/steps/terraform/run-command.yml
@@ -13,9 +13,6 @@ parameters:
 - name: retry_attempt_count
   type: number
   default: 3
-- name: credential_type
-  type: string
-  default: 'service_connection'
 - name: skip_resource_deletion
   type: string
   default: "false"

--- a/steps/terraform/run-command.yml
+++ b/steps/terraform/run-command.yml
@@ -15,7 +15,7 @@ parameters:
   default: 3
 - name: credential_type
   type: string
-  default: 'managed_identity'
+  default: 'service_connection'
 - name: skip_resource_deletion
   type: string
   default: "false"
@@ -96,8 +96,4 @@ steps:
     REGIONS: ${{ convertToJson(parameters.regions) }}
     CLOUD: ${{ parameters.cloud }}
     ARM_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-    ${{ if eq(parameters.credential_type, 'managed_identity') }}:
-      ARM_USE_MSI: true
-      ARM_TENANT_ID: $(AZURE_MI_TENANT_ID)
-      ARM_CLIENT_ID: $(AZURE_MI_CLIENT_ID)
     BUILD_REASON: $(Build.Reason)


### PR DESCRIPTION
This pull request removes support for the `managed_identity` credential type from the resource provisioning and cleanup workflows, standardizing on `service_connection` and `variable_group` for Azure authentication. The changes simplify parameter definitions and step invocations across multiple pipeline YAML files, making credential handling more consistent and reducing complexity.

**Credential Type Standardization**

* The default value for the `credential_type` parameter in `jobs/competitive-test.yml` is changed from `managed_identity` to `service_connection`, and the list of allowed values no longer includes `managed_identity`.
* All references to the `credential_type` parameter are removed from the step and job templates in `jobs/competitive-test.yml`, `steps/cleanup-resources.yml`, `steps/provision-resources.yml`, and `steps/terraform/run-command.yml`. [[1]](diffhunk://#diff-2f9729eea91e9c4269be4d0b0777b4a427c14c6fdf8ab18f804e1789ab6d0056L80) [[2]](diffhunk://#diff-2f9729eea91e9c4269be4d0b0777b4a427c14c6fdf8ab18f804e1789ab6d0056L108) [[3]](diffhunk://#diff-0baba20632afdc0472aed05c703778b9f428731dc8fedac4169d47ea05adf245L13-L15) [[4]](diffhunk://#diff-0baba20632afdc0472aed05c703778b9f428731dc8fedac4169d47ea05adf245L25) [[5]](diffhunk://#diff-bb57749fbaaea2fbff3adb99cba62fb712d6502e1e7fd2f985fa7581fa0a513bL23-L25) [[6]](diffhunk://#diff-bb57749fbaaea2fbff3adb99cba62fb712d6502e1e7fd2f985fa7581fa0a513bL79-L85) [[7]](diffhunk://#diff-bb57749fbaaea2fbff3adb99cba62fb712d6502e1e7fd2f985fa7581fa0a513bL94) [[8]](diffhunk://#diff-43b0a6e7ca97b5e7f9289dc2fc51830da2782e6b82fc5d0d091508c6b60ad70aL16-L18)

**Azure Login Workflow Simplification**

* The Azure login logic in `steps/cloud/azure/login.yml` is simplified: the conditional block for `managed_identity` authentication is removed, leaving only the logic for `service_connection` and `variable_group` types using the `AzureCLI@2` task.
* The template invocation in `steps/cloud/azure/install-kubelogin.yml` is updated to always use the Azure login template directly, passing `credential_type: service_connection`.

**Terraform Command Environment Cleanup**

* Environment variable assignments for managed identity authentication (e.g., `ARM_USE_MSI`, `ARM_TENANT_ID`, `ARM_CLIENT_ID`) are removed from `steps/terraform/run-command.yml`.

**Upload Storage Account Logic Update**

* The conditional logic in `steps/cloud/azure/upload-storage-account.yml` for including the Azure login template is simplified to only check if the cloud is not Azure, removing checks for credential type.