### PR TITLE
Update zfs localpv setup

### DIFF
--- a/modules/kustomize/fio/overlays/zfs-localpv/configuration/ds.yaml
+++ b/modules/kustomize/fio/overlays/zfs-localpv/configuration/ds.yaml
@@ -59,7 +59,10 @@ spec:
                 echo "Creating ZFS pool 'zfspv-pool' on the host..."
                 chroot /host zpool create zfspv-pool $(eval echo "/dev/nvme{0..$NUMBER_OF_NVME}n1") || echo "Failed to create ZFS pool."
               fi
-
+              
+              echo "Disabling ZFS primarycache and secondarycache on the host..."
+              chroot /host zfs set primarycache=none zfspv-pool || echo "Failed to set primarycache."
+              chroot /host zfs set secondarycache=none zfspv-pool || echo "Failed to set secondarycache."
               echo "ZFS setup complete. Keeping pod running..."
               sleep inf
           readinessProbe:

--- a/modules/kustomize/fio/overlays/zfs-localpv/configuration/storageclass.yaml
+++ b/modules/kustomize/fio/overlays/zfs-localpv/configuration/storageclass.yaml
@@ -3,10 +3,7 @@ kind: StorageClass
 metadata:
   name: zfs-localpv
 parameters:
-  recordsize: "128k"
-  compression: "off"
-  dedup: "off"
-  fstype: "zfs"
+  fstype: "ext4"
   poolname: "zfspv-pool"
 provisioner: zfs.csi.openebs.io
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
This pull request makes two key changes to the ZFS LocalPV overlay configuration for fio, focusing on ZFS pool settings and storage class parameters. The main goals are to optimize ZFS caching behavior and switch the file system type used for persistent volumes.

**ZFS Pool Configuration:**

* Disables both `primarycache` and `secondarycache` on the `zfspv-pool` ZFS pool during setup to reduce memory usage by preventing ZFS from caching data and metadata.

**StorageClass Parameter Updates:**

* Changes the `fstype` parameter in the `zfs-localpv` `StorageClass` from `zfs` to `ext4`, and removes the `recordsize`, `compression`, and `dedup` parameters, simplifying the storage class and switching to a more standard file system for persistent volumes.