### PR TITLE
Enable NAP 2k Spot

### DIFF
--- a/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-5k-nodes.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-5k-nodes.yml
@@ -61,7 +61,7 @@ stages:
   - stage: azure_eastus2_5k_spot
     condition: |
         or(
-          eq(variables['Build.CronSchedule.DisplayName'], 'Every day at 3:00 PM'),
+          eq(variables['Build.CronSchedule.DisplayName'], 'Every day at 3:00 AM'),
           eq(variables['Build.Reason'], 'Manual')
         )
     dependsOn: []


### PR DESCRIPTION
This pull request enables and configures the Azure spot testing for the 5k node auto-provisioning benchmark pipeline. The main changes are the activation of a scheduled spot test and the addition of a new stage for spot node benchmarking, including adjustments to test parameters.

**Pipeline schedule activation:**

* Reactivated the daily 3:00 AM cron schedule for the spot test on the `main` branch in `node-auto-provisioning-benchmark-5k-nodes.yml`.

**Spot test stage addition and configuration:**

* Added the `azure_eastus2_5k_spot` stage to run spot node benchmarking, triggered by either manual runs or the 3:00 AM schedule, and removed the previous comment-out/TODO.
* Updated test parameters for the spot benchmark: set `node_count` and `pod_count` to 2000, reduced `scale_up_timeout` and `scale_down_timeout` to 90 minutes, changed `vm_size` to `Standard_D2s_v4`, and lowered `timeout_in_minutes` to 120 for faster test cycles.