### PR TITLE
fix : kms KeyVault resource ID is empty when KeyVault network access is Private.

### DIFF
--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -90,10 +90,18 @@ locals {
     ]))
   )
 
-  aks_kms_role_assignments = var.aks_cli_config.managed_identity_name != null && local.key_management_service != null ? {
-    "Key Vault Crypto Service Encryption User" = local.key_management_service.key_vault_key_resource_id
-    "Key Vault Crypto User"                    = local.key_management_service.key_vault_id
-  } : {}
+  aks_kms_role_assignments = var.aks_cli_config.managed_identity_name != null && local.key_management_service != null ? merge(
+    {
+      "Key Vault Crypto Service Encryption User" = local.key_management_service.key_vault_key_resource_id
+      "Key Vault Crypto User"                    = local.key_management_service.key_vault_id
+    },
+    # When KMS uses a private endpoint, the AKS identity must be able to approve
+    # the private endpoint connection on the Key Vault (PrivateEndpointConnectionsApproval/action).
+    # Key Vault Contributor includes that action.
+    var.aks_cli_config.kms_config.network_access == "Private" ? {
+      "Key Vault Contributor" = local.key_management_service.key_vault_id
+    } : {}
+  ) : {}
 
   # Disk Encryption Set parameters for OS disk encryption with Customer-Managed Keys
   disk_encryption_parameters = (

--- a/modules/terraform/azure/aks-cli/main.tf
+++ b/modules/terraform/azure/aks-cli/main.tf
@@ -82,11 +82,12 @@ locals {
   kms_parameters = (
     local.key_management_service == null || var.aks_cli_config.managed_identity_name == null ?
     "" :
-    join(" ", [
+    join(" ", compact([
       "--enable-azure-keyvault-kms",
       format("--azure-keyvault-kms-key-id %s", local.key_management_service.key_vault_key_id),
-      format("--azure-keyvault-kms-key-vault-network-access %s", var.aks_cli_config.kms_config.network_access)
-    ])
+      format("--azure-keyvault-kms-key-vault-network-access %s", var.aks_cli_config.kms_config.network_access),
+      var.aks_cli_config.kms_config.network_access == "Private" ? format("--azure-keyvault-kms-key-vault-resource-id %s", local.key_management_service.key_vault_id) : null
+    ]))
   )
 
   aks_kms_role_assignments = var.aks_cli_config.managed_identity_name != null && local.key_management_service != null ? {


### PR DESCRIPTION
module.aks-cli["nap"].terraform_data.aks_cli (local-exec): ERROR: (BadRequest) KeyVault resource ID is empty when KeyVault network access is Private.

module.aks-cli["nap"].terraform_data.aks_cli (local-exec): Code: BadRequest

module.aks-cli["nap"].terraform_data.aks_cli (local-exec): Message: KeyVault resource ID is empty when KeyVault network access is Private.

    # When KMS uses a private endpoint, the AKS identity must be able to approve
    # the private endpoint connection on the Key Vault (PrivateEndpointConnectionsApproval/action).
    # Key Vault Contributor includes that action.