### PR TITLE
Dipowell/crud jobs v2

### DIFF
--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -977,6 +977,8 @@ class KubernetesClient:
             'deployments': ['available', 'progressing', 'replicafailure', 'ready'],
             'statefulset': ['ready'],
             'statefulsets': ['ready'],
+            'job': ['complete', 'failed'],
+            'jobs': ['complete', 'failed'],
         }
 
         # Validate wait_condition_type format and type
@@ -1053,6 +1055,9 @@ class KubernetesClient:
             if resource_type_lower in ['statefulset', 'statefulsets']:
                 return self._check_statefulset_condition(resource_name, namespace, wait_all)
 
+            if resource_type_lower in ['job', 'jobs']:
+                return self._check_job_condition(resource_name, condition_type, namespace, wait_all)
+
             logger.warning(f"Unsupported resource type for condition checking: {resource_type}")
             return False
 
@@ -1113,6 +1118,50 @@ class KubernetesClient:
             and status.ready_replicas is not None
             and status.ready_replicas == spec_replicas
         )
+
+    def _check_job_condition(self, resource_name: str, condition_type: str, namespace: str, wait_all: bool) -> bool:
+        """Check job condition (e.g., 'complete', 'failed')."""
+        try:
+            if wait_all or not resource_name:
+                jobs = self.batch.list_namespaced_job(namespace=namespace).items
+            else:
+                job = self.batch.read_namespaced_job(name=resource_name, namespace=namespace)
+                jobs = [job]
+
+            for job in jobs:
+                if not self._is_job_condition_met(job, condition_type):
+                    return False
+
+            return True
+
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                logger.debug("Job not found, waiting...")
+                return False
+            raise e
+
+    def _is_job_condition_met(self, job, condition_type: str) -> bool:
+        """Check if a job meets the specified condition."""
+        if not job.status:
+            return False
+
+        condition_type_lower = condition_type.lower()
+
+        # Check job conditions
+        if job.status.conditions:
+            for condition in job.status.conditions:
+                if condition.type.lower() == condition_type_lower and condition.status == "True":
+                    return True
+
+        # Fallback: check completion/failure status directly
+        if condition_type_lower == 'complete':
+            spec_completions = job.spec.completions or 1
+            return (job.status.succeeded is not None and
+                    job.status.succeeded >= spec_completions)
+        if condition_type_lower == 'failed':
+            return job.status.failed is not None and job.status.failed > 0
+
+        return False
 
     def _is_deployment_condition_met(self, deployment, condition_type: str) -> bool:
         """Check if a deployment meets the specified condition."""

--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -377,18 +377,18 @@ class KubernetesClient:
         :param job_name: The name of the job to wait for.
         :param namespace: The namespace where the job is located (default: "default").
         :param timeout: The timeout in seconds to wait for the job to complete (default: 300 seconds).
