### PR TITLE
Fix acstor v2 benchmark

### DIFF
--- a/modules/kustomize/fio/overlays/acstor-v2/deployment/pvc.yaml
+++ b/modules/kustomize/fio/overlays/acstor-v2/deployment/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: acstor-mount
+  name: $name
   annotations:
     localdisk.csi.acstor.io/accept-ephemeral-storage: "true"
 spec:

--- a/modules/kustomize/fio/overlays/acstor-v2/deployment/volumes.yaml
+++ b/modules/kustomize/fio/overlays/acstor-v2/deployment/volumes.yaml
@@ -13,4 +13,4 @@ spec:
       volumes:
         - name: acstor-mount
           persistentVolumeClaim:
-            claimName: acstor-mount
+            claimName: $name

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-storage.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-storage.yml
@@ -33,15 +33,15 @@ stages:
               - "4k|16|randread|600|16|32G"
               - "4k|16|randrw|600|16|32G"
           matrix:
-            # zfs-localpv:
-            #   storage_name: zfs-localpv
-            #   desired_nodes: 7
+            zfs-localpv:
+              storage_name: zfs-localpv
+              desired_nodes: 7
             acstor-v2:
               storage_name: acstor-v2
               desired_nodes: 7
-            # local-hostpath:
-            #   storage_name: local-hostpath
-            #   desired_nodes: 7
+            local-hostpath:
+              storage_name: local-hostpath
+              desired_nodes: 7
           max_parallel: 1
           timeout_in_minutes: 120
           credential_type: service_connection

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-storage.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-storage.yml
@@ -11,6 +11,7 @@ schedules:
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-gpu-storage
+  SKIP_RESOURCE_DELETION: true
 
 stages:
   - stage: azure_eastus2
@@ -38,9 +39,9 @@ stages:
             acstor-v2:
               storage_name: acstor-v2
               desired_nodes: 7
-            local-hostpath:
-              storage_name: local-hostpath
-              desired_nodes: 7
+            # local-hostpath:
+            #   storage_name: local-hostpath
+            #   desired_nodes: 7
           max_parallel: 1
           timeout_in_minutes: 120
           credential_type: service_connection

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-storage.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-storage.yml
@@ -33,9 +33,9 @@ stages:
               - "4k|16|randread|600|16|32G"
               - "4k|16|randrw|600|16|32G"
           matrix:
-            zfs-localpv:
-              storage_name: zfs-localpv
-              desired_nodes: 7
+            # zfs-localpv:
+            #   storage_name: zfs-localpv
+            #   desired_nodes: 7
             acstor-v2:
               storage_name: acstor-v2
               desired_nodes: 7

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-storage.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-storage.yml
@@ -11,7 +11,6 @@ schedules:
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-gpu-storage
-  SKIP_RESOURCE_DELETION: true
 
 stages:
   - stage: azure_eastus2


### PR DESCRIPTION
This pull request introduces changes to parameterize the storage claim name in the Acstor v2 deployment and updates the GPU storage performance evaluation pipeline. The main goals are to improve configurability for storage claim naming and to adjust the pipeline's resource handling and test matrix.

Kubernetes deployment improvements:

* Parameterized the PersistentVolumeClaim name in `pvc.yaml` and its usage in `volumes.yaml` by replacing the hardcoded `acstor-mount` with the variable `$name`, allowing for more flexible deployments. [[1]](diffhunk://#diff-fab9211e05287cd20d7b822426ed6317402ad416469204ec85c9062c3d71f735L4-R4) [[2]](diffhunk://#diff-19974d936c4c674d09d5ea790ab53ca586175b71a936d0dbd95c063a1bcbd9d0L16-R16)

Pipeline configuration updates:

* Added the `SKIP_RESOURCE_DELETION: true` variable to the GPU storage pipeline, which prevents automatic resource cleanup after pipeline runs.
* Commented out the `local-hostpath` storage configuration in the Acstor v2 test matrix, leaving only the `acstor-v2` storage as active in the performance evaluation.