### PR TITLE
kwok: fetch controller deployment from source instead of apiserver

### DIFF
--- a/kcl/example_pipeline/pipeline.yaml
+++ b/kcl/example_pipeline/pipeline.yaml
@@ -1,5 +1,4 @@
 name: Example Pipeline
-pool: AKS-Telescope-Ubuntu-EastUS2
 trigger:
 - v2
 parameters:

--- a/kcl/example_pipeline/pipeline.yaml
+++ b/kcl/example_pipeline/pipeline.yaml
@@ -1,4 +1,5 @@
 name: Example Pipeline
+pool: AKS-Telescope-Ubuntu-EastUS2
 trigger:
 - v2
 parameters:

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
 
+import json
+
 import requests
 import yaml
 from kubernetes import client
@@ -89,7 +91,7 @@ class KWOK(ABC):
             raise RuntimeError("Controller Deployment not found in kwok.yaml.")
 
         controller_deployment = client.ApiClient().deserialize(
-            type("Resp", (), {"data": yaml.dump(controller_manifest)})(),
+            type("Resp", (), {"data": json.dumps(controller_manifest)})(),
             "V1Deployment",
         )
 

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -70,11 +70,26 @@ class KWOK(ABC):
         stage_fast_yaml_url = (f"https://github.com/{self.kwok_repo}/releases/"
                               f"download/{kwok_release}/stage-fast.yaml")
 
-        # Fetch the controller Deployment manifest from kwok.yaml.
+        # Fetch kwok.yaml and apply everything except the Deployment.
         response = execute_with_retries(requests.get, kwok_yaml_url, timeout=30)
         response.raise_for_status()
+        controller_manifest = None
+        for doc in yaml.safe_load_all(response.text):
+            if not doc:
+                continue
+            if doc.get("kind") == "Deployment":
+                controller_manifest = doc
+            else:
+                execute_with_retries(
+                    self.k8s_client.apply_manifest_from_file,
+                    manifest_dict=doc,
+                )
+
+        if controller_manifest is None:
+            raise RuntimeError("Controller Deployment not found in kwok.yaml.")
+
         controller_deployment = client.ApiClient().deserialize(
-            type("Resp", (), {"data": response.text})(),
+            type("Resp", (), {"data": yaml.dump(controller_manifest)})(),
             "V1Deployment",
         )
 

--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -60,17 +60,24 @@ class KWOK(ABC):
         return response.json().get("tag_name")
 
     def _bootstrap_kwok(self, kwok_release, enable_metrics):
-        """Apply the shared KWOK bootstrap manifests and replace the configmap."""
-        # TODO(xinwei): Refactor bootstrap flow to fetch/patch source kwok.yaml first,
-        # then apply manifests, instead of mutating a Deployment read from apiserver.
+        """Apply the shared KWOK bootstrap manifests and replace the configmap.
+
+        Returns the upstream kwok-controller Deployment as a V1Deployment
+        for the caller to use as a template for per-shard controllers.
+        """
         kwok_yaml_url = (f"https://github.com/{self.kwok_repo}/releases/"
                          f"download/{kwok_release}/kwok.yaml")
         stage_fast_yaml_url = (f"https://github.com/{self.kwok_repo}/releases/"
                               f"download/{kwok_release}/stage-fast.yaml")
