### PR TITLE
feat(crud): add AKSMachineClient batch scale path (BatchPutMachine)

### DIFF
--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -769,6 +769,6 @@ class AKSMachineClient(AKSClient):
             backoff *= 2
         text = last_resp.text[:500] if last_resp is not None else ""
         raise RuntimeError(
-            f"batch request exceeded {_BATCH_429_MAX_RETRIES} 429 retries "
-            f"[{ctx}]; last text={text}"
+            f"batch request exceeded {_BATCH_429_MAX_RETRIES} attempts "
+            f"after HTTP 429 responses [{ctx}]; last text={text}"
         )

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -704,7 +704,13 @@ class AKSMachineClient(AKSClient):
         # the individual machine PUT site.
         put_timeout = min(request.timeout, _PER_REQUEST_TIMEOUT_CAP)
         self._make_batch_request(
-            "PUT", url, body, put_timeout, batch_header_value=batch_header_value,
+            "PUT",
+            url,
+            body,
+            put_timeout,
+            batch_header_value=batch_header_value,
+            chunk_idx=chunk_idx,
+            first_machine_name=first_machine_name,
         )
         return list(chunk)
 
@@ -715,6 +721,8 @@ class AKSMachineClient(AKSClient):
         data: Dict[str, Any],
         timeout: int,
         batch_header_value: str,
+        chunk_idx: Optional[int] = None,
+        first_machine_name: Optional[str] = None,
     ) -> None:
         """Send a ``BatchPutMachine``-headered request with bounded 429 backoff.
 
@@ -725,6 +733,12 @@ class AKSMachineClient(AKSClient):
         ``_BATCH_429_INITIAL_BACKOFF_SECONDS`` and doubling each attempt
         (1s, 2s, 4s by default). All other non-2xx responses raise immediately.
         """
+        # Compact prefix so every error/log line is self-identifying in Kusto
+        # (chunk_idx + first machine name pinpoint the failing slice without
+        # cross-referencing the per-worker log).
+        ctx = (
+            f"chunk={chunk_idx} target={first_machine_name} {method} {url}"
+        )
         backoff = _BATCH_429_INITIAL_BACKOFF_SECONDS
         last_resp: Optional[requests.Response] = None
         for attempt in range(_BATCH_429_MAX_RETRIES):
@@ -733,7 +747,11 @@ class AKSMachineClient(AKSClient):
                 "Content-Type": "application/json",
                 "BatchPutMachine": batch_header_value,
             }
-            resp = requests.request(
+            # Use the client's shared Session so this batch path reuses the
+            # same pooled TCP/TLS connections (and adapters/proxies) as the
+            # individual ``make_request`` path; avoids per-PUT handshakes
+            # during large scales.
+            resp = self._session.request(
                 method, url, headers=headers, json=data, timeout=timeout,
             )
             last_resp = resp
@@ -741,17 +759,19 @@ class AKSMachineClient(AKSClient):
                 return
             if resp.status_code != 429:
                 raise RuntimeError(
-                    f"batch request failed: {resp.status_code} {resp.text[:500]}"
+                    f"batch request failed [{ctx}]: "
+                    f"{resp.status_code} {resp.text[:500]}"
                 )
             if attempt == _BATCH_429_MAX_RETRIES - 1:
                 break
             logger.warning(
-                f"batch request 429; retrying in {backoff:.1f}s "
+                f"batch request 429 [{ctx}]; retrying in {backoff:.1f}s "
                 f"(attempt {attempt + 1}/{_BATCH_429_MAX_RETRIES})"
             )
             time.sleep(backoff)
             backoff *= 2
         text = last_resp.text[:500] if last_resp is not None else ""
         raise RuntimeError(
-            f"batch request exceeded {_BATCH_429_MAX_RETRIES} 429 retries; last text={text}"
+            f"batch request exceeded {_BATCH_429_MAX_RETRIES} 429 retries "
+            f"[{ctx}]; last text={text}"
         )

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -47,11 +47,13 @@ _POLL_INTERVAL_SECONDS = 10
 # consume the caller's whole ``timeout`` budget before the polling loop starts.
 # The remaining budget is reserved for ``_wait_for_agentpool_provisioning``.
 _PER_REQUEST_TIMEOUT_CAP = 60
-# Bounded 429 retry budget for ``_scale_machine_batch``. The AKS RP throttles
-# BatchPutMachine independently of normal PUTs; small bursts at the start of a
-# scale-out are common, so a short exponential backoff (1s, 2s, 4s) usually
-# clears them without ballooning the chunk's wall-time.
-_BATCH_429_MAX_RETRIES = 3
+# Bounded 429 retry budget for ``_scale_machine_batch``. Total number of
+# attempts (NOT additional retries on top of an initial call). The AKS RP
+# throttles BatchPutMachine independently of normal PUTs; small bursts at
+# the start of a scale-out are common, so a short exponential backoff
+# (1s, 2s, 4s, 8s between the five attempts) usually clears them without
+# ballooning the chunk's wall-time.
+_BATCH_429_MAX_RETRIES = 5
 _BATCH_429_INITIAL_BACKOFF_SECONDS = 1.0
 
 
@@ -722,11 +724,11 @@ class AKSMachineClient(AKSClient):
 
         Sends the request directly (NOT via ``make_request``) so we can attach
         the ``BatchPutMachine`` header alongside the standard auth/content-type
-        headers. On HTTP 429, retries up to ``_BATCH_429_MAX_RETRIES`` times
-        (total ``1 + _BATCH_429_MAX_RETRIES`` attempts) with exponential
-        backoff starting at ``_BATCH_429_INITIAL_BACKOFF_SECONDS`` and
-        doubling each retry (1s, 2s, 4s by default). All other non-2xx
-        responses raise immediately.
+        headers. Calls the endpoint up to ``_BATCH_429_MAX_RETRIES`` total
+        times on HTTP 429, sleeping between attempts with exponential backoff
+        starting at ``_BATCH_429_INITIAL_BACKOFF_SECONDS`` and doubling each
+        time (1s, 2s, 4s, 8s by default). All other non-2xx responses raise
+        immediately.
         """
         # Compact prefix so every error/log line is self-identifying in Kusto
         # (chunk_idx + first machine name pinpoint the failing slice without
@@ -736,8 +738,7 @@ class AKSMachineClient(AKSClient):
         )
         backoff = _BATCH_429_INITIAL_BACKOFF_SECONDS
         last_resp: Optional[requests.Response] = None
-        max_attempts = 1 + _BATCH_429_MAX_RETRIES
-        for attempt in range(max_attempts):
+        for attempt in range(_BATCH_429_MAX_RETRIES):
             headers = {
                 "Authorization": f"Bearer {self._get_access_token()}",
                 "Content-Type": "application/json",
@@ -758,11 +759,11 @@ class AKSMachineClient(AKSClient):
                     f"batch request failed [{ctx}]: "
                     f"{resp.status_code} {resp.text[:500]}"
                 )
-            if attempt == max_attempts - 1:
+            if attempt == _BATCH_429_MAX_RETRIES - 1:
                 break
             logger.warning(
                 f"batch request 429 [{ctx}]; retrying in {backoff:.1f}s "
-                f"(retry {attempt + 1}/{_BATCH_429_MAX_RETRIES})"
+                f"(attempt {attempt + 1}/{_BATCH_429_MAX_RETRIES})"
             )
             time.sleep(backoff)
             backoff *= 2

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -694,8 +694,8 @@ class AKSMachineClient(AKSClient):
         )
         # Cap per-request timeout so a single batch PUT (plus 429 backoff)
         # cannot consume the whole operation budget that downstream
-        # provisioning/readiness waits depend on. Mirrors the cap applied at
-        # the individual machine PUT site.
+        # provisioning/readiness waits depend on. Mirrors the cap applied
+        # inside ``put_machine`` (the per-machine PUT helper).
         put_timeout = min(request.timeout, _PER_REQUEST_TIMEOUT_CAP)
         self._make_batch_request(
             "PUT",
@@ -722,10 +722,11 @@ class AKSMachineClient(AKSClient):
 
         Sends the request directly (NOT via ``make_request``) so we can attach
         the ``BatchPutMachine`` header alongside the standard auth/content-type
-        headers. Retries on HTTP 429 up to ``_BATCH_429_MAX_RETRIES`` attempts
-        with exponential backoff starting at
-        ``_BATCH_429_INITIAL_BACKOFF_SECONDS`` and doubling each attempt
-        (1s, 2s, 4s by default). All other non-2xx responses raise immediately.
+        headers. On HTTP 429, retries up to ``_BATCH_429_MAX_RETRIES`` times
+        (total ``1 + _BATCH_429_MAX_RETRIES`` attempts) with exponential
+        backoff starting at ``_BATCH_429_INITIAL_BACKOFF_SECONDS`` and
+        doubling each retry (1s, 2s, 4s by default). All other non-2xx
+        responses raise immediately.
         """
         # Compact prefix so every error/log line is self-identifying in Kusto
         # (chunk_idx + first machine name pinpoint the failing slice without
@@ -735,7 +736,8 @@ class AKSMachineClient(AKSClient):
         )
         backoff = _BATCH_429_INITIAL_BACKOFF_SECONDS
         last_resp: Optional[requests.Response] = None
