### PR TITLE
Fix transient API failures in node validation

### DIFF
--- a/modules/python/clusterloader2/large_cluster/large_cluster.py
+++ b/modules/python/clusterloader2/large_cluster/large_cluster.py
@@ -90,7 +90,12 @@ def validate_clusterloader2(node_count, operation_timeout_in_minutes=10):
     ready_node_count = 0
     timeout = time.time() + (operation_timeout_in_minutes * 60)
     while time.time() < timeout:
-        ready_nodes = kube_client.get_ready_nodes()
+        try:
+            ready_nodes = kube_client.get_ready_nodes()
+        except Exception as e:
+            print(f"Transient error querying nodes, will retry: {e}")
+            time.sleep(10)
+            continue
         ready_node_count = len(ready_nodes)
         print(f"Currently {ready_node_count} nodes are ready.")
         if ready_node_count == node_count:


### PR DESCRIPTION
The `validate_clusterloader2` function in large_cluster.py crashes on transient Kubernetes API errors (503, 504, connection timeouts) during the node readiness check. This causes entire pipeline runs to fail even when the cluster is nearly ready.

Example from the [`cnl-observability` scheduled run on 2026-04-27](https://dev.azure.com/akstelescope/telescope/_build/results?buildId=65244&view=results): the cluster had 1003/1006 nodes ready when a single **503 Service Unavailable** (`upstream connect error or disconnect/reset before headers. reset reason: connection timeout`) killed the run.

## Root Cause

`get_ready_nodes()` was called without exception handling. At large scale (1000+ nodes), transient API server errors are expected. The API server may briefly become unavailable due to load, connection resets, or upstream proxy timeouts.

## Fix

Wrap `get_ready_nodes()` in a try/except block that catches transient exceptions, logs them, and retries after a short sleep. The existing timeout loop already provides a natural retry boundary — if the API stays down beyond the configured timeout, the function still fails as expected.

## Impact

- Prevents intermittent pipeline failures on large clusters (1000+ nodes)
- No behavior change for persistent failures — the timeout still applies
- Affects `validate_clusterloader2` only; execute/collect phases are unchanged


Test run for this change https://dev.azure.com/akstelescope/telescope/_build/results?buildId=65283&view=results