### PR TITLE
Add AKS machine CRUD scale pipeline

### DIFF
--- a/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
@@ -1,0 +1,38 @@
+trigger: none
+
+schedules:
+  - cron: "0 12 * * *"
+    displayName: "Daily 12:00 UTC"
+    branches:
+      include:
+        - main
+    always: true
+
+variables:
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: k8s-cluster-crud-machine  # matches ado-telescope: feeds Kusto table k8s_cluster_crud_machine_main
+  USE_LATEST_GA_K8S_VERSION: true
+
+stages:
+  - stage: azure_canadacentral_small_machine_pool
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - canadacentral
+          topology: k8s-cluster-crud-machine
+          engine: machine
+          matrix:
+            small_machine_pool:
+              vm_size: Standard_D2_v3
+              pool_name: smallpool1
+              scale_machine_count: 1
+              machine_workers: 1
+              use_batch_api: "false"
+              step_time_out: 600
+          max_parallel: 1
+          timeout_in_minutes: 180
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,25 +1,78 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: k8s-cluster-crud-machine
+  USE_LATEST_GA_K8S_VERSION: true
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: azure_canadacentral_small_scale_10
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml # must keep as is
+      - template: /jobs/competitive-test.yml
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
-          credential_type: service_connection # required
+          cloud: azure
+          regions:
+            - canadacentral
+          topology: k8s-cluster-crud-machine
+          engine: machine
+          matrix:
+            canadacentral-small-scale-10:
+              vm_size: Standard_D2_v3
+              pool_name: smallpool1
+              scale_machine_count: 10
+              machine_workers: 5
+              use_batch_api: "false"
+              step_time_out: 900
+          max_parallel: 1
+          timeout_in_minutes: 360
+          credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 60 # if not specified, default is 60
+
+  - stage: azure_canadacentral_medium_scale_500
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - canadacentral
+          topology: k8s-cluster-crud-machine
+          engine: machine
+          matrix:
+            canadacentral-medium-scale-500:
+              vm_size: Standard_D2_v3
+              pool_name: mediump1
+              scale_machine_count: 500
+              machine_workers: 10
+              use_batch_api: "true"
+              step_time_out: 2400
+          max_parallel: 1
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false
+
+  - stage: azure_canadacentral_large_scale_1000
+    dependsOn:
+      - azure_canadacentral_small_scale_10
+      - azure_canadacentral_medium_scale_500
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - canadacentral
+          topology: k8s-cluster-crud-machine
+          engine: machine
+          matrix:
+            canadacentral-large-scale-1000:
+              vm_size: Standard_D2_v3
+              pool_name: largep1
+              scale_machine_count: 1000
+              machine_workers: 20
+              use_batch_api: "true"
+              step_time_out: 3600
+          max_parallel: 1
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
@@ -1,0 +1,32 @@
+scenario_type  = "perf-eval"
+scenario_name  = "k8s-cluster-crud-machine"
+deletion_delay = "4h"
+owner          = "aks"
+aks_cli_config_list = [
+  {
+    role                          = "client"
+    aks_name                      = "mchapi"
+    sku_tier                      = "standard"
+    use_aks_preview_cli_extension = true
+    default_node_pool = {
+      name       = "default"
+      node_count = 2
+      vm_size    = "Standard_D2_v3"
+    }
+
+    optional_parameters = [
+      {
+        name  = "network-plugin"
+        value = "azure"
+      },
+      {
+        name  = "network-plugin-mode"
+        value = "overlay"
+      },
+      {
+        name  = "pod-cidr"
+        value = "10.128.0.0/11"
+      }
+    ]
+  }
+]

--- a/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-test-inputs/azure.json
+++ b/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-test-inputs/azure.json
@@ -1,0 +1,23 @@
+{
+    "run_id"                           : "123456789",
+    "region"                           : "canadacentral",
+    "aks_cli_system_node_pool" : {
+      "name"        : "default",
+      "node_count"  : 1,
+      "vm_size"     : "Standard_D2s_v3",
+      "vm_set_type" : "VirtualMachineScaleSets"
+    },
+    "aks_cli_user_node_pool" : [{
+        "name"        : "pool1",
+        "node_count"  : 1,
+        "vm_size"     : "Standard_D2s_v3",
+        "vm_set_type" : "VirtualMachineScaleSets"
+      },
+      {
+        "name"        : "pool2",
+        "node_count"  : 1,
+        "vm_size"     : "Standard_D2s_v3",
+        "vm_set_type" : "VirtualMachineScaleSets"
+      }]
+    
+}

