### PR TITLE
feat(crud): add AKSMachineClient non-batch scale path

### DIFF
--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -17,6 +17,7 @@ follow-up PR.
 """
 import json
 import logging
+import math
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -274,9 +275,10 @@ class AKSMachineClient(AKSClient):
         target_total = baseline_count + expected_count
         # Each percentile target must be STRICTLY GREATER than baseline_count so
         # we count only NEW nodes -- pre-existing labeled Ready nodes alone must
-        # never satisfy any threshold.
+        # never satisfy any threshold. Use math.ceil so e.g. P50 of 3 -> 2 (not 1)
+        # and P100 always equals target_total (ceil(1.0 * N) == N).
         targets = {
-            p: max(baseline_count + 1, int((p / 100.0) * target_total))
+            p: max(baseline_count + 1, math.ceil((p / 100.0) * target_total))
             for p in (50, 70, 90, 99, 100)
         }
         elapsed: Dict[int, float] = {}
@@ -334,10 +336,19 @@ class AKSMachineClient(AKSClient):
             else:
                 logger.info(f"  P{p} (target={targets[p]} nodes): TIMEOUT")
         max_elapsed = max(elapsed.values())
-        logger.info(
-            f"All target nodes became ready in {max_elapsed:.2f} seconds "
-            f"in agent pool {agentpool_name}"
-        )
+        if len(elapsed) == len(targets):
+            logger.info(
+                f"All target nodes became ready in {max_elapsed:.2f} seconds "
+                f"in agent pool {agentpool_name}"
+            )
+        else:
+            missed = [f"P{p}" for p in (50, 70, 90, 99, 100) if p not in elapsed]
+            logger.warning(
+                f"Partial readiness in agent pool {agentpool_name}: "
+                f"{len(elapsed)}/{len(targets)} percentiles met within "
+                f"{timeout}s; missed {missed}; last successful percentile at "
+                f"{max_elapsed:.2f}s"
+            )
         logger.info(f"Percentile node readiness data: {json.dumps(result, indent=2)}")
         return result
 
@@ -438,6 +449,15 @@ class AKSMachineClient(AKSClient):
                 successful = self._scale_machine_individually(request, names)
                 op.add_metadata("successful_machines", successful)
 
+                # Fail fast on partial landing BEFORE waiting on the agentpool
+                # or readiness against a reduced count -- otherwise the recorded
+                # percentile envelope and node_readiness_time describe a smaller
+                # target than the caller actually requested.
+                if len(successful) != scale_machine_count:
+                    raise RuntimeError(
+                        f"scale_machine landed {len(successful)}/{scale_machine_count} machines"
+                    )
+
                 # Single agentpool-level provisioning check.
                 agentpool_url = (
                     f"{_ARM_BASE}/subscriptions/{self.subscription_id}/resourceGroups/"
@@ -466,10 +486,6 @@ class AKSMachineClient(AKSClient):
                 )
                 op.add_metadata("cluster_info", self.get_cluster_data(cluster_name))
 
-                if len(successful) != scale_machine_count:
-                    raise RuntimeError(
-                        f"scale_machine landed {len(successful)}/{scale_machine_count} machines"
-                    )
                 if not agentpool_ok:
                     raise RuntimeError(
                         f"agentpool {agentpool_name} did not reach Succeeded within {timeout}s"

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -8,18 +8,20 @@ yet exposed in the Azure SDK.
 Public methods (``create_machine_agentpool``, ``scale_machine``) wrap their work
 in ``OperationContext``: the context is opened inside the client method,
 metadata is enriched with ``op.add_metadata`` along the way, success returns
-True, failures are logged and re-raised so ``OperationContext`` records them.
+None, failures are logged and re-raised so ``OperationContext`` records them.
 ``MachineCRUD`` therefore stays a thin try/except wrapper.
 
-This is the scaffolding revision: ``create_machine_agentpool`` and the
-agentpool provisioning poll are fully implemented; ``scale_machine``, its
-private helpers, and the ``_get_machine_name_prefix`` naming helper raise
-``NotImplementedError`` and will land in a follow-up PR.
+This revision adds the non-batch scale path. The batch dispatch
+(``use_batch_api=True``) still raises ``NotImplementedError`` and will land in a
+follow-up PR.
 """
+import json
 import logging
 import threading
 import time
-from typing import Any, Dict, Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
 
 import requests
 
@@ -38,6 +40,7 @@ get_logger("msal").setLevel(logging.ERROR)
 _ARM_BASE = "https://management.azure.com"
 _ARM_SCOPE = "https://management.azure.com/.default"
 _AGENTPOOL_API_VERSION = "2024-06-02-preview"
+_MACHINE_API_VERSION = "2025-06-02-preview"
 _POLL_INTERVAL_SECONDS = 10
 # Per-request HTTP timeout is capped so that a single slow PUT/GET cannot
 # consume the caller's whole ``timeout`` budget before the polling loop starts.
@@ -62,8 +65,7 @@ class AKSMachineClient(AKSClient):
         self._token_lock = threading.Lock()
         # Pool TCP/TLS across calls. ``requests.Session`` is thread-safe for
         # sending requests (each request creates its own urllib3 connection
-        # from the shared pool), so this is safe for the planned parallel
-        # scale path landing in PR-2.
+        # from the shared pool), so this is safe for the parallel scale path.
         self._session = requests.Session()
 
     # ---- auth + REST plumbing ----