-        for attempt in range(_BATCH_429_MAX_RETRIES):
+        max_attempts = 1 + _BATCH_429_MAX_RETRIES
+        for attempt in range(max_attempts):
             headers = {
                 "Authorization": f"Bearer {self._get_access_token()}",
                 "Content-Type": "application/json",
@@ -756,11 +758,11 @@ class AKSMachineClient(AKSClient):
                     f"batch request failed [{ctx}]: "
                     f"{resp.status_code} {resp.text[:500]}"
                 )
-            if attempt == _BATCH_429_MAX_RETRIES - 1:
+            if attempt == max_attempts - 1:
                 break
             logger.warning(
                 f"batch request 429 [{ctx}]; retrying in {backoff:.1f}s "
-                f"(attempt {attempt + 1}/{_BATCH_429_MAX_RETRIES})"
+                f"(retry {attempt + 1}/{_BATCH_429_MAX_RETRIES})"
             )
             time.sleep(backoff)
             backoff *= 2

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -22,7 +22,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
@@ -47,6 +47,12 @@ _POLL_INTERVAL_SECONDS = 10
 # consume the caller's whole ``timeout`` budget before the polling loop starts.
 # The remaining budget is reserved for ``_wait_for_agentpool_provisioning``.
 _PER_REQUEST_TIMEOUT_CAP = 60
+# Bounded 429 retry budget for ``_scale_machine_batch``. The AKS RP throttles
+# BatchPutMachine independently of normal PUTs; small bursts at the start of a
+# scale-out are common, so a short exponential backoff (1s, 2s, 4s) usually
+# clears them without ballooning the chunk's wall-time.
+_BATCH_429_MAX_RETRIES = 3
+_BATCH_429_INITIAL_BACKOFF_SECONDS = 1.0
 
 
 class AKSMachineClient(AKSClient):
@@ -384,19 +390,16 @@ class AKSMachineClient(AKSClient):
         ``tags`` is currently unused (Machine API rejects top-level tags on the
         machine PUT body; machines inherit tags from the parent agentpool).
 
-        The ``use_batch_api=True`` branch is stubbed on this PR and raises
-        ``NotImplementedError``; it will land in a follow-up PR.
+        When ``use_batch_api=True`` the work is sharded across
+        ``machine_workers`` chunks and each chunk is submitted via a single
+        ``BatchPutMachine``-headered PUT (see ``_create_batch_machines``); when
+        False each machine is PUT individually.
 
         Raises:
-            NotImplementedError: ``use_batch_api=True``.
             RuntimeError: fewer machines landed than requested, agentpool did
                 not reach Succeeded within ``timeout``, or P100 readiness did
                 not complete within ``readiness_wait_timeout``.
         """
-        if use_batch_api:
-            raise NotImplementedError(
-                "scale_machine batch path (use_batch_api=True) lands in a follow-up PR"
-            )
         cluster_name = cluster_name or self.get_cluster_name()
         metadata = {
             "cluster_name": cluster_name,
@@ -446,7 +449,11 @@ class AKSMachineClient(AKSClient):
                 names = [
                     f"{prefix}-machine-{i + 1}" for i in range(scale_machine_count)
                 ]
-                successful = self._scale_machine_individually(request, names)
+                if use_batch_api:
+                    successful, batch_times = self._scale_machine_batch(request, names)
+                    op.add_metadata("batch_command_execution_times", batch_times)
+                else:
+                    successful = self._scale_machine_individually(request, names)
                 op.add_metadata("successful_machines", successful)
 
                 # Fail fast on partial landing BEFORE waiting on the agentpool
@@ -573,3 +580,179 @@ class AKSMachineClient(AKSClient):
             logger.error(f"PUT machine {name} -> {resp.status_code} {resp.text[:500]}")
             return False
         return True
+
+    # ---- Machine API: batch scale path ----
+    def _scale_machine_batch(
+        self,
+        request: SimpleNamespace,
+        names: List[str],
+    ) -> Tuple[List[str], Dict[str, float]]:
+        """Dispatch ``names`` across ``machine_workers`` worker slices via the Batch API.
+
+        Each worker submits exactly one ``BatchPutMachine``-headered PUT carrying a
+        contiguous slice of ``names``. Slices are computed by arithmetic from the
+        ``worker_id`` (no partition helper) to match ado-telescope's per-worker
+        contract: every worker handles exactly ``scale_machine_count //
+        machine_workers`` machines, so chunk boundaries -- and the resulting
+        ``chunk_0/chunk_1/...`` Kusto correlation keys -- are byte-identical to
+        ado runs.
+
+        ``scale_machine_count`` MUST be an exact multiple of ``machine_workers``;
+        ``ValueError`` is raised otherwise so the failure surfaces at the
+        ``MachineCRUD`` boundary instead of producing a short final chunk that
+        would skew per-chunk latency dashboards.
+
+        Per-chunk wall time is captured under ``chunk_<worker_id>`` regardless
+        of success/failure. Per-worker exceptions are caught and logged; the
+        worker's slice is excluded from the returned ``successful`` list. The
+        input ``request`` is not mutated.
+        """
+        n = len(names)
+        workers = request.machine_workers
+        if workers <= 0:
+            raise ValueError(f"machine_workers must be positive (got {workers})")
+        if n % workers != 0:
+            raise ValueError(
+                f"scale_machine_count ({n}) must be an exact multiple of "
+                f"machine_workers ({workers}) when use_batch_api=True; "
+                f"got remainder {n % workers}"
+            )
+        per_worker = n // workers
+        successful: List[str] = []
+        batch_times: Dict[str, float] = {}
+
+        def run_worker(worker_id: int):
+            start = worker_id * per_worker
+            chunk = names[start:start + per_worker]
+            t0 = time.time()
+            try:
+                created = self._create_batch_machines(request, chunk, worker_id)
+            except Exception:
+                logger.exception(f"batch worker {worker_id} failed")
+                created = []
+            return worker_id, created, time.time() - t0
+
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = [ex.submit(run_worker, w) for w in range(workers)]
+            for fut in as_completed(futures):
+                try:
+                    worker_id, created, elapsed = fut.result()
+                except Exception:
+                    # run_worker already swallows; this is belt-and-suspenders.
+                    logger.exception("unexpected error retrieving batch worker result")
+                    continue
+                batch_times[f"chunk_{worker_id}"] = elapsed
+                successful.extend(created)
+        return successful, batch_times
+
+    def _create_batch_machines(
+        self,
+        request: SimpleNamespace,
+        chunk: List[str],
+        chunk_idx: int,
+    ) -> List[str]:
+        """Submit a batch-PUT request creating every machine in ``chunk``.
+
+        Uses the AKS Machine API ``BatchPutMachine`` HEADER pattern (NOT the
+        non-existent ARM ``/$batch`` envelope): a single PUT to the first
+        machine name in ``chunk`` carrying a ``BatchPutMachine`` header whose
+        value is JSON containing ``vmSkus`` and ``batchMachines`` lists.
+
+        ``batchMachines`` lists ONLY the *additional* machines; the first one
+        is created from the URL + body. Each entry uses the key
+        ``machineName`` -- the wrong key (e.g. ``name``) causes the API to
+        silently ignore the extras and create only the URL-pointed machine.
+
+        ``vmSkus`` is a ``{"value": [<rich vm_sku obj>]}`` envelope (not a
+        flat list); the inner object describes the SKU shape the Batch API
+        expects to validate against.
+
+        Returns the list of machine names submitted on 2xx. Raises
+        ``RuntimeError`` (from ``_make_batch_request``) if the request
+        exhausts 429 retries or returns a non-2xx. Caller catches and
+        excludes failed chunks from the success list.
+        """
+        if not chunk:
+            return []
+        sub = self.subscription_id
+        first_machine_name = chunk[0]
+        url = (
+            f"{_ARM_BASE}/subscriptions/{sub}/resourceGroups/{request.resource_group}"
+            f"/providers/Microsoft.ContainerService/managedClusters/{request.cluster_name}"
+            f"/agentPools/{request.agentpool_name}/machines/{first_machine_name}"
+            f"?api-version={_MACHINE_API_VERSION}"
+        )
+        body: Dict[str, Any] = {"properties": {"hardware": {"vmSize": request.vm_size}}}
+        remaining_machines = chunk[1:]
+        batch_machines = [{"machineName": name} for name in remaining_machines]
+        vm_sku = {
+            "name": request.vm_size,
+            "resourceType": "virtualMachines",
+            "family": "standardDv3Family",
+            "locations": ["westus", "eastus", "westeurope"],
+            "capabilities": [
+                {"name": "vCPUs", "value": "2"},
+                {"name": "MemoryGB", "value": "8"},
+            ],
+            "restrictions": [],
+        }
+        batch_header_value = json.dumps({
+            "vmSkus": {"value": [vm_sku]},
+            "batchMachines": batch_machines,
+        })
+        logger.info(
+            f"chunk {chunk_idx}: submitting BatchPutMachine PUT for {len(chunk)} machines "
+            f"(target={first_machine_name})"
+        )
+        self._make_batch_request(
+            "PUT", url, body, request.timeout, batch_header_value=batch_header_value,
+        )
+        return list(chunk)
+
+    def _make_batch_request(
+        self,
+        method: str,
+        url: str,
+        data: Dict[str, Any],
+        timeout: int,
+        batch_header_value: str,
+    ) -> None:
+        """Send a ``BatchPutMachine``-headered request with bounded 429 backoff.
+
+        Sends the request directly (NOT via ``make_request``) so we can attach
+        the ``BatchPutMachine`` header alongside the standard auth/content-type
+        headers. Retries on HTTP 429 up to ``_BATCH_429_MAX_RETRIES`` attempts
+        with exponential backoff starting at
+        ``_BATCH_429_INITIAL_BACKOFF_SECONDS`` and doubling each attempt
+        (1s, 2s, 4s by default). All other non-2xx responses raise immediately.
+        """
+        backoff = _BATCH_429_INITIAL_BACKOFF_SECONDS
+        last_resp: Optional[requests.Response] = None
+        for attempt in range(_BATCH_429_MAX_RETRIES):
+            headers = {
+                "Authorization": f"Bearer {self._get_access_token()}",
+                "Content-Type": "application/json",
+                "BatchPutMachine": batch_header_value,
+            }
+            resp = requests.request(
+                method, url, headers=headers, json=data, timeout=timeout,
+            )
+            last_resp = resp
+            if resp.status_code in (200, 201, 202, 204):
+                return
+            if resp.status_code != 429:
+                raise RuntimeError(
+                    f"batch request failed: {resp.status_code} {resp.text[:500]}"
+                )
+            if attempt == _BATCH_429_MAX_RETRIES - 1:
+                break
+            logger.warning(
+                f"batch request 429; retrying in {backoff:.1f}s "
+                f"(attempt {attempt + 1}/{_BATCH_429_MAX_RETRIES})"
+            )
+            time.sleep(backoff)
+            backoff *= 2
+        text = last_resp.text[:500] if last_resp is not None else ""
+        raise RuntimeError(
+            f"batch request exceeded {_BATCH_429_MAX_RETRIES} 429 retries; last text={text}"
+        )

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -449,11 +449,13 @@ class AKSMachineClient(AKSClient):
                 names = [
                     f"{prefix}-machine-{i + 1}" for i in range(scale_machine_count)
                 ]
+                command_t0 = time.time()
                 if use_batch_api:
                     successful, batch_times = self._scale_machine_batch(request, names)
                     op.add_metadata("batch_command_execution_times", batch_times)
                 else:
                     successful = self._scale_machine_individually(request, names)
+                op.add_metadata("command_execution_time", time.time() - command_t0)
                 op.add_metadata("successful_machines", successful)
 
                 # Fail fast on partial landing BEFORE waiting on the agentpool
@@ -591,11 +593,7 @@ class AKSMachineClient(AKSClient):
 
         Each worker submits exactly one ``BatchPutMachine``-headered PUT carrying a
         contiguous slice of ``names``. Slices are computed by arithmetic from the
-        ``worker_id`` (no partition helper) to match ado-telescope's per-worker
-        contract: every worker handles exactly ``scale_machine_count //
-        machine_workers`` machines, so chunk boundaries -- and the resulting
-        ``chunk_0/chunk_1/...`` Kusto correlation keys -- are byte-identical to
-        ado runs.
+        ``worker_id``.
 
         ``scale_machine_count`` MUST be an exact multiple of ``machine_workers``;
         ``ValueError`` is raised otherwise so the failure surfaces at the
@@ -653,8 +651,8 @@ class AKSMachineClient(AKSClient):
     ) -> List[str]:
         """Submit a batch-PUT request creating every machine in ``chunk``.
 