-        :return: None
+        :return: The job name if completed successfully.
         """
         start_time = time.time()
         while time.time() - start_time < timeout:
             try:
                 job = self.batch.read_namespaced_job(name=job_name, namespace=namespace)
-                if job.status.succeeded is not None and job.status.succeeded > 0:
+                if self._is_job_condition_met(job, "complete"):
                     logger.info(
                         f"Job '{job_name}' in namespace '{namespace}' has completed successfully."
                     )
                     return job.metadata.name
-                if job.status.failed is not None and job.status.failed > 0:
+                if self._is_job_condition_met(job, "failed"):
                     raise Exception(
                         f"Job '{job_name}' in namespace '{namespace}' has failed."
                     )

--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -1153,13 +1153,11 @@ class KubernetesClient:
                 if condition.type.lower() == condition_type_lower and condition.status == "True":
                     return True
 
-        # Fallback: check completion/failure status directly
+        # Fallback: infer completion from success counters when conditions are absent
         if condition_type_lower == 'complete':
             spec_completions = job.spec.completions or 1
             return (job.status.succeeded is not None and
                     job.status.succeeded >= spec_completions)
-        if condition_type_lower == 'failed':
-            return job.status.failed is not None and job.status.failed > 0
 
         return False
 

--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -1084,7 +1084,6 @@ class KubernetesClient:
 
         except client.rest.ApiException as e:
             if e.status == 404:
-                logger.debug("Deployment not found, waiting...")
                 return False
             raise e
 
@@ -1105,7 +1104,6 @@ class KubernetesClient:
 
         except client.rest.ApiException as e:
             if e.status == 404:
-                logger.debug("StatefulSet not found, waiting...")
                 return False
             raise e
 
@@ -1136,7 +1134,6 @@ class KubernetesClient:
 
         except client.rest.ApiException as e:
             if e.status == 404:
-                logger.debug("Job not found, waiting...")
                 return False
             raise e
 

--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -1243,6 +1243,8 @@ class KubernetesClient:
                 self.app.create_namespaced_daemon_set(namespace=namespace, body=manifest)
             elif kind == "StatefulSet":
                 self.app.create_namespaced_stateful_set(namespace=namespace, body=manifest)
+            elif kind == "Job":
+                self.batch.create_namespaced_job(namespace=namespace, body=manifest)
             elif kind == "Service":
                 self.api.create_namespaced_service(namespace=namespace, body=manifest)
             elif kind == "ConfigMap":
@@ -1397,6 +1399,11 @@ class KubernetesClient:
                     self.app.patch_namespaced_stateful_set(name=name, namespace=namespace, body=manifest)
                 else:
                     raise ValueError("StatefulSet requires a namespace")
+            elif kind == "Job":
+                if namespace:
+                    self.batch.patch_namespaced_job(name=name, namespace=namespace, body=manifest)
+                else:
+                    raise ValueError("Job requires a namespace")
             elif kind == "Service":
                 if namespace:
                     self.api.patch_namespaced_service(name=name, namespace=namespace, body=manifest)
@@ -1578,6 +1585,11 @@ class KubernetesClient:
                     self.app.delete_namespaced_stateful_set(name=resource_name, namespace=namespace, body=delete_options)
                 else:
                     raise ValueError("StatefulSet requires a namespace")
+            elif kind == "Job":
+                if namespace:
+                    self.batch.delete_namespaced_job(name=resource_name, namespace=namespace, body=delete_options)
+                else:
+                    raise ValueError("Job requires a namespace")
             elif kind == "Service":
                 if namespace:
                     self.api.delete_namespaced_service(name=resource_name, namespace=namespace, body=delete_options)

--- a/modules/python/crud/azure/node_pool_crud.py
+++ b/modules/python/crud/azure/node_pool_crud.py
@@ -512,6 +512,19 @@ class NodePoolCRUD:
             }
         )
 
+        # For Jobs, delete any existing job first to avoid reusing completed jobs
+        if workload_type == "job":
+            try:
+                k8s_client.batch.delete_namespaced_job(
+                    name=resource_name,
+                    namespace=namespace,
+                    propagation_policy="Background"
+                )
+                logger.info("Deleted existing job %s before recreating", resource_name)
+            except Exception:
+                # Job doesn't exist, which is fine
+                pass
+
         # Apply each document in the rendered multi-doc template
         for doc in yaml.safe_load_all(rendered_template):
             if doc:

--- a/modules/python/crud/azure/node_pool_crud.py
+++ b/modules/python/crud/azure/node_pool_crud.py
@@ -39,6 +39,13 @@ WORKLOAD_CONFIG = {
         "wait_condition": "ready",
         "verify_pods_ready": True,
     },
+    "job": {
+        "template_file": "job.yml",
+        "count_key": "JOB_COMPLETIONS",
+        "resource_type": "job",
+        "wait_condition": "complete",
+        "verify_pods_ready": False,  # Job pods terminate after completion
+    },
 }
 
 class NodePoolCRUD:
@@ -356,6 +363,39 @@ class NodePoolCRUD:
             namespace=namespace
         )
 
+    def create_job(
+        self,
+        node_pool_name,
+        completions=1,
+        manifest_dir=None,
+        number_of_jobs=1,
+        label_selector="app=nginx-container",
+        namespace="default"
+    ):
+        """
+        Create Kubernetes Jobs after node pool operations.
+
+        Args:
+            node_pool_name: Name of the node pool to target
+            completions: Number of job completions (default: 1)
+            manifest_dir: Directory containing Kubernetes manifest files
+            number_of_jobs: Number of Jobs to create (default: 1)
+            label_selector: Label selector for pods (default: "app=nginx-container")
+            namespace: Kubernetes namespace (default: "default")
+
+        Returns:
+            True if all Job creations were successful, False otherwise
+        """
+        return self._create_workloads(
+            workload_type="job",
+            node_pool_name=node_pool_name,
+            count=completions,
+            number_of_workloads=number_of_jobs,
+            manifest_dir=manifest_dir,
+            label_selector=label_selector,
+            namespace=namespace
+        )
+
     def _create_workloads(
         self,
         workload_type,
@@ -369,9 +409,9 @@ class NodePoolCRUD:
         """Unified helper to create multiple workload instances.
 
         Args:
-            workload_type: Type of workload ("deployment" or "statefulset")
+            workload_type: Type of workload ("deployment", "statefulset", or "job")
             node_pool_name: Name of the target node pool
-            count: Number of replicas per workload instance
+            count: Number of replicas/completions per workload instance
             number_of_workloads: Total number of workload instances to create
             manifest_dir: Optional custom manifest directory
             label_selector: Base label selector (e.g., "app=nginx-container")
@@ -431,7 +471,7 @@ class NodePoolCRUD:
 
         Args:
             k8s_client: Kubernetes client instance
-            workload_type: Type of workload ("deployment" or "statefulset")
+            workload_type: Type of workload ("deployment", "statefulset", or "job")
             node_pool_name: Name of the target node pool
             index: Workload instance index (1-based)
             count: Number of replicas/completions

--- a/modules/python/crud/main.py
+++ b/modules/python/crud/main.py
@@ -162,7 +162,7 @@ def handle_node_pool_operation(node_pool_crud, args):
         return 1
 
 def handle_workload_operations(node_pool_crud, args):
-    """Handle workload operations (deployment, statefulset) based on the command"""
+    """Handle workload operations (deployment, statefulset, job) based on the command"""
     command = args.command
     result = None
 
@@ -197,6 +197,21 @@ def handle_workload_operations(node_pool_crud, args):
             }
 
             result = node_pool_crud.create_statefulset(**statefulset_kwargs)
+        elif command == "job":
+            if not hasattr(node_pool_crud, 'create_job'):
+                logger.error("Cloud provider does not support job workload operations")
+                return 1
+
+            # Prepare job arguments
+            job_kwargs = {
+                "node_pool_name": args.node_pool_name,
+                "completions": args.completions,
+                "manifest_dir": args.manifest_dir,
+                "number_of_jobs": args.count,
+                "label_selector": args.label_selector,
+            }
+
+            result = node_pool_crud.create_job(**job_kwargs)
         else:
             logger.error("Unknown workload command: '%s'", command)
             return 1
@@ -530,6 +545,41 @@ def main():
         help="create statefulsets"
     )
     statefulset_parser.set_defaults(func=handle_workload_operations)
+
+    # Job command
+    job_parser = subparsers.add_parser(
+        "job",
+        parents=[common_parser],
+        help="create jobs"
+    )
+    job_parser.add_argument(
+        "--node-pool-name",
+        required=True,
+        help="Name of the node pool to target"
+    )
+    job_parser.add_argument(
+        "--count",
+        type=int,
+        default=1,
+        help="Number of jobs to create (default: 1)"
+    )
+    job_parser.add_argument(
+        "--completions",
+        type=int,
+        default=1,
+        help="Number of completions per job (default: 1)"
+    )
+    job_parser.add_argument(
+        "--manifest-dir",
+        default=None,
+        help="Directory containing Kubernetes manifest files"
+    )
+    job_parser.add_argument(
+        "--label-selector",
+        default="app=nginx-container",
+        help="Label selector for created pods (default: app=nginx-container)"
+    )
+    job_parser.set_defaults(func=handle_workload_operations)
 
     # Create-machine command (AKS Machine API)
     _add_create_machine_subparser(subparsers, common_parser)

--- a/modules/python/crud/main.py
+++ b/modules/python/crud/main.py
@@ -549,35 +549,14 @@ def main():
     # Job command
     job_parser = subparsers.add_parser(
         "job",
-        parents=[common_parser],
+        parents=[common_parser, workload_common_parser],
         help="create jobs"
-    )
-    job_parser.add_argument(
-        "--node-pool-name",
-        required=True,
-        help="Name of the node pool to target"
-    )
-    job_parser.add_argument(
-        "--count",
-        type=int,
-        default=1,
-        help="Number of jobs to create (default: 1)"
     )
     job_parser.add_argument(
         "--completions",
         type=int,
         default=1,
         help="Number of completions per job (default: 1)"
-    )
-    job_parser.add_argument(
-        "--manifest-dir",
-        default=None,
-        help="Directory containing Kubernetes manifest files"
-    )
-    job_parser.add_argument(
-        "--label-selector",
-        default="app=nginx-container",
-        help="Label selector for created pods (default: app=nginx-container)"
     )
     job_parser.set_defaults(func=handle_workload_operations)
 

--- a/modules/python/crud/workload_templates/job.yml
+++ b/modules/python/crud/workload_templates/job.yml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: myapp-{{NODE_POOL_NAME}}-{{INDEX}}
+  labels:
+    app: {{LABEL_VALUE}}
+spec:
+  completions: {{JOB_COMPLETIONS}}
+  template:
+    metadata:
+      labels:
+        app: {{LABEL_VALUE}}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{LABEL_VALUE}}
+          image: mcr.microsoft.com/oss/nginx/nginx:1.21.6
+          command: ["nginx", "-t"]
+          ports:
+            - containerPort: 80

--- a/modules/python/tests/clients/test_kubernetes_client.py
+++ b/modules/python/tests/clients/test_kubernetes_client.py
@@ -3478,6 +3478,104 @@ spec:
 
             self.assertFalse(result)
 
+    @patch('time.time')
+    def test_wait_for_condition_job_complete_success(self, mock_time):
+        """Test wait_for_condition for job - complete success case"""
+        mock_time.side_effect = [0, 0, 1, 2, 2]
+
+        mock_job = MagicMock()
+        mock_job.status.conditions = [
+            MagicMock(type="Complete", status="True")
+        ]
+        mock_job.status.succeeded = 1
+
+        with patch.object(self.client, 'batch') as mock_batch, \
+             patch('time.sleep'):
+            mock_batch.read_namespaced_job.return_value = mock_job
+
+            result = self.client.wait_for_condition(
+                resource_type="job",
+                resource_name="test-job",
+                wait_condition_type="complete",
+                namespace="test-namespace",
+                timeout_seconds=5
+            )
+
+            self.assertTrue(result)
+            mock_batch.read_namespaced_job.assert_called_with(
+                name="test-job",
+                namespace="test-namespace"
+            )
+
+    @patch('time.time')
+    def test_wait_for_condition_job_failed(self, mock_time):
+        """Test wait_for_condition for job - failed condition"""
+        mock_time.side_effect = [0, 0, 1, 2, 2]
+
+        mock_job = MagicMock()
+        mock_job.status.conditions = [
+            MagicMock(type="Failed", status="True")
+        ]
+        mock_job.status.succeeded = None
+
+        with patch.object(self.client, 'batch') as mock_batch, \
+             patch('time.sleep'):
+            mock_batch.read_namespaced_job.return_value = mock_job
+
+            result = self.client.wait_for_condition(
+                resource_type="job",
+                resource_name="test-job",
+                wait_condition_type="failed",
+                namespace="test-namespace",
+                timeout_seconds=5
+            )
+
+            self.assertTrue(result)
+
+    @patch('time.time')
+    def test_wait_for_condition_job_timeout(self, mock_time):
+        """Test wait_for_condition for job - timeout case"""
+        mock_time.side_effect = [0, 0, 2, 5, 6, 6]
+
+        mock_job = MagicMock()
+        mock_job.status.conditions = None
+        mock_job.status.succeeded = 0
+
+        with patch.object(self.client, 'batch') as mock_batch, \
+             patch('time.sleep'):
+            mock_batch.read_namespaced_job.return_value = mock_job
+
+            result = self.client.wait_for_condition(
+                resource_type="job",
+                resource_name="test-job",
+                wait_condition_type="complete",
+                namespace="test-namespace",
+                timeout_seconds=1
+            )
+
+            self.assertFalse(result)
+
+    @patch('time.time')
+    def test_wait_for_condition_job_not_found(self, mock_time):
+        """Test wait_for_condition for job - not found case"""
+        mock_time.side_effect = [0, 0, 2, 5, 6, 6]
+
+        api_exception = ApiException(status=404, reason="Not Found")
+
+        with patch.object(self.client, 'batch') as mock_batch, \
+             patch('time.sleep'):
+            mock_batch.read_namespaced_job.side_effect = api_exception
+
+            result = self.client.wait_for_condition(
+                resource_type="job",
+                resource_name="nonexistent",
+                wait_condition_type="complete",
+                namespace="test-namespace",
+                timeout_seconds=1
+            )
+
+            self.assertFalse(result)
+
     # Tests for the enhanced apply_manifest_from_file method with folder support
     @patch('os.path.isdir')
     @patch('os.path.isfile')

--- a/modules/python/tests/clients/test_kubernetes_client.py
+++ b/modules/python/tests/clients/test_kubernetes_client.py
@@ -1481,10 +1481,15 @@ class TestKubernetesClient(unittest.TestCase):
         mock_status = MagicMock()
         mock_status.succeeded = 1
         mock_status.failed = 0
+        mock_status.conditions = []  # No conditions, will use succeeded fallback
+
+        mock_spec = MagicMock()
+        mock_spec.completions = 1
 
         mock_job = MagicMock()
         mock_job.status = mock_status
         mock_job.metadata = mock_metadata
+        mock_job.spec = mock_spec
 
         mock_read_job.return_value = mock_job
 
@@ -1497,11 +1502,20 @@ class TestKubernetesClient(unittest.TestCase):
         """Test waiting for job completion when job has failed."""
         job_name = "test-job"
         namespace = "default"
+
+        # Create a proper Failed condition
+        mock_condition = MagicMock()
+        mock_condition.type = "Failed"
+        mock_condition.status = "True"
+
         mock_status = MagicMock()
         mock_status.succeeded = 0
         mock_status.failed = 1
+        mock_status.conditions = [mock_condition]
+
         mock_job = MagicMock()
         mock_job.status = mock_status
+        mock_job.spec.completions = 1
         mock_metadata = MagicMock()
         mock_metadata.name = job_name
         mock_job.metadata = mock_metadata
@@ -1531,6 +1545,7 @@ class TestKubernetesClient(unittest.TestCase):
             status=MagicMock(succeeded=0, failed=0, conditions=[]),
             metadata=MagicMock(name=job_name),
         )
+        mock_read_namespaced_job.return_value.spec = MagicMock(completions=1)
 
         with self.assertRaises(Exception) as context:
             self.client.wait_for_job_completed(job_name, namespace, timeout)

--- a/modules/python/tests/crud/test_azure_node_pool_crud.py
+++ b/modules/python/tests/crud/test_azure_node_pool_crud.py
@@ -463,5 +463,75 @@ class TestAzureNodePoolCRUD(unittest.TestCase):
         # Verify create_template was called 3 times (attempted all statefulsets)
         self.assertEqual(mock_k8s_client.create_template.call_count, 3)
 
