### PR TITLE
Update Kubernetes and AMI versions

### DIFF
--- a/scenarios/perf-eval/cilium-cluster-churn-n1000p50k/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/cilium-cluster-churn-n1000p50k/terraform-inputs/aws.tfvars
@@ -76,7 +76,7 @@ eks_config_list = [{
   eks_managed_node_groups = [
     {
       name           = "default"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.4xlarge"]
       min_size       = 5
       max_size       = 5
@@ -85,7 +85,7 @@ eks_config_list = [{
     },
     {
       name           = "prompool"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.16xlarge"]
       min_size       = 1
       max_size       = 1
@@ -96,5 +96,5 @@ eks_config_list = [{
   ]
 
   eks_addons         = []
-  kubernetes_version = "1.32"
+  kubernetes_version = "1.33"
 }]

--- a/scenarios/perf-eval/cilium-cluster-churn-n1000p50k/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cilium-cluster-churn-n1000p50k/terraform-inputs/azure.tfvars
@@ -75,6 +75,6 @@ aks_config_list = [
         node_labels          = { "slo" = "true" }
       }
     ]
-    kubernetes_version = "1.32"
+    kubernetes_version = "1.33"
   }
 ]

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/aws.tfvars
@@ -76,7 +76,7 @@ eks_config_list = [{
   eks_managed_node_groups = [
     {
       name           = "default"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.4xlarge"]
       min_size       = 5
       max_size       = 5
@@ -85,7 +85,7 @@ eks_config_list = [{
     },
     {
       name           = "prompool"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.16xlarge"]
       min_size       = 1
       max_size       = 1
@@ -95,7 +95,7 @@ eks_config_list = [{
     },
     {
       name           = "userpool0"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m5a.xlarge"]
       min_size       = 200
       max_size       = 200
@@ -115,7 +115,7 @@ eks_config_list = [{
     },
     {
       name           = "userpool1"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m5a.xlarge"]
       min_size       = 200
       max_size       = 200
@@ -135,7 +135,7 @@ eks_config_list = [{
     },
     {
       name           = "userpool2"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m5a.xlarge"]
       min_size       = 200
       max_size       = 200
@@ -155,7 +155,7 @@ eks_config_list = [{
     },
     {
       name           = "userpool3"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m5a.xlarge"]
       min_size       = 200
       max_size       = 200
@@ -175,7 +175,7 @@ eks_config_list = [{
     },
     {
       name           = "userpool4"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m5a.xlarge"]
       min_size       = 200
       max_size       = 200
@@ -203,5 +203,5 @@ eks_config_list = [{
     { name = "kube-proxy" },
     { name = "coredns" }
   ]
-  kubernetes_version = "1.32"
+  kubernetes_version = "1.33"
 }]

--- a/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/slo-servicediscovery/terraform-inputs/azure.tfvars
@@ -80,6 +80,6 @@ aks_config_list = [
         node_labels          = { "slo" = "true" }
       }
     ]
-    kubernetes_version = "1.32"
+    kubernetes_version = "1.33"
   }
 ]


### PR DESCRIPTION
# Update Kubernetes and AMI versions for test scenarios

This PR updates the Kubernetes version from 1.32 to 1.33 and upgrades AWS AMI type from AL2_x86_64 to AL2023_x86_64_STANDARD across multiple performance test scenarios.

**Changes:**
- **Kubernetes version**: 1.32 → 1.33
- **AWS AMI type**: AL2_x86_64 → AL2023_x86_64_STANDARD (Amazon Linux 2023)

**Affected scenarios:**
- `cilium-cluster-churn-n1000p50k` (AWS & Azure)
- `slo-servicediscovery` (AWS & Azure)

**Impact:**
- Tests will now run on the latest Kubernetes version (1.33)
- AWS clusters will use Amazon Linux 2023 instead of Amazon Linux 2
- No functional changes to test logic or infrastructure setup