### PR TITLE
Add --log-level CLI flag to kwok

### DIFF
--- a/modules/python/kwok/kwok.py
+++ b/modules/python/kwok/kwok.py
@@ -13,6 +13,7 @@ import yaml
 from kubernetes import client
 
 from clients.kubernetes_client import KubernetesClient
+from utils.logger_config import setup_logging
 from utils.retries import execute_with_retries
 
 
@@ -716,8 +717,15 @@ def main():
         required=True,
         help="Action to perform: create, validate, or tear_down.",
     )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="Logging verbosity for KWOK and its dependencies (default: INFO).",
+    )
 
     args = parser.parse_args()
+    setup_logging(args.log_level)
 
     node = Node(
         node_manifest_path=args.node_manifest_path,

--- a/modules/python/utils/logger_config.py
+++ b/modules/python/utils/logger_config.py
@@ -15,7 +15,7 @@ class AzureDevOpsFormatter(logging.Formatter):
         # Then add the VSO prefix at the start
         return f"{vso_prefix}{formatted_msg}"
 
-def setup_logging():
+def setup_logging(level="INFO"):
     root_logger = logging.getLogger()
     # Clear any existing handlers
     root_logger.handlers = []
@@ -24,11 +24,14 @@ def setup_logging():
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S"
     )
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
-    handler.setLevel(logging.INFO)
+    handler.setLevel(level)
     root_logger.addHandler(handler)
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(level)
     return root_logger
 
 def get_logger(name):

--- a/modules/python/utils/logger_config.py
+++ b/modules/python/utils/logger_config.py
@@ -24,9 +24,6 @@ def setup_logging(level="INFO"):
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S"
     )
-    if isinstance(level, str):
-        level = getattr(logging, level.upper(), logging.INFO)
-
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     handler.setLevel(level)


### PR DESCRIPTION
Exposes logging verbosity as an explicit `--log-level` argument. `setup_logging()` now accepts an optional `level` parameter (default "INFO").