+    def test_create_job_success(self):
+        """Test successful job creation"""
+        # Setup
+        mock_k8s_client = mock.MagicMock()
+        self.mock_aks_client.k8s_client = mock_k8s_client
+        # Must return a real string - yaml.safe_load_all(MagicMock()) causes an infinite loop
+        mock_k8s_client.create_template.return_value = "apiVersion: batch/v1\nkind: Job\n"
+        mock_k8s_client.wait_for_condition.return_value = True
+
+        # Execute
+        result = self.node_pool_crud.create_job(node_pool_name="test-pool")
+
+        # Verify
+        self.assertTrue(result)
+
+    def test_create_job_failure(self):
+        """Test job creation failure"""
+        # Setup
+        mock_k8s_client = mock.MagicMock()
+        self.mock_aks_client.k8s_client = mock_k8s_client
+        # Must return a real string - yaml.safe_load_all(MagicMock()) causes an infinite loop
+        mock_k8s_client.create_template.return_value = "apiVersion: batch/v1\nkind: Job\n"
+        mock_k8s_client.wait_for_condition.return_value = False
+
+        # Execute
+        result = self.node_pool_crud.create_job(node_pool_name="test-pool")
+
+        # Verify
+        self.assertFalse(result)
+
+    def test_create_job_no_client(self):
+        """Test job creation with no Kubernetes client"""
+        # Setup
+        self.mock_aks_client.k8s_client = None
+
+        # Execute
+        result = self.node_pool_crud.create_job(node_pool_name="test-pool")
+
+        # Verify
+        self.assertFalse(result)
+
+    def test_create_job_partial_success(self):
+        """Test job creation when some jobs succeed and others fail"""
+        # Setup
+        mock_k8s_client = mock.MagicMock()
+        self.mock_aks_client.k8s_client = mock_k8s_client
+
+        # Must return a real string - yaml.safe_load_all(MagicMock()) causes an infinite loop
+        mock_k8s_client.create_template.return_value = "apiVersion: batch/v1\nkind: Job\n"
+
+        # Simulate: Job 1 succeeds, Job 2 fails, Job 3 succeeds
+        # wait_for_condition returns True/False for each Job
+        mock_k8s_client.wait_for_condition.side_effect = [True, False, True]
+
+        # Execute - request 3 Jobs
+        result = self.node_pool_crud.create_job(
+            node_pool_name="test-pool",
+            number_of_jobs=3,
+            completions=1
+        )
+
+        # Verify - should return False (not all jobs succeeded)
+        self.assertFalse(result)
+
+        # Verify wait_for_condition was called 3 times (once per job)
+        self.assertEqual(mock_k8s_client.wait_for_condition.call_count, 3)
+
+        # Verify create_template was called 3 times (attempted all jobs)
+        self.assertEqual(mock_k8s_client.create_template.call_count, 3)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -45,6 +45,7 @@ stages:
               step_wait_time: 30
               count: 1
               replicas: 10
+              completions: 1
               manifest_dir: ""
           max_parallel: 1
           credential_type: service_connection
@@ -78,6 +79,7 @@ stages:
               step_wait_time: 30
               count: 1
               replicas: 10
+              completions: 1
               manifest_dir: ""
           max_parallel: 1
           credential_type: service_connection

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,25 +1,35 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: k8s-gpu-cluster-crud
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: azure_australiaeast
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml # must keep as is
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
-          credential_type: service_connection # required
+          cloud: azure
+          regions:
+            - australiaeast
+          topology: k8s-crud-gpu
+          engine: crud
+          matrix:
+            job_workload_test:
+              gpu_node_pool: ""
+              pool_name: jobtestpool
+              vm_size: Standard_D4s_v3
+              create_node_count: 0
+              scale_node_count: 1
+              scale_step_size: 1
+              step_time_out: 600
+              step_wait_time: 30
+              count: 1
+              replicas: 1
+              completions: 1
+              manifest_dir: ""
+          max_parallel: 1
+          credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 60 # if not specified, default is 60
+          timeout_in_minutes: 60

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,35 +1,25 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: perf-eval
-  SCENARIO_NAME: k8s-gpu-cluster-crud
+  SCENARIO_TYPE: <scenario-type>
+  SCENARIO_NAME: <scenario-name>
 
 stages:
-  - stage: azure_australiaeast
+  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
     dependsOn: []
     jobs:
       - template: /jobs/competitive-test.yml # must keep as is
         parameters:
