### PR TITLE
Removes -x from set_run_id

### DIFF
--- a/kcl/ccp_team/hyperscale_apiserver_executing_seats/pipeline.yaml
+++ b/kcl/ccp_team/hyperscale_apiserver_executing_seats/pipeline.yaml
@@ -6,7 +6,7 @@ jobs:
   steps:
   - bash: |2
 
-      set -exo pipefail
+      set -eo pipefail
 
       job_id="$(System.JobId)"
       RUN_ID=$(Build.BuildId)-${job_id:0:8}

--- a/kcl/ccp_team/hyperscale_pod_scheduling/pipeline.yaml
+++ b/kcl/ccp_team/hyperscale_pod_scheduling/pipeline.yaml
@@ -15,7 +15,7 @@ stages:
     steps:
     - bash: |2
 
-        set -exo pipefail
+        set -eo pipefail
 
         job_id="$(System.JobId)"
         RUN_ID=$(Build.BuildId)-${job_id:0:8}
@@ -319,7 +319,7 @@ stages:
     steps:
     - bash: |2
 
-        set -exo pipefail
+        set -eo pipefail
 
         job_id="$(System.JobId)"
         RUN_ID=$(Build.BuildId)-${job_id:0:8}
@@ -623,7 +623,7 @@ stages:
     steps:
     - bash: |2
 
-        set -exo pipefail
+        set -eo pipefail
 
         job_id="$(System.JobId)"
         RUN_ID=$(Build.BuildId)-${job_id:0:8}

--- a/kcl/example_pipeline/pipeline.yaml
+++ b/kcl/example_pipeline/pipeline.yaml
@@ -9,7 +9,7 @@ jobs:
   steps:
   - bash: |2
 
-      set -exo pipefail
+      set -eo pipefail
 
       job_id="$(System.JobId)"
       RUN_ID=$(Build.BuildId)-${job_id:0:8}

--- a/kcl/lib/steps/common/set_run_id.k
+++ b/kcl/lib/steps/common/set_run_id.k
@@ -2,8 +2,10 @@ import azure_pipelines.ap.steps
 
 SetRunId = lambda -> steps.Step {
     steps.Bash {
+# Can not use `set -x`.
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops
         bash = """
-set -exo pipefail
+set -eo pipefail
 
 job_id="$(System.JobId)"
 RUN_ID=$(Build.BuildId)-\${job_id:0:8}


### PR DESCRIPTION
Using `set -x` cause problem with setting variables. Details in https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops