### PR TITLE
[bugfix] Make run CL2 step exit early on consistent apiserver errors

### DIFF
--- a/kcl/lib/steps/k8s/run_cluster_loader_2.k
+++ b/kcl/lib/steps/k8s/run_cluster_loader_2.k
@@ -1,14 +1,32 @@
 import azure_pipelines.ap.steps
 import lib.steps.azure
 
+MAX_CONSECUTIVE_APISERVER_ERRORS = 20
+
 RunClusterLoader2 = lambda serviceConnection: str, namespace: str, manifest: str -> steps.Step {
     script = """
 set +eo pipefail
 kubectl create namespace "${namespace}" || true
 kubectl apply -f $(Pipeline.Workspace)/s/${manifest}
 # Wait
+consecutive_errors=0
 while true; do
-  phases="$(kubectl get pods --namespace="${namespace}" -o jsonpath='{range .items[*]}{.status.phase}{"\\n"}{end}' 2>&1)"
+  # Under consistent API server errors, we would want to exit early instead of waiting for the entire timeout duration.
+  phases="$(kubectl get pods --namespace="${namespace}" -o jsonpath='{range .items[*]}{.status.phase}{"\\n"}{end}' 2>/tmp/kubectl_err)"
+  kubectl_exit_code=$?
+  if [ $kubectl_exit_code -ne 0 ]; then
+    consecutive_errors=$((consecutive_errors + 1))
+    echo "kubectl get pods failed (exit_code=$kubectl_exit_code, consecutive=$consecutive_errors/${MAX_CONSECUTIVE_APISERVER_ERRORS}):"
+    cat /tmp/kubectl_err
+    if [ "$consecutive_errors" -ge "${MAX_CONSECUTIVE_APISERVER_ERRORS}" ]; then
+      echo "API server unresponsive for $consecutive_errors consecutive polls; aborting."
+      exit 1
+    fi
+    sleep 30
+    continue
+  fi
+  consecutive_errors=0
+
   total=0
   terminal=0
 


### PR DESCRIPTION
Under consistent apiserver errors from `kubectl` command, we would want to give up and exit early as this probably indicates non-recoverable situation. 