### PR TITLE
Configure login to export AWS session token

### DIFF
--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -16,6 +16,7 @@ steps:
         echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
         echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
         if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+          echo "Session token found (${AWS_SESSION_TOKEN:0:4}...); setting AWS_SESSION_TOKEN variable"
           echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
         fi
     displayName: 'Get login credentials'

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -27,8 +27,12 @@ steps:
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
     aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
     # ADO passes the literal string '$(AWS_SESSION_TOKEN)' when the pipeline variable is undefined
+    if [ "${AWS_SESSION:-}" = '$(AWS_SESSION_TOKEN)' ]; then
+      echo "AWS_SESSION contains unresolved ADO variable literal; treating as empty"
+      AWS_SESSION=""
+    fi
     if [ -n "${AWS_SESSION:-}" ]; then
-      echo "Session token found; configuring aws_session_token"
+      echo "Session token found (${AWS_SESSION:0:4}...); configuring aws_session_token"
       aws configure set aws_session_token "$AWS_SESSION"
     else
       echo "No session token; clearing aws_session_token"

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -25,25 +25,25 @@ steps:
     set -eu
     echo "login to AWS in $REGION"
 
-    aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
-    aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
+    aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+    aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
     # ADO passes the literal string '$(AWS_SESSION_TOKEN)' when the pipeline variable is undefined.
     # We can't use that literal directly because ADO expands $(...) in script bodies too.
     ADO_LITERAL='$'"(AWS_SESSION_TOKEN)"
-    if [ "${AWS_SESSION:-}" = "$ADO_LITERAL" ]; then
-      echo "No session token; AWS_SESSION contains unresolved ADO variable literal"
-      AWS_SESSION=""
+    if [ "${AWS_SESSION_TOKEN:-}" = "$ADO_LITERAL" ]; then
+      echo "No session token; AWS_SESSION_TOKEN contains unresolved ADO variable literal, clearing"
+      AWS_SESSION_TOKEN=""
     fi
-    if [ -n "${AWS_SESSION:-}" ]; then
-      echo "Session token found (${AWS_SESSION:0:4}...); configuring aws_session_token"
-      aws configure set aws_session_token "$AWS_SESSION"
+    if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+      echo "Session token found (${AWS_SESSION_TOKEN:0:4}...); configuring aws_session_token"
+      aws configure set aws_session_token "$AWS_SESSION_TOKEN"
     fi
     aws configure set default.region "$REGION"
     aws configure list
     echo "##vso[task.setvariable variable=AWS_DEFAULT_REGION]$REGION"
   displayName: "AWS Login"
   env:
-    AWS_ACCESS_KEY: $(AWS_ACCESS_KEY_ID)
-    AWS_SECRET_KEY: $(AWS_SECRET_ACCESS_KEY)
-    AWS_SESSION: $(AWS_SESSION_TOKEN)
+    AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+    AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+    AWS_SESSION_TOKEN: $(AWS_SESSION_TOKEN)
     REGION: ${{ parameters.region }}

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -15,7 +15,7 @@ steps:
       inlineScript: |
         echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
         echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
-        if [ -n "${AWS_SESSION_TOKEN:-}" ] && [ "${AWS_SESSION_TOKEN}" != '$(AWS_SESSION_TOKEN)' ]; then
+        if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
           echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
         fi
     displayName: 'Get login credentials'
@@ -26,9 +26,11 @@ steps:
 
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
     aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
+    # ADO passes the literal string '$(AWS_SESSION_TOKEN)' when the pipeline variable is undefined
     if [ -n "${AWS_SESSION:-}" ] && [ "${AWS_SESSION}" != '$(AWS_SESSION_TOKEN)' ]; then
       aws configure set aws_session_token "$AWS_SESSION"
     else
+      echo "No session token; unsetting aws_session_token"
       aws configure unset aws_session_token
     fi
     aws configure set default.region "$REGION"

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -27,11 +27,6 @@ steps:
 
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
     aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
-    # ADO passes the literal string '$(AWS_SESSION_TOKEN)' when the pipeline variable is undefined
-    if [ "${AWS_SESSION:-}" = '$(AWS_SESSION_TOKEN)' ]; then
-      echo "AWS_SESSION contains unresolved ADO variable literal; treating as empty"
-      AWS_SESSION=""
-    fi
     if [ -n "${AWS_SESSION:-}" ]; then
       echo "Session token found (${AWS_SESSION:0:4}...); configuring aws_session_token"
       aws configure set aws_session_token "$AWS_SESSION"

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -15,7 +15,7 @@ steps:
       inlineScript: |
         echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
         echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
-        if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+        if [ -n "${AWS_SESSION_TOKEN:-}" ] && [ "${AWS_SESSION_TOKEN}" != '$(AWS_SESSION_TOKEN)' ]; then
           echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
         fi
     displayName: 'Get login credentials'
@@ -26,8 +26,10 @@ steps:
 
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
     aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
-    if [ -n "${AWS_SESSION:-}" ]; then
+    if [ -n "${AWS_SESSION:-}" ] && [ "${AWS_SESSION}" != '$(AWS_SESSION_TOKEN)' ]; then
       aws configure set aws_session_token "$AWS_SESSION"