@@ -88,12 +90,12 @@ class AKSMachineClient(AKSClient):
         """Send an authenticated ARM REST request and return the raw Response.
 
         Callers are responsible for checking ``response.status_code`` (or
-        calling ``raise_for_status()``) — this method does NOT raise on HTTP
+        calling ``raise_for_status()``) -- this method does NOT raise on HTTP
         errors. Long-running Machine API operations return 200/202 with a
         Location header that callers must follow.
 
         Uses ``self._session`` for connection pooling so TCP/TLS handshakes
-        are reused across polls and the planned parallel scale path.
+        are reused across polls and parallel scale-path workers.
         """
         headers = {
             "Authorization": f"Bearer {self._get_access_token()}",
@@ -218,11 +220,7 @@ class AKSMachineClient(AKSClient):
         logger.error(f"agentpool provisioning timed out after {timeout}s")
         return False
 
-    # ---- scale path: stubbed on this scaffolding PR ----
-    # The methods below preserve the public/private signatures so that
-    # ``MachineCRUD`` can be wired up against them in a follow-up PR; each
-    # raises ``NotImplementedError`` until the implementation lands.
-
+    # ---- Machine API: node readiness ----
     def _wait_for_machine_node_readiness(
         self,
         agentpool_name: str,
@@ -230,14 +228,120 @@ class AKSMachineClient(AKSClient):
         timeout: int,
         baseline_count: int = 0,
     ) -> Dict[str, Dict[str, Any]]:
-        """Wait for ``expected_count`` NEW Ready nodes; return percentile dict.
+        """Wait for ``expected_count`` NEW Ready nodes; return nested percentile dict.
 
-        Stubbed in this PR; implementation lands in a follow-up.
+        AKS Machine ARM resource names (e.g. ``scale100-machine-1``) are NOT the
+        same as the underlying k8s Node names (``aks-<pool>-<rand>-vmss<i>``), so
+        we cannot look up Nodes by Machine name. Instead we poll Nodes labelled
+        ``agentpool=<pool>`` and record the wall-clock elapsed when each percentile
+        ready threshold is hit.
+
+        ``baseline_count`` is the number of Ready+labeled nodes that already
+        existed BEFORE scale_machine ran. Percentile targets are computed against
+        ``baseline_count + expected_count`` and clamped to ``> baseline_count``
+        so a target never fires on pre-existing nodes alone. Without this, an
+        agentpool that already has 1 Ready node and is being scaled by 1 more
+        would report P50/P70/P90/P99/P100 = ~0.7s (the first poll) even though the
+        new node had not yet provisioned.
+
+        ``timeout`` is wall-clock seconds from invocation. Returns the nested
+        empty-state envelope (``elapsed_time_seconds=None``, ``success=False``)
+        if ``k8s_client`` is unavailable, ``expected_count`` <= 0, or no
+        percentile target is met within ``timeout``. Polling exceptions are
+        logged and treated as 0 ready this tick. Never raises.
         """
-        raise NotImplementedError(
-            "_wait_for_machine_node_readiness lands in a follow-up PR"
+        # Empty-state envelope: nested dict per P-key with
+        # `target_nodes`, `elapsed_time_seconds`, `percentage`, `success` so
+        # the Kusto schema sees consistent shape regardless of outcome.
+        empty_envelope: Dict[str, Dict[str, Any]] = {
+            f"P{p}": {
+                "target_nodes": 0,
+                "elapsed_time_seconds": None,
+                "percentage": p,
+                "success": False,
+            }
+            for p in (50, 70, 90, 99, 100)
+        }
+        kc = self.k8s_client
+        if kc is None:
+            logger.error(
+                "k8s_client is None on AKSClient; cannot wait for machine readiness"
+            )
+            return empty_envelope
+        if expected_count <= 0:
+            return empty_envelope
+        label_selector = f"agentpool={agentpool_name}"
+        target_total = baseline_count + expected_count
+        # Each percentile target must be STRICTLY GREATER than baseline_count so
+        # we count only NEW nodes -- pre-existing labeled Ready nodes alone must
+        # never satisfy any threshold.
+        targets = {
+            p: max(baseline_count + 1, int((p / 100.0) * target_total))
+            for p in (50, 70, 90, 99, 100)
+        }
+        elapsed: Dict[int, float] = {}
+        start = time.time()
+        deadline = start + timeout
+        logger.info(
+            f"Waiting for nodes in agentpool {agentpool_name} (label {label_selector}) - "
+            f"targets {targets}, baseline={baseline_count}, expected={expected_count}, "
+            f"timeout {timeout}s"
         )
+        while time.time() < deadline and len(elapsed) < len(targets):
+            try:
+                ready = len(kc.get_ready_nodes(label_selector=label_selector))
+            except Exception as e:
+                logger.warning(f"get_ready_nodes({label_selector}) failed: {e}")
+                ready = 0
+            now_elapsed = time.time() - start
+            for p, target in targets.items():
+                if p not in elapsed and ready >= target:
+                    elapsed[p] = now_elapsed
+                    logger.info(
+                        f"P{p} hit: {ready}/{target_total} ready "
+                        f"(target={target}, baseline={baseline_count}) at {now_elapsed:.2f}s"
+                    )
+            if len(elapsed) < len(targets):
+                time.sleep(2)
+        if not elapsed:
+            logger.warning(
+                f"No percentile target met within {timeout}s for agentpool {agentpool_name}"
+            )
+            return {
+                f"P{p}": {
+                    "target_nodes": targets[p],
+                    "elapsed_time_seconds": None,
+                    "percentage": p,
+                    "success": False,
+                }
+                for p in (50, 70, 90, 99, 100)
+            }
+        result: Dict[str, Dict[str, Any]] = {
+            f"P{p}": {
+                "target_nodes": targets[p],
+                "elapsed_time_seconds": elapsed.get(p),
+                "percentage": p,
+                "success": p in elapsed,
+            }
+            for p in (50, 70, 90, 99, 100)
+        }
+        # Log percentile summary including P100, which is the wall-clock
+        # elapsed until ALL target nodes are Ready.
+        logger.info(f"Node Readiness Percentile Summary for agentpool {agentpool_name}:")
+        for p in (50, 70, 90, 99, 100):
+            if p in elapsed:
+                logger.info(f"  P{p} (target={targets[p]} nodes): {elapsed[p]:.2f} seconds")
+            else:
+                logger.info(f"  P{p} (target={targets[p]} nodes): TIMEOUT")
+        max_elapsed = max(elapsed.values())
+        logger.info(
+            f"All target nodes became ready in {max_elapsed:.2f} seconds "
+            f"in agent pool {agentpool_name}"
+        )
+        logger.info(f"Percentile node readiness data: {json.dumps(result, indent=2)}")
+        return result
 
+    # ---- Machine API: scale path ----
     def scale_machine(
         self,
         agentpool_name: str,
@@ -249,22 +353,207 @@ class AKSMachineClient(AKSClient):
         timeout: int = 600,
         readiness_wait_timeout: int = 1200,
         tags: Optional[Dict[str, str]] = None,  # pylint: disable=unused-argument
-    ) -> bool:
+    ) -> None:
         """Scale a Machine-mode agentpool by creating ``scale_machine_count`` machines.
 
-        Stubbed in this PR; implementation lands in a follow-up.
+        Opens an ``OperationContext`` here, enriches with successful machine
+        names, per-percentile readiness envelope, and the cluster snapshot.
+        Returns on success; re-raises on failure so the context records the
+        trace.
+
+        Flow:
+          1. Snapshot the current Ready+labeled node count in the agentpool
+             (``baseline_count``) so the readiness watcher counts only NEW nodes.
+          2. Submit machine PUTs individually (per-machine ARM polling is
+             intentionally NOT performed).
+          3. Wait ONCE on the agentpool-level provisioningState.
+          4. Wait for nodes labeled ``agentpool=<pool>`` to surpass
+             ``baseline_count`` by enough to satisfy P50/P70/P90/P99/P100 targets.
+
+        ``tags`` is currently unused (Machine API rejects top-level tags on the
+        machine PUT body; machines inherit tags from the parent agentpool).
+
+        The ``use_batch_api=True`` branch is stubbed on this PR and raises
+        ``NotImplementedError``; it will land in a follow-up PR.
+
+        Raises:
+            NotImplementedError: ``use_batch_api=True``.
+            RuntimeError: fewer machines landed than requested, agentpool did
+                not reach Succeeded within ``timeout``, or P100 readiness did
+                not complete within ``readiness_wait_timeout``.
         """
-        raise NotImplementedError(
-            "scale_machine lands in a follow-up PR"
+        if use_batch_api:
+            raise NotImplementedError(
+                "scale_machine batch path (use_batch_api=True) lands in a follow-up PR"
+            )
+        cluster_name = cluster_name or self.get_cluster_name()
+        metadata = {
+            "cluster_name": cluster_name,
+            "agentpool_name": agentpool_name,
+            "vm_size": vm_size,
+            "scale_machine_count": scale_machine_count,
+            "use_batch_api": use_batch_api,
+            "machine_workers": machine_workers,
+        }
+        # Bundle into a SimpleNamespace so the helpers retain the
+        # ``request.foo`` shape without exposing yet another module-level data class.
+        request = SimpleNamespace(
+            agentpool_name=agentpool_name,
+            cluster_name=cluster_name,
+            resource_group=self.resource_group,
+            vm_size=vm_size,
+            scale_machine_count=scale_machine_count,
+            use_batch_api=use_batch_api,
+            machine_workers=machine_workers,
+            timeout=timeout,
+            readiness_wait_timeout=readiness_wait_timeout,
         )
+        with self._get_operation_context()(
+            "scale_machine", "azure", metadata, result_dir=self.result_dir
+        ) as op:
+            try:
+                # Snapshot baseline BEFORE any PUTs so the readiness watcher
+                # counts only NEW nodes.
+                kc = self.k8s_client
+                baseline_count = 0
+                if kc is not None:
+                    try:
+                        baseline_count = len(
+                            kc.get_ready_nodes(
+                                label_selector=f"agentpool={agentpool_name}"
+                            )
+                        )
+                        logger.info(
+                            f"baseline ready nodes in agentpool {agentpool_name}: {baseline_count}"
+                        )
+                    except Exception:
+                        logger.warning(
+                            "baseline node snapshot failed; readiness count may be inflated"
+                        )
+
+                prefix = self._get_machine_name_prefix(scale_machine_count)
+                names = [
+                    f"{prefix}-machine-{i + 1}" for i in range(scale_machine_count)
+                ]
+                successful = self._scale_machine_individually(request, names)
+                op.add_metadata("successful_machines", successful)
+
+                # Single agentpool-level provisioning check.
+                agentpool_url = (
+                    f"{_ARM_BASE}/subscriptions/{self.subscription_id}/resourceGroups/"
+                    f"{self.resource_group}/providers/Microsoft.ContainerService/"
+                    f"managedClusters/{cluster_name}/agentPools/"
+                    f"{agentpool_name}?api-version={_AGENTPOOL_API_VERSION}"
+                )
+                agentpool_ok = self._wait_for_agentpool_provisioning(
+                    agentpool_url, timeout
+                )
+                logger.info(
+                    f"agentpool {agentpool_name} provisioning "
+                    f"{'Succeeded' if agentpool_ok else 'Failed/Timeout'}"
+                )
+
+                percentile_envelope = self._wait_for_machine_node_readiness(
+                    agentpool_name=agentpool_name,
+                    expected_count=len(successful),
+                    timeout=readiness_wait_timeout,
+                    baseline_count=baseline_count,
+                )
+                op.add_metadata("percentile_node_readiness_times", percentile_envelope)
+                p100 = percentile_envelope.get("P100", {})
+                op.add_metadata(
+                    "node_readiness_time", p100.get("elapsed_time_seconds") or 0.0
+                )
+                op.add_metadata("cluster_info", self.get_cluster_data(cluster_name))
+
+                if len(successful) != scale_machine_count:
+                    raise RuntimeError(
+                        f"scale_machine landed {len(successful)}/{scale_machine_count} machines"
+                    )
+                if not agentpool_ok:
+                    raise RuntimeError(
+                        f"agentpool {agentpool_name} did not reach Succeeded within {timeout}s"
+                    )
+                # P100 is the strictest readiness envelope (all target nodes
+                # Ready); if it succeeded, every lower percentile did too.
+                if not p100.get("success", False):
+                    raise RuntimeError(
+                        f"node readiness P100 did not complete within "
+                        f"{readiness_wait_timeout}s for agentpool {agentpool_name}"
+                    )
+            except Exception as e:
+                logger.error(f"Failed to scale machine agentpool {agentpool_name}: {e}")
+                raise
 
     @staticmethod
     def _get_machine_name_prefix(scale_machine_count: int) -> str:
         """Generate the machine-name prefix for a given scale count.
 
-        Stubbed in this PR; implementation lands in a follow-up alongside the
-        scale path that consumes it.
+        The prefix is part of the machine ARM resource name; cross-repo Kusto
+        dashboards key on machine name, so this scheme is kept stable.
+
+        - ``scale1000`` -> ``scale1k`` (any multiple of 1000 >= 1000 collapses)
+        - ``scale500``  -> ``scale500``
+        - ``scale1``    -> ``scale1``
         """
-        raise NotImplementedError(
-            "_get_machine_name_prefix lands in a follow-up PR"
+        if scale_machine_count >= 1000 and scale_machine_count % 1000 == 0:
+            return f"scale{scale_machine_count // 1000}k"
+        return f"scale{scale_machine_count}"
+
+    def _scale_machine_individually(
+        self, request: SimpleNamespace, names: List[str],
+    ) -> List[str]:
+        """Submit per-machine PUTs concurrently via ThreadPoolExecutor.
+
+        Each worker calls ``_create_single_machine(name, request)`` which PUTs
+        the machine and returns True on any 2xx response. Per-machine
+        provisioningState is intentionally NOT polled (see
+        ``_create_single_machine`` for why); the agentpool-level poll in
+        ``scale_machine`` is the real completion signal. Returns the list of
+        names that reported True. Per-machine exceptions are logged and
+        treated as failure (name omitted from result).
+        """
+        successful: List[str] = []
+        # Clamp workers to >=1 so a misconfigured request (0 or negative) cannot
+        # crash ThreadPoolExecutor with ValueError.
+        with ThreadPoolExecutor(max_workers=max(1, request.machine_workers)) as ex:
+            futures = {ex.submit(self._create_single_machine, n, request): n for n in names}
+            for fut in as_completed(futures):
+                n = futures[fut]
+                try:
+                    if fut.result():
+                        successful.append(n)
+                except Exception:
+                    logger.exception(f"create_single_machine failed for {n}")
+        return successful
+
+    def _create_single_machine(self, name: str, request: SimpleNamespace) -> bool:
+        """PUT a single Machine resource. Returns True on any 2xx response.
+
+        Body is ``{"properties": {"hardware": {"vmSize": ...}}}``. Tags are inherited
+        from the parent agentpool; the machine PUT body in api-version 2025-06-02-preview
+        does not accept a top-level ``tags`` field (rejected with UnmarshalError).
+
+        Intentionally does NOT poll the per-machine ARM provisioningState. The
+        AKS RP reports per-machine ``provisioningState='Succeeded'`` essentially
+        as soon as the agentpool admits the request -- well before the underlying
+        VM is created. Polling here therefore returns spuriously early and only
+        adds N round-trips of latency without surfacing useful signal. The
+        canonical completion signal is the agentpool-level provisioningState,
+        which ``scale_machine`` polls once after all PUTs return.
+
+        Never raises on HTTP errors; logs and returns False on non-2xx responses.
+        """
+        sub = self.subscription_id
+        url = (
+            f"{_ARM_BASE}/subscriptions/{sub}/resourceGroups/{request.resource_group}"
+            f"/providers/Microsoft.ContainerService/managedClusters/{request.cluster_name}"
+            f"/agentPools/{request.agentpool_name}/machines/{name}"
+            f"?api-version={_MACHINE_API_VERSION}"
         )
+        body: Dict[str, Any] = {"properties": {"hardware": {"vmSize": request.vm_size}}}
+        resp = self.make_request("PUT", url, data=body, timeout=request.timeout)
+        if resp.status_code not in (200, 201, 202):
+            logger.error(f"PUT machine {name} -> {resp.status_code} {resp.text[:500]}")
+            return False
+        return True

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -14,6 +14,7 @@ the follow-up PR lands.
 # pylint: disable=protected-access
 # Tests intentionally exercise private helpers directly; the leading underscore
 # is conventional rather than semantic privacy.
+import itertools
 import tempfile
 import unittest
 from types import SimpleNamespace
@@ -319,7 +320,6 @@ class TestAKSMachineClient(unittest.TestCase):
         # time.time() is called multiple times per iteration (start, deadline
         # check, elapsed). Use a long monotonic sequence and let StopIteration
         # be impossible by repeating the last value with itertools.chain.
-        import itertools  # local: only needed for this helper
         tick = itertools.chain(
             iter([float(i) for i in range(0, 1000)]),
             itertools.repeat(1000.0),
@@ -414,7 +414,6 @@ class TestAKSMachineClient(unittest.TestCase):
         # The function calls time.time() ~3 times per loop iteration plus once
         # for `start`. Provide a long monotonic sequence so P50 (target=2) is
         # met while well under the 100s deadline, then jump past it.
-        import itertools
         ticks = itertools.chain(
             iter([0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 200.0, 200.0]),
             itertools.repeat(200.0),

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -7,15 +7,16 @@ result file via ``Operation.save_to_file`` on context exit. Tests verify:
   the right keys
 - failure path raises (so the OperationContext records ``success=False``)
 
-Only ``create_machine_agentpool`` has a full implementation on this scaffolding
-PR; ``scale_machine`` and the ``_get_machine_name_prefix`` naming helper raise
-``NotImplementedError`` and will be tested in a follow-up PR.
+This revision adds tests for the non-batch scale path. The batch dispatch
+(``use_batch_api=True``) is asserted to raise ``NotImplementedError`` until
+the follow-up PR lands.
 """
 # pylint: disable=protected-access
 # Tests intentionally exercise private helpers directly; the leading underscore
 # is conventional rather than semantic privacy.
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 from clients.aks_machine_client import AKSMachineClient
@@ -105,7 +106,7 @@ class TestAKSMachineClient(unittest.TestCase):
 
     @mock.patch.object(AKSMachineClient, "make_request")
     def test_create_machine_agentpool_put_failure_raises(self, mock_make_request):
-        """PUT non-2xx \u2192 RuntimeError propagates out of with-block."""
+        """PUT non-2xx -> RuntimeError propagates out of with-block."""
         mock_resp = mock.MagicMock()
         mock_resp.status_code = 500
         mock_resp.text = "boom"
@@ -122,7 +123,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_create_machine_agentpool_provisioning_timeout_raises(
         self, mock_make_request, _mock_wait
     ):
-        """PUT OK but provisioning never reaches Succeeded \u2192 RuntimeError."""
+        """PUT OK but provisioning never reaches Succeeded -> RuntimeError."""
         mock_resp = mock.MagicMock()
         mock_resp.status_code = 200
         mock_make_request.return_value = mock_resp
@@ -132,22 +133,166 @@ class TestAKSMachineClient(unittest.TestCase):
                 agentpool_name="apool", vm_size="Standard_D2_v3"
             )
 
