### PR TITLE
Update condition logic in competitive-test.yml

### DIFF
--- a/jobs/competitive-test.yml
+++ b/jobs/competitive-test.yml
@@ -36,6 +36,9 @@ parameters:
 - name: timeout_in_minutes
   type: number
   default: 60 # default when not specified is 60 minutes
+- name: cancellation_timeout_in_minutes
+  type: number
+  default: 60 # default when not specified is 5 minutes
 - name: retry_attempt_count
   type: number
   default: 3
@@ -56,7 +59,8 @@ jobs:
     matrix:
       ${{ parameters.matrix }}
   timeoutInMinutes: ${{ parameters.timeout_in_minutes }}
-  condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+  cancelTimeoutInMinutes: ${{ parameters.cancellation_timeout_in_minutes }}
+  condition: and(not(canceled()), or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main'))))
   steps:
   - template: /steps/setup-tests.yml
     parameters:

--- a/jobs/competitive-test.yml
+++ b/jobs/competitive-test.yml
@@ -38,7 +38,7 @@ parameters:
   default: 60 # default when not specified is 60 minutes
 - name: cancellation_timeout_in_minutes
   type: number
-  default: 60 # default when not specified is 5 minutes
+  default: 60 # default when not specified is 60 minutes
 - name: retry_attempt_count
   type: number
   default: 3


### PR DESCRIPTION
This pull request updates the `jobs/competitive-test.yml` workflow to improve job cancellation handling and make job conditions more robust. The main changes introduce a configurable cancellation timeout and ensure jobs do not run if already canceled.

Job execution and cancellation improvements:

* Added a new `cancellation_timeout_in_minutes` parameter to allow configuring how long to wait before force-canceling a job, and set its default value.
* Updated the job definition to use the new `cancelTimeoutInMinutes` parameter and changed the job's `condition` to ensure it does not run if already canceled.