-          cloud: azure
-          regions:
-            - australiaeast
-          topology: k8s-crud-gpu
-          engine: crud
-          matrix:
-            job_workload_test:
-              gpu_node_pool: ""
-              pool_name: jobtestpool
-              vm_size: Standard_D4s_v3
-              create_node_count: 0
-              scale_node_count: 1
-              scale_step_size: 1
-              step_time_out: 600
-              step_wait_time: 30
-              count: 1
-              replicas: 1
-              completions: 1
-              manifest_dir: ""
-          max_parallel: 1
-          credential_type: service_connection
+          cloud: <cloud> # e.g. azure, aws
+          regions: # list of regions
+            - region1 # e.g. eastus2
+          topology: <topology> # e.g. cluster-autoscaler
+          engine: <engine> # e.g. clusterloader2
+          matrix: # list of test parameters to customize the provisioned resources
+            <case-name>:
+              <key1>: <value1>
+              <key2>: <value2>
+          max_parallel: <number of concurrent jobs> # required
+          credential_type: service_connection # required
           ssh_key_enabled: false
-          timeout_in_minutes: 60
+          timeout_in_minutes: 60 # if not specified, default is 60

--- a/steps/engine/crud/k8s/execute.yml
+++ b/steps/engine/crud/k8s/execute.yml
@@ -101,6 +101,33 @@ steps:
       REPLICAS: $(REPLICAS)
       MANIFEST_DIR: $(MANIFEST_DIR)
 
+  - script: |
+      set -eo pipefail
+
+      # Deploy Jobs
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" job \
+        --cloud "$CLOUD" \
+        --run-id "$RUN_ID" \
+        --result-dir "$RESULT_DIR" \
+        --node-pool-name "$POOL_NAME" \
+        --count "$COUNT" \
+        --completions "$COMPLETIONS" \
+        ${MANIFEST_DIR:+--manifest-dir "$MANIFEST_DIR"} \
+        --step-timeout "$STEP_TIME_OUT" \
+        ${GPU_NODE_POOL:+--gpu-node-pool}
+    displayName: 'Execute K8s Job operations for ${{ parameters.cloud }}'
+    workingDirectory: modules/python
+    env:
+      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
+      POOL_NAME: $(POOL_NAME)
+      CLOUD: ${{ parameters.cloud }}
+      STEP_TIME_OUT: $(STEP_TIME_OUT)
+      RESULT_DIR: $(System.DefaultWorkingDirectory)/$(RUN_ID)
+      GPU_NODE_POOL: $(GPU_NODE_POOL)
+      COUNT: $(COUNT)
+      COMPLETIONS: $(COMPLETIONS)
+      MANIFEST_DIR: $(MANIFEST_DIR)
+
 - script: |
     set -eo pipefail
 


### PR DESCRIPTION
Add Job workload support to CRUD benchmarking framework

## Summary

Adds Job workload support to the CRUD benchmarking framework - the third and final of three planned workload methods (`deployment`, `statefulset`, `job`). Measures K8s Job create/verify latency on AKS node pools.

## Changes

`modules/python/crud/workload_templates/job.yml`
- New K8s Job manifest template using nginx config validation for quick completion
- Uses `JOB_COMPLETIONS` placeholder, configurable node affinity via label_selector

`modules/python/crud/azure/node_pool_crud.py`
- Add `job` entry to `WORKLOAD_CONFIG` with template path, completions key, `complete` condition, and `verify_pods_ready=False` (jobs terminate after completion)
- Add `create_job()` using unified `_create_workloads` helper

`modules/python/crud/main.py`
- Add `job` subparser with `--completions` argument (distinct from `--replicas`)
- Add `elif command == "job"` routing in `handle_workload_operations`

`modules/python/clients/kubernetes_client.py`
- Add `job`/`jobs` to `valid_conditions` with `['complete', 'failed']`
- Add `_check_job_condition` and `_is_job_condition_met` for job status polling
- Extend `wait_for_condition` to support Job resource type

`steps/engine/crud/k8s/execute.yml`
- Add `job` script block (Azure-only, consistent with deployment/statefulset)

`pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml`
- Add `completions: 1` to matrix entries

## Tests

`test_azure_node_pool_crud.py`:
- `test_create_job_success` - happy path
- `test_create_job_failure` - all fail to complete
- `test_create_job_no_client` - returns early when k8s client unavailable
- `test_create_job_partial_success` - continues on failures, returns False

`test_kubernetes_client.py`:
- `test_wait_for_condition_job_complete_success`
- `test_wait_for_condition_job_failed`
- `test_wait_for_condition_job_timeout`
- `test_wait_for_condition_job_not_found`