### PR TITLE
Remove aws creds from CI check

### DIFF
--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -11,7 +11,6 @@ on:
 env:
   TERRAFORM_AZURE_MODULES_DIR: modules/terraform/azure
   TERRAFORM_AWS_MODULES_DIR: modules/terraform/aws
-  AWS_REGION: us-east-1
 jobs:
   terraform-validation:
     permissions:
@@ -70,9 +69,6 @@ jobs:
       - name: Terraform AWS Test
         working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
         run: terraform test
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Azure login
         uses: azure/login@v1
@@ -99,7 +95,7 @@ jobs:
         id: setup-matrix-scenarios
         run: |
           set -eux
-          matrix=$(find $GITHUB_WORKSPACE/scenarios/ -name "*.tfvars" | grep -E '(aws|azure)' | awk -F'/' '{split($11, file_name, "."); split(file_name[1], cloud_region, "-");region= (length(cloud_region) > 1) ? substr($11, index($11, "-") + 1) : ""; cloud=cloud_region[1]; gsub(".json", "", region); print "{\"cloud\": \"" cloud "\", \"file_name\": \"" file_name[1] "\", " (region != "" ? "\"region\": \"" region "\", " : "") "\"scenario_type\": \"" $8 "\", \"scenario_name\": \"" $9 "\"},"}' | sort | uniq | sed 's/,$/,/')
+          matrix=$(find $GITHUB_WORKSPACE/scenarios/ -name "*.tfvars" | grep -E '(azure)' | awk -F'/' '{split($11, file_name, "."); split(file_name[1], cloud_region, "-");region= (length(cloud_region) > 1) ? substr($11, index($11, "-") + 1) : ""; cloud=cloud_region[1]; gsub(".json", "", region); print "{\"cloud\": \"" cloud "\", \"file_name\": \"" file_name[1] "\", " (region != "" ? "\"region\": \"" region "\", " : "") "\"scenario_type\": \"" $8 "\", \"scenario_name\": \"" $9 "\"},"}' | sort | uniq | sed 's/,$/,/')
           matrix_array="[${matrix%,}]"
 
           file_changes=$(git diff --name-only -r origin/main HEAD)
@@ -184,19 +180,12 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: AWS login
-        if: ${{ matrix.cloud == 'aws' }}
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-
       - name: Terraform Init
         working-directory: ${{ env.TERRAFORM_MODULES_DIR }}
         run: terraform init
 
       - name: Terraform Plan
+        if: ${{ matrix.cloud != 'aws' }}
         working-directory: ${{ env.TERRAFORM_MODULES_DIR }}
         run: |
           terraform plan -var-file "$TERRAFORM_INPUT_FILE" -var="json_input=$INPUT_JSON"

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -185,7 +185,6 @@ jobs:
         run: terraform init
 
       - name: Terraform Plan
-        if: ${{ matrix.cloud != 'aws' }}
         working-directory: ${{ env.TERRAFORM_MODULES_DIR }}
         run: |
           terraform plan -var-file "$TERRAFORM_INPUT_FILE" -var="json_input=$INPUT_JSON"

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -95,7 +95,7 @@ jobs:
         id: setup-matrix-scenarios
         run: |
           set -eux
-          matrix=$(find $GITHUB_WORKSPACE/scenarios/ -name "*.tfvars" | grep -E '(azure)' | awk -F'/' '{split($11, file_name, "."); split(file_name[1], cloud_region, "-");region= (length(cloud_region) > 1) ? substr($11, index($11, "-") + 1) : ""; cloud=cloud_region[1]; gsub(".json", "", region); print "{\"cloud\": \"" cloud "\", \"file_name\": \"" file_name[1] "\", " (region != "" ? "\"region\": \"" region "\", " : "") "\"scenario_type\": \"" $8 "\", \"scenario_name\": \"" $9 "\"},"}' | sort | uniq | sed 's/,$/,/')
+          matrix=$(find $GITHUB_WORKSPACE/scenarios/ -name "*.tfvars" | grep 'azure' | awk -F'/' '{split($11, file_name, "."); split(file_name[1], cloud_region, "-");region= (length(cloud_region) > 1) ? substr($11, index($11, "-") + 1) : ""; cloud=cloud_region[1]; gsub(".json", "", region); print "{\"cloud\": \"" cloud "\", \"file_name\": \"" file_name[1] "\", " (region != "" ? "\"region\": \"" region "\", " : "") "\"scenario_type\": \"" $8 "\", \"scenario_name\": \"" $9 "\"},"}' | sort | uniq | sed 's/,$/,/')
           matrix_array="[${matrix%,}]"
 
           file_changes=$(git diff --name-only -r origin/main HEAD)