--- a/steps/engine/machine/k8s/collect.yml
+++ b/steps/engine/machine/k8s/collect.yml
@@ -1,0 +1,18 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: region
+    type: string
+
+steps:
+  - bash: |
+      set -euo pipefail
+      python3 -m crud.main collect
+    workingDirectory: modules/python
+    displayName: "Collect Machine API results"
+    env:
+      PYTHONPATH: $(Pipeline.Workspace)/s/modules/python
+      RUN_ID: $(RUN_ID)
+      REGION: ${{ parameters.region }}
+      RESULT_DIR: $(System.DefaultWorkingDirectory)/$(RUN_ID)
+      RUN_URL: $(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs&j=$(System.JobId)

--- a/steps/engine/machine/k8s/execute.yml
+++ b/steps/engine/machine/k8s/execute.yml
@@ -1,0 +1,60 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: result_dir
+    type: string
+  - name: vm_size
+    type: string
+  - name: pool_name
+    type: string
+  - name: scale_machine_count
+    type: string  # numeric matrix values resolve at runtime via $(VAR)
+  - name: machine_workers
+    type: string
+  - name: use_batch_api
+    type: string  # 'true'|'false' as ADO doesn't have boolean type for matrix
+  - name: step_time_out
+    type: string
+    default: "600"
+
+steps:
+  - bash: |
+      set -euo pipefail
+      tags=$(jq -nc --arg run_id "$RUN_ID" \
+        --arg deletion_due_time "$DELETION_DUE_TIME" \
+        --arg creation_time "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+        --arg scenario "$SCENARIO_TYPE-$SCENARIO_NAME" \
+        --arg owner aks \
+        '{run_id:$run_id, deletion_due_time:$deletion_due_time, creation_time:$creation_time, scenario:$scenario, owner:$owner}')
+      python3 -m crud.main create-machine \
+        --cloud "${{ parameters.cloud }}" \
+        --run-id "$RUN_ID" \
+        --node-pool-name "${{ parameters.pool_name }}" \
+        --vm-size "${{ parameters.vm_size }}" \
+        --step-timeout "${{ parameters.step_time_out }}" \
+        --result-dir "${{ parameters.result_dir }}"
+      USE_BATCH_FLAG=""
+      if [[ "${{ parameters.use_batch_api }}" == "true" ]]; then
+        USE_BATCH_FLAG="--use-batch-api"
+      fi
+      # shellcheck disable=SC2086
+      python3 -m crud.main scale-machine \
+        --cloud "${{ parameters.cloud }}" \
+        --run-id "$RUN_ID" \
+        --node-pool-name "${{ parameters.pool_name }}" \
+        --vm-size "${{ parameters.vm_size }}" \
+        --scale-machine-count "${{ parameters.scale_machine_count }}" \
+        --machine-workers "${{ parameters.machine_workers }}" \
+        $USE_BATCH_FLAG \
+        --step-timeout "${{ parameters.step_time_out }}" \
+        --readiness-wait-timeout "${{ parameters.step_time_out }}" \
+        --result-dir "${{ parameters.result_dir }}" \
+        --tags "$tags"
+    workingDirectory: modules/python
+    displayName: "Execute Machine API CRUD"
+    env:
+      PYTHONPATH: $(Pipeline.Workspace)/s/modules/python
+      RUN_ID: $(RUN_ID)
+      DELETION_DUE_TIME: $(DELETION_DUE_TIME)
+      SCENARIO_TYPE: $(SCENARIO_TYPE)
+      SCENARIO_NAME: $(SCENARIO_NAME)

--- a/steps/topology/k8s-cluster-crud-machine/collect-machine.yml
+++ b/steps/topology/k8s-cluster-crud-machine/collect-machine.yml
@@ -1,0 +1,14 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: regions
+    type: object
+  - name: engine_input
+    type: object
+    default: {}
+
+steps:
+  - template: /steps/engine/machine/k8s/collect.yml
+    parameters:
+      cloud: ${{ parameters.cloud }}
+      region: ${{ parameters.regions[0] }}

--- a/steps/topology/k8s-cluster-crud-machine/execute-machine.yml
+++ b/steps/topology/k8s-cluster-crud-machine/execute-machine.yml
@@ -1,0 +1,20 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: regions
+    type: object
+  - name: engine_input
+    type: object
+    default: {}
+
+steps:
+  - template: /steps/engine/machine/k8s/execute.yml
+    parameters:
+      cloud: ${{ parameters.cloud }}
+      result_dir: $(System.DefaultWorkingDirectory)/$(RUN_ID)
+      vm_size: $(VM_SIZE)
+      pool_name: $(POOL_NAME)
+      scale_machine_count: $(SCALE_MACHINE_COUNT)
+      machine_workers: $(MACHINE_WORKERS)
+      use_batch_api: $(USE_BATCH_API)
+      step_time_out: $(STEP_TIME_OUT)

--- a/steps/topology/k8s-cluster-crud-machine/validate-resources.yml
+++ b/steps/topology/k8s-cluster-crud-machine/validate-resources.yml
@@ -1,0 +1,13 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: regions
+    type: object
+  - name: engine
+    type: string
+
+steps:
+  - template: /steps/cloud/${{ parameters.cloud }}/update-kubeconfig.yml
+    parameters:
+      role: client
+      region: ${{ parameters.regions[0] }}


### PR DESCRIPTION
## Summary
- Add the AKS machine CRUD perf pipeline and topology/engine steps.
- Add canadacentral scale stages for 10, 500, and 1000 nodes.
- Run 10 and 500 in parallel, then run 1000 after both complete.

## Stack
- Draft PR stacked on #1204 so this PR shows only the non-Python pipeline/scenario diff.
- After #1204 merges, retarget/rebase this PR onto main before marking ready.

## Scale setup
- 500 nodes uses batch API with 10 workers for a calculated batch size of 50.
- 1000 nodes uses batch API with 20 workers for a calculated batch size of 50.
- Large-scale overlay pod CIDR uses 10.128.0.0/11, aligned with existing 1000-node perf scenarios.

## Validation
- yamllint -c .yamllint . --no-warnings
- focused stage dependency validation for pipelines/system/new-pipeline-test.yml
- git diff --check