-        Uses the AKS Machine API ``BatchPutMachine`` HEADER pattern (NOT the
-        non-existent ARM ``/$batch`` envelope): a single PUT to the first
+        Uses the AKS Machine API ``BatchPutMachine`` HEADER pattern (implicit
+        contract with AKS NAP, not publicly available): a single PUT to the first
         machine name in ``chunk`` carrying a ``BatchPutMachine`` header whose
         value is JSON containing ``vmSkus`` and ``batchMachines`` lists.
 
@@ -663,9 +661,12 @@ class AKSMachineClient(AKSClient):
         ``machineName`` -- the wrong key (e.g. ``name``) causes the API to
         silently ignore the extras and create only the URL-pointed machine.
 
-        ``vmSkus`` is a ``{"value": [<rich vm_sku obj>]}`` envelope (not a
-        flat list); the inner object describes the SKU shape the Batch API
-        expects to validate against.
+        ``vmSkus`` is a ``{"value": [<vm_sku obj>]}`` envelope (not a flat
+        list); the inner object only needs ``name`` (the requested VM size)
+        and ``resourceType`` -- the AKS NAP Batch endpoint validates the
+        rest server-side. We deliberately omit speculative SKU shape fields
+        (family, locations, capabilities) so the header schema stays
+        consistent across all VM sizes.
 
         Returns the list of machine names submitted on 2xx. Raises
         ``RuntimeError`` (from ``_make_batch_request``) if the request
@@ -688,13 +689,6 @@ class AKSMachineClient(AKSClient):
         vm_sku = {
             "name": request.vm_size,
             "resourceType": "virtualMachines",
-            "family": "standardDv3Family",
-            "locations": ["westus", "eastus", "westeurope"],
-            "capabilities": [
-                {"name": "vCPUs", "value": "2"},
-                {"name": "MemoryGB", "value": "8"},
-            ],
-            "restrictions": [],
         }
         batch_header_value = json.dumps({
             "vmSkus": {"value": [vm_sku]},
@@ -704,8 +698,13 @@ class AKSMachineClient(AKSClient):
             f"chunk {chunk_idx}: submitting BatchPutMachine PUT for {len(chunk)} machines "
             f"(target={first_machine_name})"
         )
+        # Cap per-request timeout so a single batch PUT (plus 429 backoff)
+        # cannot consume the whole operation budget that downstream
+        # provisioning/readiness waits depend on. Mirrors the cap applied at
+        # the individual machine PUT site.
+        put_timeout = min(request.timeout, _PER_REQUEST_TIMEOUT_CAP)
         self._make_batch_request(
-            "PUT", url, body, request.timeout, batch_header_value=batch_header_value,
+            "PUT", url, body, put_timeout, batch_header_value=batch_header_value,
         )
         return list(chunk)
 

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -694,10 +694,10 @@ class AKSMachineClient(AKSClient):
             f"chunk {chunk_idx}: submitting BatchPutMachine PUT for {len(chunk)} machines "
             f"(target={first_machine_name})"
         )
