### PR TITLE
Update CODEOWNERS to add @LeonardCareer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,6 @@ updates:
       - liyu-ma
       - vittoriasalim
       - xinWeiWei24
+      - LeonardCareer
     open-pull-requests-limit: 10
     target-branch: "main"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
-* @alyssa1303 @anson627 @sumanthreddy29 @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma
+* @alyssa1303 @anson627 @sumanthreddy29 @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma @LeonardCareer
 
 # CCP pipelines
-/pipelines/perf-eval/API\ Server\ Benchmark/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma
-/pipelines/perf-eval/Scheduler\ Benchmark/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma
-/scenarios/perf-eval/apiserver-*/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma
-/scenarios/perf-eval/job-scheduling/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma
+/pipelines/perf-eval/API\ Server\ Benchmark/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma @LeonardCareer
+/pipelines/perf-eval/Scheduler\ Benchmark/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma @LeonardCareer
+/scenarios/perf-eval/apiserver-*/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma @LeonardCareer
+/scenarios/perf-eval/job-scheduling/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma @LeonardCareer


### PR DESCRIPTION
## Summary
- Add `@LeonardCareer` (Leonard Du) to `CODEOWNERS` — global `*` line and the four perf-eval path entries — mirroring existing team members' coverage. Leonard recently joined the team.
- Add `LeonardCareer` to `.github/dependabot.yml` reviewers so Terraform dependency PRs are routed alongside the rest of the team.

## Test plan
- [ ] CODEOWNERS syntax validated by GitHub (no parse warnings on PR page)