--- a/modules/terraform/aws/tests/test_deletion_delay.tftest.hcl
+++ b/modules/terraform/aws/tests/test_deletion_delay.tftest.hcl
@@ -1,3 +1,7 @@
+mock_provider "aws" {
+  source = "./tests"
+}
+
 variables {
   scenario_type  = "perf-eval"
   scenario_name  = "my_scenario"

--- a/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_auto_mode.tftest.hcl
@@ -1,3 +1,7 @@
+mock_provider "aws" {
+  source = "./tests"
+}
+
 variables {
   scenario_type  = "perf-eval"
   scenario_name  = "my_scenario"

--- a/modules/terraform/aws/tests/test_eks_machine_type.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_machine_type.tftest.hcl
@@ -1,3 +1,7 @@
+mock_provider "aws" {
+  source = "./tests"
+}
+
 variables {
   scenario_type  = "perf-eval"
   scenario_name  = "my_scenario"

--- a/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups.tftest.hcl
@@ -1,3 +1,7 @@
+mock_provider "aws" {
+  source = "./tests"
+}
+
 variables {
   scenario_type  = "perf-eval"
   scenario_name  = "my_scenario"

--- a/modules/terraform/aws/tests/test_eks_node_groups_subnets.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_node_groups_subnets.tftest.hcl
@@ -1,3 +1,7 @@
+mock_provider "aws" {
+  source = "./tests"
+}
+
 variables {
   scenario_type  = "perf-eval"
   scenario_name  = "my_scenario"
@@ -83,9 +87,6 @@ variables {
   }]
 }
 
-mock_provider "aws" {
-  source = "./tests"
-}
 
 override_data {
   target = module.eks["eks_name"].data.aws_subnets.subnets

--- a/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
+++ b/modules/terraform/aws/tests/test_eks_vpc_config.tftest.hcl
@@ -1,3 +1,6 @@
+mock_provider "aws" {
+  source = "./tests"
+}
 
 variables {
   scenario_type  = "perf-eval"

--- a/modules/terraform/aws/tests/test_launch_template_edge_cases.tftest.hcl
+++ b/modules/terraform/aws/tests/test_launch_template_edge_cases.tftest.hcl
@@ -1,3 +1,7 @@
+mock_provider "aws" {
+  source = "./tests"
+}
+
 variables {
   scenario_type  = "perf-eval"
   scenario_name  = "launch_template_edge_cases"

--- a/modules/terraform/aws/tests/test_launch_template_features.tftest.hcl
+++ b/modules/terraform/aws/tests/test_launch_template_features.tftest.hcl
@@ -1,3 +1,7 @@
+mock_provider "aws" {
+  source = "./tests"
+}
+
 variables {
   scenario_type  = "perf-eval"
   scenario_name  = "launch_template_test"


### PR DESCRIPTION
### Context
The CI workflow required AWS static access keys stored as GitHub Secrets. These were only used for CI checks where `terraform plan` is run. Remove these to reduce the concern over security surface.

### Changes
- Add mock_provider "aws" to all 8 AWS terraform test files so terraform test runs without real AWS credentials, using the existing .tfmock.hcl override files
- Remove AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY secret references and the AWS login step from the CI workflow
- Exclude AWS scenarios from the terraform plan matrix. Running `terraform plan` here serves little marginal benefits and this is the tradeoff we accept for security.