### PR TITLE
Remove run_id parameter and simplify Set Run ID step

### DIFF
--- a/kcl/example_pipeline/pipeline.k
+++ b/kcl/example_pipeline/pipeline.k
@@ -81,15 +81,6 @@ output = ap.Pipeline {
     trigger =  ["v2"]
     pool = const.DEFAULT_POOL
 
-    parameters = [
-        ap.Parameter {
-            name = "run_id"
-            displayName = "Run ID (leave empty to auto-generate)"
-            type = "string"
-            default = "default"
-        }
-    ]
-
     jobs = [
         job.Job {
             job = "benchmarking"

--- a/kcl/example_pipeline/pipeline.yaml
+++ b/kcl/example_pipeline/pipeline.yaml
@@ -1,12 +1,7 @@
 name: Example Pipeline
-pool: AKS-Telescope-Ubuntu-EastUS2
+pool: AKS-Telescope-Airlock
 trigger:
 - v2
-parameters:
-- name: run_id
-  displayName: Run ID (leave empty to auto-generate)
-  type: string
-  default: default
 jobs:
 - job: benchmarking
   displayName: Benchmarking
@@ -15,17 +10,13 @@ jobs:
   - bash: |2
 
       set -exo pipefail
-      if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "default" ]; then
-        echo "Using provided Run ID: $RUN_ID"
-      else
-        job_id="$(System.JobId)"
-        RUN_ID=$(Build.BuildId)-${job_id:0:8}
-        echo "Run ID: $RUN_ID"
-      fi
+
+      job_id="$(System.JobId)"
+      RUN_ID=$(Build.BuildId)-${job_id:0:8}
+      echo "Run ID: $RUN_ID"
+
       echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
     displayName: Set Run ID
-    env:
-      RUN_ID: ${{ parameters.run_id }}
   - bash: |-
       set -exo pipefail
       pip3 install --upgrade "pip<24"

--- a/kcl/lib/steps/common/set_run_id.k
+++ b/kcl/lib/steps/common/set_run_id.k
@@ -4,18 +4,13 @@ SetRunId = lambda -> steps.Step {
     steps.Bash {
         bash = """
 set -exo pipefail
-if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "default" ]; then
-  echo "Using provided Run ID: $RUN_ID"
-else
-  job_id="$(System.JobId)"
-  RUN_ID=$(Build.BuildId)-\${job_id:0:8}
-  echo "Run ID: $RUN_ID"
-fi
+
+job_id="$(System.JobId)"
+RUN_ID=$(Build.BuildId)-\${job_id:0:8}
+echo "Run ID: $RUN_ID"
+
 echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
 """
         displayName = "Set Run ID"
-        env = {
-            RUN_ID = "\${{ parameters.run_id }}"
-        }
     }
 }


### PR DESCRIPTION
The run_id parameter was unused in practice. Simplify the step to always auto-generate the run ID from BuildId and JobId.