### PR TITLE
Declare contents: read on python-validation and yaml-validation

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -9,6 +9,8 @@ env:
   PYTHON_MODULES_DIR: modules/python
 jobs:
   python-validation:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   yaml-validation:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Two lint-only workflows currently rely on the default `GITHUB_TOKEN` scope, which can include write access to several scopes depending on org/repo defaults. This PR pins both jobs to `contents: read`, matching the per-job permissions style already used in `terraform-validation.yml`.

- `python-validation.yml`: only runs pylint + pytest on changed files.
- `yaml-validation.yml`: only runs `yamllint`.

Neither touches issues, PRs, releases, packages, or pages, so `contents: read` is sufficient. Validated by `yaml.safe_load` on each edited file.