+    else
+      aws configure unset aws_session_token
     fi
     aws configure set default.region "$REGION"
     aws configure list

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -27,11 +27,12 @@ steps:
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
     aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
     # ADO passes the literal string '$(AWS_SESSION_TOKEN)' when the pipeline variable is undefined
-    if [ -n "${AWS_SESSION:-}" ] && [ "${AWS_SESSION}" != '$(AWS_SESSION_TOKEN)' ]; then
+    if [ -n "${AWS_SESSION:-}" ]; then
+      echo "Session token found; configuring aws_session_token"
       aws configure set aws_session_token "$AWS_SESSION"
     else
-      echo "No session token; unsetting aws_session_token"
-      aws configure unset aws_session_token
+      echo "No session token; clearing aws_session_token"
+      aws configure set aws_session_token ""
     fi
     aws configure set default.region "$REGION"
     aws configure list

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -16,7 +16,7 @@ steps:
         echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
         echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
         if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
-          echo "Session token found (${AWS_SESSION_TOKEN:0:4}...); setting AWS_SESSION_TOKEN variable"
+          echo "Session token found; setting it to AWS_SESSION_TOKEN pipeline variable"
           echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
         fi
     displayName: 'Get login credentials'
@@ -35,7 +35,7 @@ steps:
       AWS_SESSION_TOKEN=""
     fi
     if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
-      echo "Session token found (${AWS_SESSION_TOKEN:0:4}...); configuring aws_session_token"
+      echo "Session token found; configuring aws_session_token"
       aws configure set aws_session_token "$AWS_SESSION_TOKEN"
     fi
     aws configure set default.region "$REGION"

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -27,8 +27,10 @@ steps:
 
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
     aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
-    # ADO passes the literal string '$(AWS_SESSION_TOKEN)' when the pipeline variable is undefined
-    if [ "${AWS_SESSION:-}" = '$(AWS_SESSION_TOKEN)' ]; then
+    # ADO passes the literal string '$(AWS_SESSION_TOKEN)' when the pipeline variable is undefined.
+    # We can't use that literal directly because ADO expands $(...) in script bodies too.
+    ADO_LITERAL='$'"(AWS_SESSION_TOKEN)"
+    if [ "${AWS_SESSION:-}" = "$ADO_LITERAL" ]; then
       echo "No session token; AWS_SESSION contains unresolved ADO variable literal"
       AWS_SESSION=""
     fi

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -34,9 +34,6 @@ steps:
     if [ -n "${AWS_SESSION:-}" ]; then
       echo "Session token found (${AWS_SESSION:0:4}...); configuring aws_session_token"
       aws configure set aws_session_token "$AWS_SESSION"
-    else
-      echo "No session token; clearing aws_session_token"
-      aws configure set aws_session_token ""
     fi
     aws configure set default.region "$REGION"
     aws configure list

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -27,6 +27,11 @@ steps:
 
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
     aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
+    # ADO passes the literal string '$(AWS_SESSION_TOKEN)' when the pipeline variable is undefined
+    if [ "${AWS_SESSION:-}" = '$(AWS_SESSION_TOKEN)' ]; then
+      echo "No session token; AWS_SESSION contains unresolved ADO variable literal"
+      AWS_SESSION=""
+    fi
     if [ -n "${AWS_SESSION:-}" ]; then
       echo "Session token found (${AWS_SESSION:0:4}...); configuring aws_session_token"
       aws configure set aws_session_token "$AWS_SESSION"

--- a/steps/cloud/aws/login.yml
+++ b/steps/cloud/aws/login.yml
@@ -15,6 +15,9 @@ steps:
       inlineScript: |
         echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
         echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
+        if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+          echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
+        fi
     displayName: 'Get login credentials'
 
 - bash: |
@@ -23,12 +26,15 @@ steps:
 
     aws configure set aws_access_key_id "$AWS_ACCESS_KEY"
     aws configure set aws_secret_access_key "$AWS_SECRET_KEY"
+    if [ -n "${AWS_SESSION:-}" ]; then
+      aws configure set aws_session_token "$AWS_SESSION"
+    fi
     aws configure set default.region "$REGION"
     aws configure list
     echo "##vso[task.setvariable variable=AWS_DEFAULT_REGION]$REGION"
   displayName: "AWS Login"
-  name: aws_login
   env:
     AWS_ACCESS_KEY: $(AWS_ACCESS_KEY_ID)
     AWS_SECRET_KEY: $(AWS_SECRET_ACCESS_KEY)
+    AWS_SESSION: $(AWS_SESSION_TOKEN)
     REGION: ${{ parameters.region }}


### PR DESCRIPTION
### Context
`login.yml` supports two configuration of credential: service_connection and variable_group. OIDC token requires service connection and three parameters: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN. Note that `AWS_SESSION_TOKEN` is the addition here while it is not required for static keys use case.

In OIDC setup, `AWSShellScript@1` will inject AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN values, where in static key flow AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY is read from pipeline variables.

### Change
- Export and AWS_SESSION_TOKEN in `Get login credentials` step. Note that this step is not run at internal pipelines as they use `variable_group` credential type.
- Pass the session token as env var to `AWS Login` step, and use it to configure aws cli `aws_session_token`
- `AWS_SESSION` env var will default to literal '$(AWS_SESSION_TOKEN)' when the var is not set (indicating this is not OIDC auth). Need to clear this literal value because it is invalid and will fail pipeline
- Remove unnecessary step name.