### PR TITLE
feat: use latest version of nap test

### DIFF
--- a/scenarios/perf-eval/nap/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/nap/terraform-inputs/azure.tfvars
@@ -10,7 +10,6 @@ aks_cli_config_list = [
     role               = "nap"
     aks_name           = "nap"
     sku_tier           = "standard"
-    kubernetes_version = "1.33"
     default_node_pool = {
       name       = "system"
       node_count = 5


### PR DESCRIPTION
remove k8s version and let az cli pick latest version