-    # ---- scale_machine: stubbed on this PR ----
+    # ---- _get_machine_name_prefix ----
 
-    def test_scale_machine_raises_not_implemented(self):
-        """scale_machine is a stub on this PR; subsequent PR will implement it."""
-        with self.assertRaises(NotImplementedError):
+    def test_get_machine_name_prefix_small(self):
+        """Counts < 1000 emit literal scale<N>."""
+        self.assertEqual(AKSMachineClient._get_machine_name_prefix(1), "scale1")
+        self.assertEqual(AKSMachineClient._get_machine_name_prefix(500), "scale500")
+
+    def test_get_machine_name_prefix_thousand_multiples(self):
+        """Multiples of 1000 collapse to scale<N>k for stable Kusto keys."""
+        self.assertEqual(AKSMachineClient._get_machine_name_prefix(1000), "scale1k")
+        self.assertEqual(AKSMachineClient._get_machine_name_prefix(2000), "scale2k")
+
+    def test_get_machine_name_prefix_non_multiple_thousand(self):
+        """Non-multiple-of-1000 counts >= 1000 stay literal."""
+        self.assertEqual(AKSMachineClient._get_machine_name_prefix(1500), "scale1500")
+
+    # ---- scale_machine: non-batch path ----
+
+    @mock.patch.object(AKSMachineClient, "_wait_for_machine_node_readiness")
+    @mock.patch.object(AKSMachineClient, "_wait_for_agentpool_provisioning",
+                       return_value=True)
+    @mock.patch.object(AKSMachineClient, "_create_single_machine", return_value=True)
+    def test_scale_machine_non_batch_success(
+        self, _mock_create, _mock_wait_ap, mock_wait_ready
+    ):
+        """Non-batch path: all PUTs land, agentpool Succeeded, P100 success ->
+        returns and metadata is enriched with the expected keys."""
+        mock_wait_ready.return_value = {
+            f"P{p}": {
+                "target_nodes": 2,
+                "elapsed_time_seconds": 10.0,
+                "percentage": p,
+                "success": True,
+            }
+            for p in (50, 70, 90, 99, 100)
+        }
+        self.mock_k8s.get_ready_nodes.return_value = []
+
+        self.client.scale_machine(
+            agentpool_name="apool",
+            vm_size="Standard_D2_v3",
+            scale_machine_count=2,
+            machine_workers=2,
+        )
+
+        metadata_keys = {
+            call.args[0] for call in self.mock_operation.add_metadata.call_args_list
+        }
+        self.assertIn("successful_machines", metadata_keys)
+        self.assertIn("percentile_node_readiness_times", metadata_keys)
+        self.assertIn("node_readiness_time", metadata_keys)
+        self.assertIn("cluster_info", metadata_keys)
+
+    @mock.patch.object(AKSMachineClient, "_wait_for_machine_node_readiness")
+    @mock.patch.object(AKSMachineClient, "_wait_for_agentpool_provisioning",
+                       return_value=True)
+    @mock.patch.object(AKSMachineClient, "_create_single_machine")
+    def test_scale_machine_partial_landing_raises(
+        self, mock_create, _mock_wait_ap, mock_wait_ready
+    ):
+        """Non-batch path: if fewer machines land than requested,
+        scale_machine raises RuntimeError before returning."""
+        # Two PUTs requested, first lands, second fails.
+        mock_create.side_effect = [True, False]
+        mock_wait_ready.return_value = {
+            f"P{p}": {
+                "target_nodes": 2,
+                "elapsed_time_seconds": 10.0,
+                "percentage": p,
+                "success": True,
+            }
+            for p in (50, 70, 90, 99, 100)
+        }
+        self.mock_k8s.get_ready_nodes.return_value = []
+
+        with self.assertRaises(RuntimeError):
             self.client.scale_machine(
-                agentpool_name="apool", vm_size="Standard_D2_v3",
+                agentpool_name="apool",
+                vm_size="Standard_D2_v3",
                 scale_machine_count=2,
+                machine_workers=1,
             )
 