-        execute_with_retries(
-            self.k8s_client.apply_manifest_from_url,
-            kwok_yaml_url
+
+        # Fetch the controller Deployment manifest from kwok.yaml.
+        response = execute_with_retries(requests.get, kwok_yaml_url, timeout=30)
+        response.raise_for_status()
+        controller_deployment = client.ApiClient().deserialize(
+            type("Resp", (), {"data": response.text})(),
+            "V1Deployment",
         )
+
         execute_with_retries(
             self.k8s_client.apply_manifest_from_url,
             stage_fast_yaml_url
@@ -83,6 +90,8 @@ class KWOK(ABC):
                 self.k8s_client.apply_manifest_from_url,
                 metrics_usage_url
             )
+
+        return controller_deployment
 
     @staticmethod
     def _upsert_container_arg(container, arg_name, arg_value):
@@ -125,32 +134,12 @@ class KWOK(ABC):
 
         return key, value
 
-    def _copy_and_remove_upstream_controller_deployment(self):
-        """Copy the upstream kwok-controller deployment and then remove it."""
-        base_deployment = self.k8s_client.get_deployment("kwok-controller", "kube-system")
-        if not base_deployment:
-            raise RuntimeError("Upstream kwok-controller deployment not found. "
-                             "Ensure kwok.yaml was applied first.")
-        copied_deployment = deepcopy(base_deployment)
-
-        print("Deleting upstream kwok-controller deployment")
-        self.k8s_client.get_app_client().delete_namespaced_deployment(
-            name="kwok-controller",
-            namespace="kube-system",
-            body=client.V1DeleteOptions(propagation_policy="Foreground"),
-        )
-
-        return copied_deployment
 
     def _build_controller_deployment(self, base_deployment, controller_index):
         """Clone the upstream controller deployment and patch shard-specific fields."""
         deployment = deepcopy(base_deployment)
         deployment_name = self._controller_name(controller_index)
         controller_selector = f"kwok-controller-group={controller_index}"
-
-        # TODO(xinwei): Refactor to avoid mutating a deployment read from kube-apiserver.
-        # Prefer patching kwok.yaml before _bootstrap_kwok so controllers are created
-        # from the desired manifest directly.
 
         deployment.metadata.name = deployment_name
         deployment.metadata.resource_version = None
@@ -333,12 +322,11 @@ class Node(KWOK):
             self.kwok_release = self.kwok_release or self.fetch_latest_release()
             print(f"Using KWOK_RELEASE={self.kwok_release}")
 
-            self._bootstrap_kwok(self.kwok_release, self.enable_metrics)
+            controller_deployment_base = self._bootstrap_kwok(self.kwok_release, self.enable_metrics)
 
             controller_count = self._controller_count()
             print(f"Using {controller_count} controller(s) for {self.node_count} nodes, "
                   f"{self.nodes_per_controller} nodes each")
-            controller_deployment_base = self._copy_and_remove_upstream_controller_deployment()
             for controller_index in range(controller_count):
                 self._create_controller_deployment(controller_index, controller_deployment_base)
             self._wait_for_controllers_ready()

--- a/modules/python/tests/kwok/test_kwok_node.py
+++ b/modules/python/tests/kwok/test_kwok_node.py
@@ -193,12 +193,13 @@ class TestNodeIntegration(unittest.TestCase):
         self.mock_k8s_client.create_resource_slice.return_value = None
 
         mock_kwok_yaml_response = MagicMock()
-        mock_kwok_yaml_response.text = yaml.dump(
-            client.ApiClient().sanitize_for_serialization(make_base_controller_deployment())
-        )
+        deployment_dict = client.ApiClient().sanitize_for_serialization(make_base_controller_deployment())
+        deployment_dict["apiVersion"] = "apps/v1"
+        deployment_dict["kind"] = "Deployment"
+        mock_kwok_yaml_response.text = yaml.dump(deployment_dict)
 
         try:
-            with patch('requests.get', return_value=mock_kwok_yaml_response):
+            with patch('kwok.kwok.requests.get', return_value=mock_kwok_yaml_response):
                 self.node.create()
             print("Nodes created successfully.")
             self.mock_k8s_client.apply_manifest_from_url.assert_has_calls([
@@ -308,10 +309,11 @@ class TestNodeIntegration(unittest.TestCase):
         self.mock_k8s_client.create_node.return_value = None
 
         mock_kwok_yaml_response = MagicMock()
-        mock_kwok_yaml_response.text = yaml.dump(
-            client.ApiClient().sanitize_for_serialization(mock_deployment)
-        )
-        with patch('requests.get', return_value=mock_kwok_yaml_response):
+        deployment_dict = client.ApiClient().sanitize_for_serialization(mock_deployment)
+        deployment_dict["apiVersion"] = "apps/v1"
+        deployment_dict["kind"] = "Deployment"
+        mock_kwok_yaml_response.text = yaml.dump(deployment_dict)
+        with patch('kwok.kwok.requests.get', return_value=mock_kwok_yaml_response):
             grouped_node.create()
 
         self.mock_k8s_client.apply_manifest_from_url.assert_has_calls([
@@ -355,32 +357,29 @@ class TestNodeIntegration(unittest.TestCase):
             ["0", "0", "1", "1", "2"],
         )
 
-    def test_prepare_controller_base_deletes_upstream_with_delete_options(self):
-        """Test controller preparation copies and removes the upstream controller deployment."""
+    def test_bootstrap_returns_controller_deployment(self):
+        """Test that _bootstrap_kwok returns a V1Deployment from fetched kwok.yaml."""
         mock_deployment = make_base_controller_deployment(image="controller-image")
-        self.mock_k8s_client.get_deployment.return_value = mock_deployment
-
-        mock_app_client = MagicMock()
-        self.mock_k8s_client.get_app_client.return_value = mock_app_client
         self.mock_k8s_client.get_config_map.return_value = None
         self.mock_k8s_client.create_template.return_value = make_rendered_config_map()
         self.mock_k8s_client.apply_manifest_from_url.return_value = None
         self.mock_k8s_client.delete_manifest_from_file.return_value = None
         self.mock_k8s_client.apply_manifest_from_file.return_value = None
 
-        controller_base = self.node._prepare_controller_deployment_base(
-            "v0.7.0", enable_metrics=False
-        )
+        mock_response = MagicMock()
+        deployment_dict = client.ApiClient().sanitize_for_serialization(mock_deployment)
+        deployment_dict["apiVersion"] = "apps/v1"
+        deployment_dict["kind"] = "Deployment"
+        mock_response.text = yaml.dump(deployment_dict)
 
+        with patch('kwok.kwok.requests.get', return_value=mock_response):
+            controller_base = self.node._bootstrap_kwok("v0.7.0", enable_metrics=False)
+
+        self.assertIsInstance(controller_base, client.V1Deployment)
         self.assertEqual(
             controller_base.spec.template.spec.containers[0].image,
             "controller-image",
         )
-        self.mock_k8s_client.delete_manifest_from_file.assert_called_once_with(
-            self.node.kwok_config_path
-        )
-        self.mock_k8s_client.apply_manifest_from_file.assert_called_once()
-        mock_app_client.delete_namespaced_deployment.assert_called_once()
 
         derived_manifest = client.ApiClient().sanitize_for_serialization(
             self.node._build_controller_deployment(controller_base, 0)
@@ -397,15 +396,11 @@ class TestNodeIntegration(unittest.TestCase):
                 "requests": {"cpu": "2", "memory": "5Gi"},
             },
         )
+        # Verify the original deployment is not mutated
         self.assertNotIn(
             "--manage-nodes-with-label-selector=kwok-controller-group=0",
             mock_deployment.spec.template.spec.containers[0].args,
         )
-
-        _, kwargs = mock_app_client.delete_namespaced_deployment.call_args
-        self.assertEqual(kwargs["name"], "kwok-controller")
-        self.assertEqual(kwargs["namespace"], "kube-system")
-        self.assertEqual(kwargs["body"].propagation_policy, "Foreground")
 
     def test_tear_down_nodes(self):
         """

--- a/modules/python/tests/kwok/test_kwok_node.py
+++ b/modules/python/tests/kwok/test_kwok_node.py
@@ -166,13 +166,10 @@ class TestNodeIntegration(unittest.TestCase):
 
     def test_create_nodes(self):
         """Test creating KWOK nodes."""
-        upstream_deployment = make_base_controller_deployment()
         ready_deployment = make_ready_deployment("kwok-controller-0")
 
         def get_deployment_side_effect(name, namespace):
             self.assertEqual(namespace, "kube-system")
-            if name == "kwok-controller":
-                return upstream_deployment
             if name == "kwok-controller-0":
                 return ready_deployment
             self.fail(f"Unexpected deployment lookup: {name}")
@@ -186,9 +183,7 @@ class TestNodeIntegration(unittest.TestCase):
                 return "resource-slice-template"
             self.fail(f"Unexpected template path: {template_path}")
 
-        mock_app_client = MagicMock()
         self.mock_k8s_client.get_deployment.side_effect = get_deployment_side_effect
-        self.mock_k8s_client.get_app_client.return_value = mock_app_client
         self.mock_k8s_client.get_config_map.return_value = None
         self.mock_k8s_client.create_template.side_effect = create_template_side_effect
         self.mock_k8s_client.apply_manifest_from_url.return_value = None
@@ -197,15 +192,19 @@ class TestNodeIntegration(unittest.TestCase):
         self.mock_k8s_client.create_node.return_value = None
         self.mock_k8s_client.create_resource_slice.return_value = None
 
+        mock_kwok_yaml_response = MagicMock()
+        mock_kwok_yaml_response.text = yaml.dump(
+            client.ApiClient().sanitize_for_serialization(make_base_controller_deployment())
+        )
+
         try:
-            self.node.create()
+            with patch('requests.get', return_value=mock_kwok_yaml_response):
+                self.node.create()
             print("Nodes created successfully.")
             self.mock_k8s_client.apply_manifest_from_url.assert_has_calls([
-                call("https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/kwok.yaml"),
                 call("https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/stage-fast.yaml"),
                 call("https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/metrics-usage.yaml"),
             ])
-            mock_app_client.delete_namespaced_deployment.assert_called_once()
 
             controller_manifests = collect_applied_manifests(
                 self.mock_k8s_client.apply_manifest_from_file.call_args_list,
@@ -289,8 +288,6 @@ class TestNodeIntegration(unittest.TestCase):
 
         def get_deployment_side_effect(name, namespace):
             self.assertEqual(namespace, "kube-system")
-            if name == "kwok-controller":
-                return mock_deployment
             if name in {"kwok-controller-0", "kwok-controller-1", "kwok-controller-2"}:
                 return ready_deployment
             self.fail(f"Unexpected deployment lookup: {name}")
@@ -302,9 +299,7 @@ class TestNodeIntegration(unittest.TestCase):
                 return make_rendered_node_template(replacements)
             self.fail(f"Unexpected template path: {template_path}")
 
-        mock_app_client = MagicMock()
         self.mock_k8s_client.get_deployment.side_effect = get_deployment_side_effect
-        self.mock_k8s_client.get_app_client.return_value = mock_app_client
         self.mock_k8s_client.get_config_map.return_value = None
         self.mock_k8s_client.create_template.side_effect = create_template_side_effect
         self.mock_k8s_client.apply_manifest_from_url.return_value = None
@@ -312,15 +307,17 @@ class TestNodeIntegration(unittest.TestCase):
         self.mock_k8s_client.apply_manifest_from_file.return_value = None
         self.mock_k8s_client.create_node.return_value = None
 
-        grouped_node.create()
+        mock_kwok_yaml_response = MagicMock()
+        mock_kwok_yaml_response.text = yaml.dump(
+            client.ApiClient().sanitize_for_serialization(mock_deployment)
+        )
+        with patch('requests.get', return_value=mock_kwok_yaml_response):
+            grouped_node.create()
 
         self.mock_k8s_client.apply_manifest_from_url.assert_has_calls([
-            call("https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/kwok.yaml"),
             call("https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/stage-fast.yaml"),
         ])
-        self.assertEqual(self.mock_k8s_client.apply_manifest_from_url.call_count, 2)
-        self.assertEqual(self.mock_k8s_client.apply_manifest_from_file.call_count, 4)
-        mock_app_client.delete_namespaced_deployment.assert_called_once()
+        self.assertEqual(self.mock_k8s_client.apply_manifest_from_url.call_count, 1)
 
         controller_manifests = collect_applied_manifests(
             self.mock_k8s_client.apply_manifest_from_file.call_args_list,

--- a/modules/python/tests/kwok/test_kwok_node.py
+++ b/modules/python/tests/kwok/test_kwok_node.py
@@ -441,29 +441,6 @@ class TestNodeIntegration(unittest.TestCase):
 
 
 
-class TestDeploymentDeserialization(unittest.TestCase):
-    """Verify that a YAML-parsed deployment dict deserializes into V1Deployment."""
-
-    def test_deserialize_controller_manifest(self):
-        manifest = client.ApiClient().sanitize_for_serialization(
-            make_base_controller_deployment()
-        )
-        deployment = client.ApiClient().deserialize(
-            type("Resp", (), {"data": json.dumps(manifest)})(),
-            "V1Deployment",
-        )
-        self.assertIsInstance(deployment, client.V1Deployment)
-        self.assertEqual(deployment.metadata.name, "kwok-controller")
-        self.assertEqual(
-            deployment.spec.template.spec.containers[0].image,
-            "registry.k8s.io/kwok/kwok:v0.7.0",
-        )
-        self.assertEqual(
-            deployment.spec.template.spec.containers[0].args,
-            ["--config=/root/.kwok/kwok.yaml", "--server-address=0.0.0.0:10247"],
-        )
-
-
 class TestNodeValidation(unittest.TestCase):
     """Test class for KWOK node validation tests."""
     def setUp(self):

--- a/modules/python/tests/kwok/test_kwok_node.py
+++ b/modules/python/tests/kwok/test_kwok_node.py
@@ -1,4 +1,5 @@
 """Tests for KWOK node functionality."""
+import json
 import os
 import unittest
 from unittest.mock import MagicMock, call, patch
@@ -446,6 +447,29 @@ class TestNodeIntegration(unittest.TestCase):
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.fail(f"Node deletion failed: {exc}")
 
+
+
+class TestDeploymentDeserialization(unittest.TestCase):
+    """Verify that a YAML-parsed deployment dict deserializes into V1Deployment."""
+
+    def test_deserialize_controller_manifest(self):
+        manifest = client.ApiClient().sanitize_for_serialization(
+            make_base_controller_deployment()
+        )
+        deployment = client.ApiClient().deserialize(
+            type("Resp", (), {"data": json.dumps(manifest)})(),
+            "V1Deployment",
+        )
+        self.assertIsInstance(deployment, client.V1Deployment)
+        self.assertEqual(deployment.metadata.name, "kwok-controller")
+        self.assertEqual(
+            deployment.spec.template.spec.containers[0].image,
+            "registry.k8s.io/kwok/kwok:v0.7.0",
+        )
+        self.assertEqual(
+            deployment.spec.template.spec.containers[0].args,
+            ["--config=/root/.kwok/kwok.yaml", "--server-address=0.0.0.0:10247"],
+        )
 
 
 class TestNodeValidation(unittest.TestCase):


### PR DESCRIPTION
Refactor to avoid mutating a deployment read from kube-apiserver.