### PR TITLE
ci: declare workflow-level contents: read on python and yaml validation

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -7,6 +7,9 @@ on:
 
 env:
   PYTHON_MODULES_DIR: modules/python
+permissions:
+  contents: read
+
 jobs:
   python-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/yaml-validation.yml
+++ b/.github/workflows/yaml-validation.yml
@@ -3,6 +3,9 @@ name: YAML Validation
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   yaml-validation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.