-        # Cap per-request timeout so a single batch PUT (plus 429 backoff)
-        # cannot consume the whole operation budget that downstream
-        # provisioning/readiness waits depend on. Mirrors the cap applied
-        # inside ``put_machine`` (the per-machine PUT helper).
+        # Cap the timeout value passed to this batch PUT attempt. This limits
+        # the per-attempt request timeout given to ``_make_batch_request``,
+        # but it does not bound total wall time for the chunk because retry
+        # and backoff handling can still extend the overall elapsed time.
         put_timeout = min(request.timeout, _PER_REQUEST_TIMEOUT_CAP)
         self._make_batch_request(
             "PUT",

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -22,7 +22,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import requests
 
@@ -381,8 +381,10 @@ class AKSMachineClient(AKSClient):
         Flow:
           1. Snapshot the current Ready+labeled node count in the agentpool
              (``baseline_count``) so the readiness watcher counts only NEW nodes.
-          2. Submit machine PUTs individually (per-machine ARM polling is
-             intentionally NOT performed).
+          2. Submit machine PUTs -- individually by default, or sharded into
+             ``machine_workers`` chunks where each chunk is sent as a single
+             ``BatchPutMachine``-headered PUT when ``use_batch_api=True`` (per-
+             machine ARM polling is intentionally NOT performed in either path).
           3. Wait ONCE on the agentpool-level provisioningState.
           4. Wait for nodes labeled ``agentpool=<pool>`` to surpass
              ``baseline_count`` by enough to satisfy P50/P70/P90/P99/P100 targets.
@@ -390,10 +392,8 @@ class AKSMachineClient(AKSClient):
         ``tags`` is currently unused (Machine API rejects top-level tags on the
         machine PUT body; machines inherit tags from the parent agentpool).
 
-        When ``use_batch_api=True`` the work is sharded across
-        ``machine_workers`` chunks and each chunk is submitted via a single
-        ``BatchPutMachine``-headered PUT (see ``_create_batch_machines``); when
-        False each machine is PUT individually.
+        See ``_create_batch_machines`` for the batch chunking contract and the
+        ``BatchPutMachine`` header schema.
 
         Raises:
             RuntimeError: fewer machines landed than requested, agentpool did
@@ -451,8 +451,7 @@ class AKSMachineClient(AKSClient):
                 ]
                 command_t0 = time.time()
                 if use_batch_api:
-                    successful, batch_times = self._scale_machine_batch(request, names)
-                    op.add_metadata("batch_command_execution_times", batch_times)
+                    successful = self._scale_machine_batch(request, names)
                 else:
                     successful = self._scale_machine_individually(request, names)
                 op.add_metadata("command_execution_time", time.time() - command_t0)
@@ -588,7 +587,7 @@ class AKSMachineClient(AKSClient):
         self,
         request: SimpleNamespace,
         names: List[str],
-    ) -> Tuple[List[str], Dict[str, float]]:
+    ) -> List[str]:
         """Dispatch ``names`` across ``machine_workers`` worker slices via the Batch API.
 
         Each worker submits exactly one ``BatchPutMachine``-headered PUT carrying a
@@ -600,10 +599,9 @@ class AKSMachineClient(AKSClient):
         ``MachineCRUD`` boundary instead of producing a short final chunk that
         would skew per-chunk latency dashboards.
 
-        Per-chunk wall time is captured under ``chunk_<worker_id>`` regardless
-        of success/failure. Per-worker exceptions are caught and logged; the
-        worker's slice is excluded from the returned ``successful`` list. The
-        input ``request`` is not mutated.
+        Per-worker exceptions are caught and logged; the worker's slice is
+        excluded from the returned ``successful`` list. The input ``request``
+        is not mutated.
         """
         n = len(names)
         workers = request.machine_workers
@@ -617,31 +615,27 @@ class AKSMachineClient(AKSClient):
             )
         per_worker = n // workers
         successful: List[str] = []
-        batch_times: Dict[str, float] = {}
 
-        def run_worker(worker_id: int):
+        def run_worker(worker_id: int) -> List[str]:
             start = worker_id * per_worker
             chunk = names[start:start + per_worker]
-            t0 = time.time()
             try:
-                created = self._create_batch_machines(request, chunk, worker_id)
+                return self._create_batch_machines(request, chunk, worker_id)
             except Exception:
                 logger.exception(f"batch worker {worker_id} failed")
-                created = []
-            return worker_id, created, time.time() - t0
+                return []
 
         with ThreadPoolExecutor(max_workers=workers) as ex:
             futures = [ex.submit(run_worker, w) for w in range(workers)]
             for fut in as_completed(futures):
                 try:
-                    worker_id, created, elapsed = fut.result()
+                    created = fut.result()
                 except Exception:
                     # run_worker already swallows; this is belt-and-suspenders.
                     logger.exception("unexpected error retrieving batch worker result")
                     continue
-                batch_times[f"chunk_{worker_id}"] = elapsed
                 successful.extend(created)
