### PR TITLE
Fix EKS AMI type for Kubernetes 1.35

### DIFF
--- a/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/aws.tfvars
@@ -63,7 +63,7 @@ eks_config_list = [{
   eks_managed_node_groups = [
     {
       name           = "idle"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.large"]
       min_size       = 1
       max_size       = 1
@@ -73,7 +73,7 @@ eks_config_list = [{
     },
     {
       name           = "virtualnodes"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.2xlarge"]
       min_size       = 5
       max_size       = 5
@@ -83,7 +83,7 @@ eks_config_list = [{
     },
     {
       name           = "runner"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.4xlarge"]
       min_size       = 3
       max_size       = 3

--- a/scenarios/perf-eval/apiserver-vn100pod3k/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod3k/terraform-inputs/aws.tfvars
@@ -63,7 +63,7 @@ eks_config_list = [{
   eks_managed_node_groups = [
     {
       name           = "idle"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.large"]
       min_size       = 1
       max_size       = 1
@@ -73,7 +73,7 @@ eks_config_list = [{
     },
     {
       name           = "virtualnodes"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.2xlarge"]
       min_size       = 5
       max_size       = 5
@@ -83,7 +83,7 @@ eks_config_list = [{
     },
     {
       name           = "runner"
-      ami_type       = "AL2_x86_64"
+      ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.4xlarge"]
       min_size       = 3
       max_size       = 3


### PR DESCRIPTION
AL2_x86_64 is only supported for Kubernetes <= 1.32. Per [recommendation here](https://github.com/Azure/telescope/blob/b629c6443b25bc5b8a7fc7d2b19bba76a55b6509/modules/python/clients/eks_client.py#L1446-L1457), update to AL2023_x86_64_STANDARD for apiserver-vn100pod10k and apiserver-vn100pod3k scenarios which use Kubernetes 1.35.