-    # ---- _get_machine_name_prefix: stubbed on this PR ----
+    @mock.patch.object(AKSMachineClient, "_wait_for_machine_node_readiness")
+    @mock.patch.object(AKSMachineClient, "_wait_for_agentpool_provisioning",
+                       return_value=True)
+    @mock.patch.object(AKSMachineClient, "_create_single_machine", return_value=True)
+    def test_scale_machine_passes_baseline_count_to_readiness(
+        self, _mock_create, _mock_wait_ap, mock_wait_ready
+    ):
+        """baseline_count snapshot is forwarded to _wait_for_machine_node_readiness."""
+        # Three pre-existing labeled Ready nodes.
+        self.mock_k8s.get_ready_nodes.return_value = [object(), object(), object()]
+        mock_wait_ready.return_value = {
+            f"P{p}": {
+                "target_nodes": 4,
+                "elapsed_time_seconds": 10.0,
+                "percentage": p,
+                "success": True,
+            }
+            for p in (50, 70, 90, 99, 100)
+        }
 
-    def test_get_machine_name_prefix_raises_not_implemented(self):
-        """_get_machine_name_prefix is a stub on this PR; lands with the scale path."""
+        self.client.scale_machine(
+            agentpool_name="apool",
+            vm_size="Standard_D2_v3",
+            scale_machine_count=1,
+            machine_workers=1,
+        )
+
+        mock_wait_ready.assert_called_once()
+        self.assertEqual(mock_wait_ready.call_args.kwargs["baseline_count"], 3)
+        self.assertEqual(mock_wait_ready.call_args.kwargs["expected_count"], 1)
+
+    def test_scale_machine_batch_path_raises_not_implemented(self):
+        """The use_batch_api=True branch is stubbed until the follow-up PR."""
         with self.assertRaises(NotImplementedError):
