### PR TITLE
Clean up unused AKS settings in job scheduling pipeline

### DIFF
--- a/scenarios/perf-eval/job-scheduling/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/job-scheduling/terraform-inputs/azure.tfvars
@@ -10,7 +10,6 @@ aks_cli_config_list = [
     sku_tier                      = "standard"
     kubernetes_version            = "1.33"
     use_aks_preview_private_build = true
-    use_custom_configurations     = true
     default_node_pool = {
       name       = "default"
       node_count = 2

--- a/scenarios/perf-eval/job-scheduling/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/job-scheduling/terraform-inputs/azure.tfvars
@@ -9,7 +9,7 @@ aks_cli_config_list = [
     aks_name                      = "job-scheduling"
     sku_tier                      = "standard"
     kubernetes_version            = "1.33"
-    use_aks_preview_private_build = true
+
     default_node_pool = {
       name       = "default"
       node_count = 2


### PR DESCRIPTION
Remove the unnecessary use_aks_preview_private_build and use_custom_configurations settings.