### PR TITLE
fix python dependency issue

### DIFF
--- a/modules/python/requirements.txt
+++ b/modules/python/requirements.txt
@@ -12,4 +12,4 @@ coverage==7.6.12
 semver==3.0.4
 requests==2.32.4
 pyyaml==6.0.2
-pyopenssl>=24.0.0
+pyopenssl==24.0.0

--- a/modules/python/requirements.txt
+++ b/modules/python/requirements.txt
@@ -12,3 +12,4 @@ coverage==7.6.12
 semver==3.0.4
 requests==2.32.4
 pyyaml==6.0.2
+pyopenssl>=24.0.0


### PR DESCRIPTION
We have been seeing below error, the fix is to pin pyopenssl dependency
File "/home/AzDevOps/.local/lib/python3.10/site-packages/botocore/httpsession.py", line 45, in
from urllib3.contrib.pyopenssl import (
File "/usr/lib/python3/dist-packages/urllib3/contrib/pyopenssl.py", line 50, in
import OpenSSL.SSL
File "/usr/lib/python3/dist-packages/OpenSSL/init.py", line 8, in
from OpenSSL import crypto, SSL
File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1579, in
class X509StoreFlags(object):
File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1598, in X509StoreFlags
NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'. Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?