-        return successful, batch_times
+        return successful
 
     def _create_batch_machines(
         self,

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -7,9 +7,10 @@ result file via ``Operation.save_to_file`` on context exit. Tests verify:
   the right keys
 - failure path raises (so the OperationContext records ``success=False``)
 
-This revision adds tests for the non-batch scale path. The batch dispatch
-(``use_batch_api=True``) is asserted to raise ``NotImplementedError`` until
-the follow-up PR lands.
+This revision adds tests for both scale paths (non-batch individual PUTs and
+the BatchPutMachine-headered chunked path) plus the batch-path helpers
+``_scale_machine_batch``, ``_create_batch_machines``, and
+``_make_batch_request``.
 """
 # pylint: disable=protected-access
 # Tests intentionally exercise private helpers directly; the leading underscore
@@ -256,15 +257,46 @@ class TestAKSMachineClient(unittest.TestCase):
         self.assertEqual(mock_wait_ready.call_args.kwargs["baseline_count"], 3)
         self.assertEqual(mock_wait_ready.call_args.kwargs["expected_count"], 1)
 
-    def test_scale_machine_batch_path_raises_not_implemented(self):
-        """The use_batch_api=True branch is stubbed until the follow-up PR."""
-        with self.assertRaises(NotImplementedError):
+    def test_scale_machine_batch_path_dispatches_to_batch(self):
+        """The use_batch_api=True branch calls _scale_machine_batch (not _individually)
+        and records batch_command_execution_times in operation metadata."""
+        names = [f"scale2-machine-{i+1}" for i in range(2)]
+        with mock.patch.object(
+            AKSMachineClient,
+            "_scale_machine_batch",
+            return_value=(names, {"chunk_0": 1.5}),
+        ) as mock_batch, mock.patch.object(
+            AKSMachineClient, "_scale_machine_individually"
+        ) as mock_individual, mock.patch.object(
+            AKSMachineClient, "_wait_for_agentpool_provisioning", return_value=True
+        ), mock.patch.object(
+            AKSMachineClient,
+            "_wait_for_machine_node_readiness",
+            return_value={
+                f"P{p}": {
+                    "target_nodes": 2,
+                    "elapsed_time_seconds": 12.0,
+                    "percentage": p,
+                    "success": True,
+                }
+                for p in (50, 70, 90, 99, 100)
+            },
+        ):
+            self.mock_k8s.get_ready_nodes.return_value = []
             self.client.scale_machine(
                 agentpool_name="apool",
                 vm_size="Standard_D2_v3",
                 scale_machine_count=2,
                 use_batch_api=True,
+                machine_workers=2,
             )
+        mock_batch.assert_called_once()
+        mock_individual.assert_not_called()
+        # batch_command_execution_times must be added to operation metadata.
+        added_keys = {
+            call.args[0] for call in self.mock_operation.add_metadata.call_args_list
+        }
+        self.assertIn("batch_command_execution_times", added_keys)
 
     # ---- _create_single_machine ----
 
@@ -476,6 +508,201 @@ class TestAKSMachineClient(unittest.TestCase):
         for p in (50, 70, 90, 99, 100):
             self.assertFalse(env[f"P{p}"]["success"])
             self.assertEqual(env[f"P{p}"]["target_nodes"], 0)
+
+    # ---- _scale_machine_batch ----
+
+    def test_scale_machine_batch_partitions_and_aggregates(self):
+        """Names sharded across machine_workers; per-worker wall time captured."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+            machine_workers=2,
+        )
+        names = ["m-1", "m-2", "m-3", "m-4"]
+        with mock.patch.object(
+            AKSMachineClient,
+            "_create_batch_machines",
+            side_effect=lambda req, chunk, worker_id: list(chunk),
+        ) as mock_create_batch:
+            successful, batch_times = self.client._scale_machine_batch(request, names)
+        self.assertEqual(set(successful), set(names))
+        self.assertEqual(set(batch_times.keys()), {"chunk_0", "chunk_1"})
+        # 2 workers, each handling per_worker = 4 // 2 = 2 names
+        self.assertEqual(mock_create_batch.call_count, 2)
+
+    def test_scale_machine_batch_per_worker_failure_isolated(self):
+        """One worker raising does not poison the other worker's success list."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+            machine_workers=2,
+        )
+        names = ["m-1", "m-2", "m-3", "m-4"]
+        counter = itertools.count()
+
+        def fake_create(req, chunk, worker_id):  # pylint: disable=unused-argument
+            if next(counter) == 0:
+                raise RuntimeError("first worker boom")
+            return list(chunk)
+
+        with mock.patch.object(
+            AKSMachineClient, "_create_batch_machines", side_effect=fake_create
+        ):
+            successful, batch_times = self.client._scale_machine_batch(request, names)
+        # Exactly one worker's slice survives.
+        self.assertEqual(len(successful), 2)
+        # But both workers recorded wall time.
+        self.assertEqual(set(batch_times.keys()), {"chunk_0", "chunk_1"})
+
+    def test_scale_machine_batch_rejects_non_exact_multiple(self):
+        """scale_machine_count must be an exact multiple of machine_workers."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+            machine_workers=3,
+        )
+        names = ["m-1", "m-2", "m-3", "m-4"]  # 4 not divisible by 3
+        with self.assertRaises(ValueError):
+            self.client._scale_machine_batch(request, names)
+
+    # ---- _create_batch_machines ----
+
+    def test_create_batch_machines_empty_chunk_returns_empty(self):
+        """Empty chunk -> early return, no HTTP call."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+        )
+        with mock.patch.object(
+            AKSMachineClient, "_make_batch_request"
+        ) as mock_make_batch:
+            result = self.client._create_batch_machines(request, [], 0)
+        self.assertEqual(result, [])
+        mock_make_batch.assert_not_called()
+
+    def test_create_batch_machines_header_shape(self):
+        """BatchPutMachine header carries vmSkus envelope + batchMachines
+        using machineName (NOT name) keys for the *additional* machines only."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+        )
+        with mock.patch.object(
+            AKSMachineClient, "_make_batch_request"
+        ) as mock_make_batch:
+            result = self.client._create_batch_machines(
+                request, ["m-1", "m-2", "m-3"], chunk_idx=0
+            )
+        self.assertEqual(result, ["m-1", "m-2", "m-3"])
+        mock_make_batch.assert_called_once()
+        # Inspect the batch_header_value kwarg.
+        import json as _json  # pylint: disable=import-outside-toplevel
+        kwargs = mock_make_batch.call_args.kwargs
+        header_value = kwargs["batch_header_value"]
+        parsed = _json.loads(header_value)
+        # vmSkus is wrapped in {"value": [...]}
+        self.assertIn("vmSkus", parsed)
+        self.assertIn("value", parsed["vmSkus"])
+        self.assertEqual(len(parsed["vmSkus"]["value"]), 1)
+        self.assertEqual(
+            parsed["vmSkus"]["value"][0]["name"], "Standard_D2_v3"
+        )
+        # First machine of chunk is created from the URL+body; only the rest
+        # appear in batchMachines.
+        self.assertEqual(
+            parsed["batchMachines"],
+            [{"machineName": "m-2"}, {"machineName": "m-3"}],
+        )
+
+    # ---- _make_batch_request ----
+
+    def test_make_batch_request_2xx_returns(self):
+        """2xx response returns without raising; one HTTP call made."""
+        with mock.patch(
+            "clients.aks_machine_client.requests.request"
+        ) as mock_request:
+            mock_request.return_value.status_code = 200
+            self.client._make_batch_request(
+                "PUT",
+                "https://fake/url",
+                {"k": "v"},
+                timeout=30,
+                batch_header_value="{}",
+            )
+        mock_request.assert_called_once()
+
+    def test_make_batch_request_non_2xx_non_429_raises(self):
+        """500 -> RuntimeError, no retry."""
+        with mock.patch(
+            "clients.aks_machine_client.requests.request"
+        ) as mock_request:
+            mock_request.return_value.status_code = 500
+            mock_request.return_value.text = "boom"
+            with self.assertRaises(RuntimeError):
+                self.client._make_batch_request(
+                    "PUT",
+                    "https://fake/url",
+                    {},
+                    timeout=30,
+                    batch_header_value="{}",
+                )
+        self.assertEqual(mock_request.call_count, 1)
+
+    def test_make_batch_request_429_then_success(self):
+        """429 then 200 -> succeeds after 1 retry."""
+        responses = [
+            mock.MagicMock(status_code=429),
+            mock.MagicMock(status_code=201),
+        ]
+        with mock.patch(
+            "clients.aks_machine_client.requests.request",
+            side_effect=responses,
+        ) as mock_request, mock.patch(
+            "clients.aks_machine_client.time.sleep"
+        ):
+            self.client._make_batch_request(
+                "PUT",
+                "https://fake/url",
+                {},
+                timeout=30,
+                batch_header_value="{}",
+            )
+        self.assertEqual(mock_request.call_count, 2)
+
+    def test_make_batch_request_429_exhausted_raises(self):
+        """429 across the full retry budget -> RuntimeError."""
+        with mock.patch(
+            "clients.aks_machine_client.requests.request"
+        ) as mock_request, mock.patch(
+            "clients.aks_machine_client.time.sleep"
+        ):
+            mock_request.return_value.status_code = 429
+            mock_request.return_value.text = "rate limited"
+            with self.assertRaises(RuntimeError):
+                self.client._make_batch_request(
+                    "PUT",
+                    "https://fake/url",
+                    {},
+                    timeout=30,
+                    batch_header_value="{}",
+                )
+        # _BATCH_429_MAX_RETRIES == 3
+        self.assertEqual(mock_request.call_count, 3)
 
 
 if __name__ == "__main__":

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -697,8 +697,8 @@ class TestAKSMachineClient(unittest.TestCase):
                     timeout=30,
                     batch_header_value="{}",
                 )
