### PR TITLE
Named Arguments Support in Large Cluster Module

### DIFF
--- a/modules/python/clusterloader2/large_cluster/large_cluster.py
+++ b/modules/python/clusterloader2/large_cluster/large_cluster.py
@@ -191,46 +191,46 @@ def main():
 
     # Sub-command for configure_clusterloader2
     parser_configure = subparsers.add_parser("configure", help="Override CL2 config file")
-    parser_configure.add_argument("cpu_per_node", type=int, help="CPU per node")
-    parser_configure.add_argument("node_count", type=int, help="Number of nodes")
-    parser_configure.add_argument("node_per_step", type=int, help="Number of nodes per scaling step")
-    parser_configure.add_argument("pods_per_node", type=int, help="The number of pods per node")
-    parser_configure.add_argument("repeats", type=int, help="Number of times to repeat the deployment churn")
-    parser_configure.add_argument("operation_timeout", type=str, help="Timeout before failing the scale up test")
-    parser_configure.add_argument("provider", type=str, help="Cloud provider name")
-    parser_configure.add_argument("cilium_enabled", type=str2bool, choices=[True, False], default=False,
+    parser_configure.add_argument("--cpu_per_node", type=int, help="CPU per node")
+    parser_configure.add_argument("--node_count", type=int, help="Number of nodes")
+    parser_configure.add_argument("--node_per_step", type=int, help="Number of nodes per scaling step")
+    parser_configure.add_argument("--pods_per_node", type=int, help="The number of pods per node")
+    parser_configure.add_argument("--repeats", type=int, help="Number of times to repeat the deployment churn")
+    parser_configure.add_argument("--operation_timeout", type=str, help="Timeout before failing the scale up test")
+    parser_configure.add_argument("--provider", type=str, help="Cloud provider name")
+    parser_configure.add_argument("--cilium_enabled", type=str2bool, choices=[True, False], default=False,
                                   help="Whether cilium is enabled. Must be either True or False")
-    parser_configure.add_argument("scrape_containerd", type=str2bool, choices=[True, False], default=False,
+    parser_configure.add_argument("--scrape_containerd", type=str2bool, choices=[True, False], default=False,
                                   help="Whether to scrape containerd metrics. Must be either True or False")
-    parser_configure.add_argument("cl2_override_file", type=str, help="Path to the overrides of CL2 config file")
+    parser_configure.add_argument("--cl2_override_file", type=str, help="Path to the overrides of CL2 config file")
 
     # Sub-command for validate_clusterloader2
     parser_validate = subparsers.add_parser("validate", help="Validate cluster setup")
-    parser_validate.add_argument("node_count", type=int, help="Number of desired nodes")
-    parser_validate.add_argument("operation_timeout", type=int, default=600, help="Operation timeout to wait for nodes to be ready")
+    parser_validate.add_argument("--node_count", type=int, help="Number of desired nodes")
+    parser_validate.add_argument("--operation_timeout", type=int, default=600, help="Operation timeout to wait for nodes to be ready")
 
     # Sub-command for execute_clusterloader2
     parser_execute = subparsers.add_parser("execute", help="Execute scale up operation")
-    parser_execute.add_argument("cl2_image", type=str, help="Name of the CL2 image")
-    parser_execute.add_argument("cl2_config_dir", type=str, help="Path to the CL2 config directory")
-    parser_execute.add_argument("cl2_report_dir", type=str, help="Path to the CL2 report directory")
-    parser_execute.add_argument("cl2_config_file", type=str, help="Path to the CL2 config file")
-    parser_execute.add_argument("kubeconfig", type=str, help="Path to the kubeconfig file")
-    parser_execute.add_argument("provider", type=str, help="Cloud provider name")
-    parser_execute.add_argument("scrape_containerd", type=str2bool, choices=[True, False], default=False,
+    parser_execute.add_argument("--cl2_image", type=str, help="Name of the CL2 image")
+    parser_execute.add_argument("--cl2_config_dir", type=str, help="Path to the CL2 config directory")
+    parser_execute.add_argument("--cl2_report_dir", type=str, help="Path to the CL2 report directory")
+    parser_execute.add_argument("--cl2_config_file", type=str, help="Path to the CL2 config file")
+    parser_execute.add_argument("--kubeconfig", type=str, help="Path to the kubeconfig file")
+    parser_execute.add_argument("--provider", type=str, help="Cloud provider name")
+    parser_execute.add_argument("--scrape_containerd", type=str2bool, choices=[True, False], default=False,
                                 help="Whether to scrape containerd metrics. Must be either True or False")
 
     # Sub-command for collect_clusterloader2
     parser_collect = subparsers.add_parser("collect", help="Collect scale up data")
-    parser_collect.add_argument("cpu_per_node", type=int, help="CPU per node")
-    parser_collect.add_argument("node_count", type=int, help="Number of nodes")
-    parser_collect.add_argument("pods_per_node", type=int, help="The number of pods per node")
-    parser_collect.add_argument("repeats", type=int, help="Number of times to repeat the deployment churn")
-    parser_collect.add_argument("cl2_report_dir", type=str, help="Path to the CL2 report directory")
-    parser_collect.add_argument("cloud_info", type=str, help="Cloud information")
-    parser_collect.add_argument("run_id", type=str, help="Run ID")
-    parser_collect.add_argument("run_url", type=str, help="Run URL")
-    parser_collect.add_argument("result_file", type=str, help="Path to the result file")
+    parser_collect.add_argument("--cpu_per_node", type=int, help="CPU per node")
+    parser_collect.add_argument("--node_count", type=int, help="Number of nodes")
+    parser_collect.add_argument("--pods_per_node", type=int, help="The number of pods per node")
+    parser_collect.add_argument("--repeats", type=int, help="Number of times to repeat the deployment churn")
+    parser_collect.add_argument("--cl2_report_dir", type=str, help="Path to the CL2 report directory")
+    parser_collect.add_argument("--cloud_info", type=str, help="Cloud information")
+    parser_collect.add_argument("--run_id", type=str, help="Run ID")
+    parser_collect.add_argument("--run_url", type=str, help="Run URL")
+    parser_collect.add_argument("--result_file", type=str, help="Path to the result file")
 
     args = parser.parse_args()
 

--- a/modules/python/tests/test_large_cluster.py
+++ b/modules/python/tests/test_large_cluster.py
@@ -707,8 +707,11 @@ class TestLargeCluster(unittest.TestCase):
     # ==================== main() Tests ====================
 
     @patch('clusterloader2.large_cluster.large_cluster.configure_clusterloader2')
-    @patch('sys.argv', ['large_cluster.py', 'configure', '4', '20', '5', '10', '3', '30m',
-                        'aws', 'False', 'False', '/tmp/override.yaml'])
+    @patch('sys.argv', ['large_cluster.py', 'configure',
+                        '--cpu_per_node', '4', '--node_count', '20', '--node_per_step', '5',
+                        '--pods_per_node', '10', '--repeats', '3', '--operation_timeout', '30m',
+                        '--provider', 'aws', '--cilium_enabled', 'False', '--scrape_containerd', 'False',
+                        '--cl2_override_file', '/tmp/override.yaml'])
     def test_main_configure_command(self, mock_configure):
         """Test configure command parsing"""
         main()
@@ -718,7 +721,7 @@ class TestLargeCluster(unittest.TestCase):
         )
 
     @patch('clusterloader2.large_cluster.large_cluster.validate_clusterloader2')
-    @patch('sys.argv', ['large_cluster.py', 'validate', '20', '600'])
+    @patch('sys.argv', ['large_cluster.py', 'validate', '--node_count', '20', '--operation_timeout', '600'])
     def test_main_validate_command(self, mock_validate):
         """Test validate command parsing"""
         main()
@@ -726,8 +729,10 @@ class TestLargeCluster(unittest.TestCase):
         mock_validate.assert_called_once_with(20, 600)
 
     @patch('clusterloader2.large_cluster.large_cluster.execute_clusterloader2')
-    @patch('sys.argv', ['large_cluster.py', 'execute', 'cl2:latest', '/config', '/report',
-                        'config.yaml', '/kubeconfig', 'aws', 'False'])
+    @patch('sys.argv', ['large_cluster.py', 'execute',
+                        '--cl2_image', 'cl2:latest', '--cl2_config_dir', '/config',
+                        '--cl2_report_dir', '/report', '--cl2_config_file', 'config.yaml',
+                        '--kubeconfig', '/kubeconfig', '--provider', 'aws', '--scrape_containerd', 'False'])
     def test_main_execute_command(self, mock_execute):
         """Test execute command parsing"""
         main()
@@ -737,8 +742,10 @@ class TestLargeCluster(unittest.TestCase):
         )
 
     @patch('clusterloader2.large_cluster.large_cluster.collect_clusterloader2')
-    @patch('sys.argv', ['large_cluster.py', 'collect', '4', '20', '10', '3', '/report',
-                        '{"cloud":"test"}', 'run123', 'http://example.com', '/result.json'])
+    @patch('sys.argv', ['large_cluster.py', 'collect',
+                        '--cpu_per_node', '4', '--node_count', '20', '--pods_per_node', '10',
+                        '--repeats', '3', '--cl2_report_dir', '/report', '--cloud_info', '{"cloud":"test"}',
+                        '--run_id', 'run123', '--run_url', 'http://example.com', '--result_file', '/result.json'])
     def test_main_collect_command(self, mock_collect):
         """Test collect command parsing"""
         main()

--- a/steps/engine/clusterloader2/slo/collect.yml
+++ b/steps/engine/clusterloader2/slo/collect.yml
@@ -16,15 +16,15 @@ steps:
     set -eo pipefail
 
     PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE collect \
-      $CPU_PER_NODE \
-      $NODE_COUNT \
-      ${PODS_PER_NODE:-0} \
-      $REPEATS \
-      $CL2_REPORT_DIR \
-      "$CLOUD_INFO" \
-      $RUN_ID \
-      $RUN_URL \
-      $TEST_RESULTS_FILE
+      --cpu_per_node $CPU_PER_NODE \
+      --node_count $NODE_COUNT \
+      --pods_per_node ${PODS_PER_NODE:-0} \
+      --repeats $REPEATS \
+      --cl2_report_dir $CL2_REPORT_DIR \
+      --cloud_info "$CLOUD_INFO" \
+      --run_id $RUN_ID \
+      --run_url $RUN_URL \
+      --result_file $TEST_RESULTS_FILE
   workingDirectory: modules/python
   env:
     CLOUD: ${{ parameters.cloud }}

--- a/steps/engine/clusterloader2/slo/execute.yml
+++ b/steps/engine/clusterloader2/slo/execute.yml
@@ -13,24 +13,24 @@ steps:
       set -eo pipefail
 
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE configure \
-        $CPU_PER_NODE \
-        $NODE_COUNT \
-        $NODE_PER_STEP \
-        ${PODS_PER_NODE:-0} \
-        $REPEATS \
-        $SCALE_TIMEOUT \
-        $CLOUD \
-        $CILIUM_ENABLED \
-        ${SCRAPE_CONTAINERD:-False} \
-        ${CL2_CONFIG_DIR}/overrides.yaml
+        --cpu_per_node $CPU_PER_NODE \
+        --node_count $NODE_COUNT \
+        --node_per_step $NODE_PER_STEP \
+        --pods_per_node ${PODS_PER_NODE:-0} \
+        --repeats $REPEATS \
+        --operation_timeout $SCALE_TIMEOUT \
+        --provider $CLOUD \
+        --cilium_enabled $CILIUM_ENABLED \
+        --scrape_containerd ${SCRAPE_CONTAINERD:-False} \
+        --cl2_override_file ${CL2_CONFIG_DIR}/overrides.yaml
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE execute \
-        ${CL2_IMAGE} \
-        ${CL2_CONFIG_DIR} \
-        $CL2_REPORT_DIR \
-        $CL2_CONFIG_FILE \
-        ${HOME}/.kube/config \
-        $CLOUD \
-        ${SCRAPE_CONTAINERD:-False}
+        --cl2_image ${CL2_IMAGE} \
+        --cl2_config_dir ${CL2_CONFIG_DIR} \
+        --cl2_report_dir $CL2_REPORT_DIR \
+        --cl2_config_file $CL2_CONFIG_FILE \
+        --kubeconfig ${HOME}/.kube/config \
+        --provider $CLOUD \
+        --scrape_containerd ${SCRAPE_CONTAINERD:-False}
     workingDirectory: modules/python
     env:
       ${{ if eq(parameters.cloud, 'azure') }}:

--- a/steps/engine/clusterloader2/slo/validate.yml
+++ b/steps/engine/clusterloader2/slo/validate.yml
@@ -10,8 +10,8 @@ steps:
       set -eo pipefail
 
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE validate \
-        $DESIRED_NODES \
-        $VALIDATION_TIMEOUT_IN_MINUTES
+        --node_count $DESIRED_NODES \
+        --operation_timeout $VALIDATION_TIMEOUT_IN_MINUTES
     workingDirectory: modules/python
     timeoutInMinutes: ${{ parameters.validation_timeout_in_minutes }}
     displayName: "Validate node count"


### PR DESCRIPTION
# Update large_cluster.py to use long-name arguments

### Summary
Changed all command-line arguments in large_cluster.py from positional to long-name format (with double dashes) and updated all referencing YAML files accordingly.

### Changes
- **Python script**: Updated all `argparse` arguments to use `--argument_name` format instead of positional arguments
- **YAML files**: Updated all script invocations in validate.yml, execute.yml, and collect.yml to use the new long-name argument format

### Benefits
- Improved code readability and maintainability
- Reduced risk of argument ordering errors
- Better self-documenting command-line interface
- Follows standard CLI argument conventions