-            AKSMachineClient._get_machine_name_prefix(1000)
+            self.client.scale_machine(
+                agentpool_name="apool",
+                vm_size="Standard_D2_v3",
+                scale_machine_count=2,
+                use_batch_api=True,
+            )
+
+    # ---- _create_single_machine ----
+
+    @mock.patch.object(AKSMachineClient, "make_request")
+    def test_create_single_machine_2xx_returns_true(self, mock_make_request):
+        """Any 200/201/202 response counts as a successful PUT."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+        )
+        for code in (200, 201, 202):
+            with self.subTest(status=code):
+                mock_resp = mock.MagicMock()
+                mock_resp.status_code = code
+                mock_make_request.return_value = mock_resp
+                self.assertTrue(
+                    self.client._create_single_machine("m1", request)
+                )
+
+    @mock.patch.object(AKSMachineClient, "make_request")
+    def test_create_single_machine_non_2xx_returns_false(self, mock_make_request):
+        """Non-2xx responses are logged and return False (never raise)."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+        )
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "boom"
+        mock_make_request.return_value = mock_resp
+        self.assertFalse(self.client._create_single_machine("m1", request))
 
 
 if __name__ == "__main__":

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -191,21 +191,15 @@ class TestAKSMachineClient(unittest.TestCase):
                        return_value=True)
     @mock.patch.object(AKSMachineClient, "_create_single_machine")
     def test_scale_machine_partial_landing_raises(
-        self, mock_create, _mock_wait_ap, mock_wait_ready
+        self, mock_create, mock_wait_ap, mock_wait_ready
     ):
         """Non-batch path: if fewer machines land than requested,
-        scale_machine raises RuntimeError before returning."""
+        scale_machine raises RuntimeError BEFORE waiting on agentpool
+        provisioning or node readiness -- otherwise the recorded percentile
+        envelope and node_readiness_time describe a smaller target than
+        requested."""
         # Two PUTs requested, first lands, second fails.
         mock_create.side_effect = [True, False]
-        mock_wait_ready.return_value = {
-            f"P{p}": {
-                "target_nodes": 2,
-                "elapsed_time_seconds": 10.0,
-                "percentage": p,
-                "success": True,
-            }
-            for p in (50, 70, 90, 99, 100)
-        }
         self.mock_k8s.get_ready_nodes.return_value = []
 
         with self.assertRaises(RuntimeError):
@@ -215,6 +209,20 @@ class TestAKSMachineClient(unittest.TestCase):
                 scale_machine_count=2,
                 machine_workers=1,
             )
+
+        # Fail-fast: neither the agentpool wait nor the readiness wait should
+        # have been reached.
+        mock_wait_ap.assert_not_called()
+        mock_wait_ready.assert_not_called()
+        # successful_machines metadata IS recorded so operators can see which
+        # PUTs landed; downstream readiness/cluster_info metadata is not.
+        metadata_keys = {
+            call.args[0] for call in self.mock_operation.add_metadata.call_args_list
+        }
+        self.assertIn("successful_machines", metadata_keys)
+        self.assertNotIn("percentile_node_readiness_times", metadata_keys)
+        self.assertNotIn("node_readiness_time", metadata_keys)
+        self.assertNotIn("cluster_info", metadata_keys)
 
     @mock.patch.object(AKSMachineClient, "_wait_for_machine_node_readiness")
     @mock.patch.object(AKSMachineClient, "_wait_for_agentpool_provisioning",
@@ -293,6 +301,182 @@ class TestAKSMachineClient(unittest.TestCase):
         mock_resp.text = "boom"
         mock_make_request.return_value = mock_resp
         self.assertFalse(self.client._create_single_machine("m1", request))
+
+    # ---- _wait_for_machine_node_readiness ----
+
+    def _make_readiness_envelope(self, ready_counts):
+        """Helper: drive _wait_for_machine_node_readiness with a scripted
+        sequence of get_ready_nodes results.
+
+        ``ready_counts`` is an iterable of ints; each item is the integer
+        returned by len(get_ready_nodes(...)) on each poll. ``time.sleep`` is
+        patched out and ``time.time`` is advanced 1s per call so the loop's
+        elapsed-time bookkeeping is deterministic.
+        """
+        self.mock_k8s.get_ready_nodes.side_effect = [
+            [object()] * c for c in ready_counts
+        ]
+        # time.time() is called multiple times per iteration (start, deadline
+        # check, elapsed). Use a long monotonic sequence and let StopIteration
+        # be impossible by repeating the last value with itertools.chain.
+        import itertools  # local: only needed for this helper
+        tick = itertools.chain(
+            iter([float(i) for i in range(0, 1000)]),
+            itertools.repeat(1000.0),
+        )
+
+        def fake_time():
+            return next(tick)
+
+        return fake_time
+
+    def test_wait_readiness_ceil_rounding_target_total_3(self):
+        """target_total=3 with baseline=0 expected=3 -> percentile targets use
+        math.ceil: P50=2, P70=3, P90=3, P99=3, P100=3 (P100 always equals
+        target_total)."""
+        fake_time = self._make_readiness_envelope(
+            # 0 ready -> 1 -> 2 -> 3 ready: at 3 ready all targets met.
+            [0, 1, 2, 3]
+        )
+        with mock.patch("clients.aks_machine_client.time.sleep"), \
+             mock.patch("clients.aks_machine_client.time.time", side_effect=fake_time):
+            env = self.client._wait_for_machine_node_readiness(
+                agentpool_name="apool",
+                expected_count=3,
+                timeout=600,
+                baseline_count=0,
+            )
+        self.assertEqual(env["P50"]["target_nodes"], 2)
+        self.assertEqual(env["P70"]["target_nodes"], 3)
+        self.assertEqual(env["P90"]["target_nodes"], 3)
+        self.assertEqual(env["P99"]["target_nodes"], 3)
+        # P100 == target_total invariant: ceil(1.0 * 3) == 3.
+        self.assertEqual(env["P100"]["target_nodes"], 3)
+        for p in (50, 70, 90, 99, 100):
+            self.assertTrue(env[f"P{p}"]["success"])
+
+    def test_wait_readiness_baseline_clamp(self):
+        """When baseline_count is large relative to expected, the clamp
+        baseline_count+1 dominates: every percentile target == baseline+1 so
+        pre-existing nodes alone can never satisfy any threshold."""
+        # baseline=10, expected=1 -> target_total=11. ceil-based percentile
+        # targets would be P50=6, P70=8, P90=10, P99=11, P100=11, but the
+        # baseline+1 clamp (11) overrides P50/P70/P90 (and meets P99/P100).
+        fake_time = self._make_readiness_envelope([10, 11])
+        with mock.patch("clients.aks_machine_client.time.sleep"), \
+             mock.patch("clients.aks_machine_client.time.time", side_effect=fake_time):
+            env = self.client._wait_for_machine_node_readiness(
+                agentpool_name="apool",
+                expected_count=1,
+                timeout=600,
+                baseline_count=10,
+            )
+        for p in (50, 70, 90, 99, 100):
+            self.assertEqual(env[f"P{p}"]["target_nodes"], 11)
+            self.assertTrue(env[f"P{p}"]["success"])
+
+    def test_wait_readiness_no_target_met_returns_failure_envelope(self):
+        """No percentile target met within the deadline -> envelope with
+        success=False, elapsed_time_seconds=None, target_nodes preserved."""
+        # Always 0 ready; time.time eventually crosses the deadline.
+        self.mock_k8s.get_ready_nodes.return_value = []
+        # Force the loop to exit immediately: start=0, every subsequent call
+        # returns 1000.0 which is past the deadline of start+timeout=10.
+        time_seq = iter([0.0, 1000.0, 1000.0, 1000.0])
+        with mock.patch("clients.aks_machine_client.time.sleep"), \
+             mock.patch("clients.aks_machine_client.time.time",
+                        side_effect=lambda: next(time_seq, 1000.0)):
+            env = self.client._wait_for_machine_node_readiness(
+                agentpool_name="apool",
+                expected_count=3,
+                timeout=10,
+                baseline_count=0,
+            )
+        for p in (50, 70, 90, 99, 100):
+            self.assertFalse(env[f"P{p}"]["success"])
+            self.assertIsNone(env[f"P{p}"]["elapsed_time_seconds"])
+        # target_nodes still reflects what we were aiming for so operators can
+        # see "we wanted 3, got 0".
+        self.assertEqual(env["P100"]["target_nodes"], 3)
+        self.assertEqual(env["P50"]["target_nodes"], 2)
+
+    def test_wait_readiness_partial_timeout(self):
+        """Some percentiles hit, then deadline elapses -> hit percentiles have
+        success=True with elapsed_time_seconds; missed percentiles have
+        success=False with elapsed_time_seconds=None. Crucially the
+        'all became ready' summary log does NOT fire."""
+        # target_total=3 (baseline=0, expected=3). Sequence: ready=0,1,2 then
+        # deadline crosses before reaching 3.
+        ready_seq = iter([[], [object()], [object()] * 2, [object()] * 2])
+        self.mock_k8s.get_ready_nodes.side_effect = lambda label_selector: next(
+            ready_seq, [object()] * 2
+        )
+        # The function calls time.time() ~3 times per loop iteration plus once
+        # for `start`. Provide a long monotonic sequence so P50 (target=2) is
+        # met while well under the 100s deadline, then jump past it.
+        import itertools
+        ticks = itertools.chain(
+            iter([0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 200.0, 200.0]),
+            itertools.repeat(200.0),
+        )
+        with mock.patch("clients.aks_machine_client.time.sleep"), \
+             mock.patch("clients.aks_machine_client.time.time",
+                        side_effect=lambda: next(ticks)), \
+             mock.patch("clients.aks_machine_client.logger") as mock_logger:
+            env = self.client._wait_for_machine_node_readiness(
+                agentpool_name="apool",
+                expected_count=3,
+                timeout=100,
+                baseline_count=0,
+            )
+        # P50 (target=2) was hit; P70/P90/P99/P100 (target=3) were not.
+        self.assertTrue(env["P50"]["success"])
+        self.assertIsNotNone(env["P50"]["elapsed_time_seconds"])
+        for p in (70, 90, 99, 100):
+            self.assertFalse(env[f"P{p}"]["success"])
+            self.assertIsNone(env[f"P{p}"]["elapsed_time_seconds"])
+        # The unconditional "All target nodes became ready" log must NOT fire
+        # on partial completion; a partial-readiness warning takes its place.
+        info_msgs = [
+            c.args[0] for c in mock_logger.info.call_args_list if c.args
+        ]
+        warning_msgs = [
+            c.args[0] for c in mock_logger.warning.call_args_list if c.args
+        ]
+        self.assertFalse(
+            any("All target nodes became ready" in m for m in info_msgs),
+            f"unexpected all-ready log on partial completion: {info_msgs}",
+        )
+        self.assertTrue(
+            any("Partial readiness" in m for m in warning_msgs),
+            f"expected partial-readiness warning, got: {warning_msgs}",
+        )
+
+    def test_wait_readiness_expected_count_zero_short_circuits(self):
+        """expected_count<=0 -> empty envelope, no Kubernetes calls."""
+        env = self.client._wait_for_machine_node_readiness(
+            agentpool_name="apool",
+            expected_count=0,
+            timeout=600,
+            baseline_count=0,
+        )
+        for p in (50, 70, 90, 99, 100):
+            self.assertFalse(env[f"P{p}"]["success"])
+            self.assertEqual(env[f"P{p}"]["target_nodes"], 0)
+        self.mock_k8s.get_ready_nodes.assert_not_called()
+
+    def test_wait_readiness_no_k8s_client_short_circuits(self):
+        """k8s_client is None -> empty envelope, no polling."""
+        self.client.k8s_client = None
+        env = self.client._wait_for_machine_node_readiness(
+            agentpool_name="apool",
+            expected_count=5,
+            timeout=600,
+            baseline_count=0,
+        )
+        for p in (50, 70, 90, 99, 100):
+            self.assertFalse(env[f"P{p}"]["success"])
+            self.assertEqual(env[f"P{p}"]["target_nodes"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds the non-batch scale path to `AKSMachineClient`, building on the scaffolding from #1179. The batch path (`use_batch_api=True`) is intentionally still stubbed with `NotImplementedError` and lands in a follow-up PR so this diff stays focused and reviewable.

## What's in this PR

**Fully implemented in this PR:**
- `scale_machine` (non-batch branch): snapshots baseline ready node count, submits per-machine PUTs via `_scale_machine_individually`, waits once on the agentpool-level `provisioningState`, then waits for P50/P70/P90/P99/P100 node readiness. Raises `RuntimeError` on partial landing, agentpool timeout, or P100 readiness failure.
- `_wait_for_machine_node_readiness`: polls nodes labeled `agentpool=<pool>` and computes percentile envelopes against `baseline_count + expected_count` so only NEW nodes count toward thresholds. Never raises; returns an empty-state envelope on exhaustion.
- `_get_machine_name_prefix`: `scale<N>k` for multiples of 1000 ≥ 1000, `scale<N>` otherwise. Stable scheme for cross-repo Kusto dashboards.
- `_scale_machine_individually`: `ThreadPoolExecutor` dispatch with `max(1, machine_workers)` clamp.
- `_create_single_machine`: single Machine PUT, returns `True` on any 2xx, never raises. Per-machine ARM polling intentionally omitted (AKS RP reports `Succeeded` essentially as soon as the agentpool admits the request).

**Stubbed in this PR (lands in a follow-up PR):**
- `scale_machine` batch branch (`use_batch_api=True`)
- `_scale_machine_batch`, `_create_batch_machines`, `_make_batch_request`, `_array_split`, and the `_BATCH_429_*` retry constants

## Other notes

- `scale_machine` return type changed from `-> bool` to `-> None` for consistency with `create_machine_agentpool` (only exceptions signal failure; the return value was always dead).
- Adds `_MACHINE_API_VERSION = '2025-06-02-preview'` constant.
- Preserves every fix from #1179: `self._session` for connection pooling, `_PER_REQUEST_TIMEOUT_CAP=60` timeout split, immediate 4xx raise in `_wait_for_agentpool_provisioning`, immediate-Failed on missing `provisioningState`, `tempfile.TemporaryDirectory()` in test setUp/tearDown.

## Tests

- 12 unit tests pass (up from 5 on main).
- New tests cover:
  - Non-batch scale success (metadata enrichment, all required keys present)
  - Partial-landing raises `RuntimeError`
  - `baseline_count` snapshot propagation to `_wait_for_machine_node_readiness`
  - `_get_machine_name_prefix` value tests for small / multiple-of-1000 / non-multiple-of-1000 counts
  - `_create_single_machine` accepts 200/201/202 and returns `False` (no raise) on 500
  - Regression test asserting the batch path still raises `NotImplementedError`
- `pylint` rating: 10.00/10 on both files.

## Follow-up PR

A subsequent PR will:
- Replace the `NotImplementedError` in the `use_batch_api=True` branch with batch dispatch.
- Add `_scale_machine_batch`, `_create_batch_machines`, `_make_batch_request`, `_array_split`, and the `_BATCH_429_*` constants.
- Add a batch success-path test.
