### PR TITLE
feat: extend NodePool schema and CreateResourceGroup with optional fields

### DIFF
--- a/kcl/lib/steps/azure/create_node_pool.k
+++ b/kcl/lib/steps/azure/create_node_pool.k
@@ -9,12 +9,16 @@ schema NodePool:
     taintPrefix: str = ""
     labels: str = ""
     maxPods?: int
+    vnetSubnetId: str = ""
+    osSKU: str = ""
 
 CreateNodePool = lambda serviceConnection: str, cluster: str, resourceGroup: str, subscription: str, pool: NodePool, noWait: bool = False -> steps.Step {
     flagDecision = [
         "--node-taints ${pool.taintPrefix}=true:NoSchedule" if pool.taintPrefix else "",
         "--labels \"${pool.labels}\"" if pool.labels else "",
         "--max-pods ${pool.maxPods}" if pool.maxPods else "",
+        "--vnet-subnet-id \"${pool.vnetSubnetId}\"" if pool.vnetSubnetId else "",
+        "--os-sku ${pool.osSKU}" if pool.osSKU else "",
         "--no-wait" if noWait else "",
     ]
     flags = " \\\n  ".join([f for f in flagDecision if f])

--- a/kcl/lib/steps/azure/create_node_pool.k
+++ b/kcl/lib/steps/azure/create_node_pool.k
@@ -9,8 +9,8 @@ schema NodePool:
     taintPrefix: str = ""
     labels: str = ""
     maxPods?: int
-    vnetSubnetId: str = ""
-    osSKU: str = ""
+    vnetSubnetId?: str
+    osSKU?: str
 
 CreateNodePool = lambda serviceConnection: str, cluster: str, resourceGroup: str, subscription: str, pool: NodePool, noWait: bool = False -> steps.Step {
     flagDecision = [

--- a/kcl/lib/steps/azure/resource_group.k
+++ b/kcl/lib/steps/azure/resource_group.k
@@ -1,12 +1,12 @@
 import azure_pipelines.ap.steps
 
 CreateResourceGroup = lambda serviceConnection: str, name: str, location: str, subscription: str, tags: str = "" -> steps.Step {
-    tagsFlag = " \\\n  --tags ${tags}" if tags else ""
     script = """
 az group create \\
   --name "${name}" \\
   --location "${location}" \\
-  --subscription "${subscription}"${tagsFlag}
+  --subscription "${subscription}" \\
+${"--tags " + tags if tags else ""}
 """
     AzCli(
         serviceConnection,

--- a/kcl/lib/steps/azure/resource_group.k
+++ b/kcl/lib/steps/azure/resource_group.k
@@ -1,8 +1,12 @@
 import azure_pipelines.ap.steps
 
-CreateResourceGroup = lambda serviceConnection: str, name: str, location: str, subscription: str -> steps.Step {
+CreateResourceGroup = lambda serviceConnection: str, name: str, location: str, subscription: str, tags: str = "" -> steps.Step {
+    tagsFlag = " \\\n  --tags ${tags}" if tags else ""
     script = """
-az group create --name "${name}" --location "${location}" --subscription "${subscription}"
+az group create \\
+  --name "${name}" \\
+  --location "${location}" \\
+  --subscription "${subscription}"${tagsFlag}
 """
     AzCli(
         serviceConnection,


### PR DESCRIPTION
Add vnetSubnetId and osSKU optional fields to NodePool schema, and tags optional parameter to CreateResourceGroup. Both default to empty/omitted for backwards compatibility with existing pipelines.