-        # 1 initial attempt + _BATCH_429_MAX_RETRIES (3) retries = 4 calls
-        self.assertEqual(mock_request.call_count, 4)
+        # _BATCH_429_MAX_RETRIES == 5 total attempts (no extra initial call)
+        self.assertEqual(mock_request.call_count, 5)
 
 
 if __name__ == "__main__":

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -259,12 +259,12 @@ class TestAKSMachineClient(unittest.TestCase):
 
     def test_scale_machine_batch_path_dispatches_to_batch(self):
         """The use_batch_api=True branch calls _scale_machine_batch (not _individually)
-        and records batch_command_execution_times in operation metadata."""
+        and records command_execution_time in operation metadata."""
         names = [f"scale2-machine-{i+1}" for i in range(2)]
         with mock.patch.object(
             AKSMachineClient,
             "_scale_machine_batch",
-            return_value=(names, {"chunk_0": 1.5}),
+            return_value=names,
         ) as mock_batch, mock.patch.object(
             AKSMachineClient, "_scale_machine_individually"
         ) as mock_individual, mock.patch.object(
@@ -292,11 +292,11 @@ class TestAKSMachineClient(unittest.TestCase):
             )
         mock_batch.assert_called_once()
         mock_individual.assert_not_called()
-        # batch_command_execution_times must be added to operation metadata.
+        # command_execution_time must be added to operation metadata.
         added_keys = {
             call.args[0] for call in self.mock_operation.add_metadata.call_args_list
         }
-        self.assertIn("batch_command_execution_times", added_keys)
+        self.assertIn("command_execution_time", added_keys)
 
     # ---- _create_single_machine ----
 
@@ -512,7 +512,7 @@ class TestAKSMachineClient(unittest.TestCase):
     # ---- _scale_machine_batch ----
 
     def test_scale_machine_batch_partitions_and_aggregates(self):
-        """Names sharded across machine_workers; per-worker wall time captured."""
+        """Names sharded across machine_workers; all successful slices aggregated."""
         request = SimpleNamespace(
             agentpool_name="apool",
             cluster_name="fake-cluster",
@@ -527,9 +527,8 @@ class TestAKSMachineClient(unittest.TestCase):
             "_create_batch_machines",
             side_effect=lambda req, chunk, worker_id: list(chunk),
         ) as mock_create_batch:
-            successful, batch_times = self.client._scale_machine_batch(request, names)
+            successful = self.client._scale_machine_batch(request, names)
         self.assertEqual(set(successful), set(names))
-        self.assertEqual(set(batch_times.keys()), {"chunk_0", "chunk_1"})
         # 2 workers, each handling per_worker = 4 // 2 = 2 names
         self.assertEqual(mock_create_batch.call_count, 2)
 
@@ -554,11 +553,9 @@ class TestAKSMachineClient(unittest.TestCase):
         with mock.patch.object(
             AKSMachineClient, "_create_batch_machines", side_effect=fake_create
         ):
-            successful, batch_times = self.client._scale_machine_batch(request, names)
+            successful = self.client._scale_machine_batch(request, names)
         # Exactly one worker's slice survives.
         self.assertEqual(len(successful), 2)
-        # But both workers recorded wall time.
-        self.assertEqual(set(batch_times.keys()), {"chunk_0", "chunk_1"})
 
     def test_scale_machine_batch_rejects_non_exact_multiple(self):
         """scale_machine_count must be an exact multiple of machine_workers."""
@@ -664,7 +661,7 @@ class TestAKSMachineClient(unittest.TestCase):
         self.assertEqual(mock_request.call_count, 1)
 
     def test_make_batch_request_429_then_success(self):
-        """429 then 200 -> succeeds after 1 retry."""
+        """429 then 2xx (201) -> succeeds after 1 retry."""
         responses = [
             mock.MagicMock(status_code=429),
             mock.MagicMock(status_code=201),

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -633,8 +633,8 @@ class TestAKSMachineClient(unittest.TestCase):
 
     def test_make_batch_request_2xx_returns(self):
         """2xx response returns without raising; one HTTP call made."""
-        with mock.patch(
-            "clients.aks_machine_client.requests.request"
+        with mock.patch.object(
+            self.client._session, "request"
         ) as mock_request:
             mock_request.return_value.status_code = 200
             self.client._make_batch_request(
@@ -648,8 +648,8 @@ class TestAKSMachineClient(unittest.TestCase):
 
     def test_make_batch_request_non_2xx_non_429_raises(self):
         """500 -> RuntimeError, no retry."""
-        with mock.patch(
-            "clients.aks_machine_client.requests.request"
+        with mock.patch.object(
+            self.client._session, "request"
         ) as mock_request:
             mock_request.return_value.status_code = 500
             mock_request.return_value.text = "boom"
@@ -669,9 +669,8 @@ class TestAKSMachineClient(unittest.TestCase):
             mock.MagicMock(status_code=429),
             mock.MagicMock(status_code=201),
         ]
-        with mock.patch(
-            "clients.aks_machine_client.requests.request",
-            side_effect=responses,
+        with mock.patch.object(
+            self.client._session, "request", side_effect=responses,
         ) as mock_request, mock.patch(
             "clients.aks_machine_client.time.sleep"
         ):
@@ -686,8 +685,8 @@ class TestAKSMachineClient(unittest.TestCase):
 
     def test_make_batch_request_429_exhausted_raises(self):
         """429 across the full retry budget -> RuntimeError."""
-        with mock.patch(
-            "clients.aks_machine_client.requests.request"
+        with mock.patch.object(
+            self.client._session, "request"
         ) as mock_request, mock.patch(
             "clients.aks_machine_client.time.sleep"
         ):

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -697,8 +697,8 @@ class TestAKSMachineClient(unittest.TestCase):
                     timeout=30,
                     batch_header_value="{}",
                 )
-        # _BATCH_429_MAX_RETRIES == 3
-        self.assertEqual(mock_request.call_count, 3)
+        # 1 initial attempt + _BATCH_429_MAX_RETRIES (3) retries = 4 calls
+        self.assertEqual(mock_request.call_count, 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Adds the AKS Machine API **batch** scale path (`use_batch_api=True`) to `AKSMachineClient`, dispatching across multiple workers via the `BatchPutMachine` HEADER pattern. This is the final piece needed to scale machine-mode agent pools efficiently at 1000+ machine counts where N individual PUTs would exhaust per-machine RP overhead.

Stack: builds on #1179 (scaffolding) + #1181 (non-batch scale path).

## What

`scale_machine(use_batch_api=True)` now dispatches to a new `_scale_machine_batch` helper instead of raising `NotImplementedError`. The helper:

1. Validates `scale_machine_count % machine_workers == 0` (raises `ValueError` otherwise — see *contract* below).
2. Computes `per_worker = scale_machine_count // machine_workers` and slices the pre-built `names` list by `worker_id` using arithmetic indexing.
3. Submits one PUT per worker in a `ThreadPoolExecutor` (`max_workers=machine_workers`); each PUT carries a contiguous slice of machines in its `BatchPutMachine` header.
4. Isolates per-worker failures: an exception in one worker is logged and that worker's slice is excluded from `successful_machines`; the other workers' results still surface.

### Contract: exact-multiple partitioning (ado-telescope parity)

`scale_machine_count` MUST be an exact multiple of `machine_workers` when `use_batch_api=True`. This mirrors ado-telescope's batch contract verbatim: every worker handles exactly the same per-worker count, so chunk boundaries are byte-identical across runs and the resulting `chunk_0/chunk_1/...` Kusto correlation keys line up exactly with ado dashboards. Non-exact-multiple inputs raise `ValueError` at the `MachineCRUD` boundary instead of producing a short final chunk that would skew per-chunk latency dashboards.

### Background: the `machineName` (NOT `name`) landmine

The `BatchPutMachine` header payload's `batchMachines` array uses the key **`machineName`** — the wrong key (e.g. `name`) causes the API to silently ignore the extras and create only the URL-pointed machine. This was the root cause of an earlier staging build where `succeeded=true` was reported but only `worker_count` machines actually landed.

### 429 retry budget

`_make_batch_request` retries on HTTP 429 with bounded exponential backoff: up to `_BATCH_429_MAX_RETRIES` total attempts (5 by default) with sleeps of 1s, 2s, 4s, 8s between them. All other non-2xx responses raise immediately.

## Metadata enrichment

`scale_machine` records a single `op.add_metadata("command_execution_time", <wall_seconds>)` covering both the individual and batch dispatch paths (uniform shape across modes for downstream dashboards). `successful_machines` / `percentile_node_readiness_times` / `node_readiness_time` / `cluster_info` semantics are unchanged from #1181.

## Verification

- `pylint modules/python/clients/aks_machine_client.py modules/python/tests/test_aks_machine_client.py`: **10.00/10**
- `pytest modules/python/tests/test_aks_machine_client.py`: **27 passed**
- Full module `pytest --cov=. --cov-fail-under=80`: **720 passed, 83.43%** total

## Stack

This is the final code-level slice. Remaining slices in the series:

| # | PR title | Files | LOC |
|---|---|---|---|
| 4 | `feat(crud): add MachineCRUD orchestrator` | `crud/azure/machine_crud.py` + tests | ~200 |
| 5 | `feat(crud): add create-machine + scale-machine CLI subcommands` | `crud/main.py` edits + tests | ~280 |
| 6 | `feat(crud-machine): scenario terraform inputs` | tfvars + test inputs | ~51 |
| 7 | `feat(crud-machine): pipeline templates + production pipeline` | YAML | ~170 |
