### PR TITLE
Fail fast on terminal AKS machine failures

### DIFF
--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -59,7 +59,7 @@ _BATCH_MAX_MACHINES_PER_REQUEST = 50
 _MACHINE_TERMINAL_STATES = {"Succeeded", "Failed", "Canceled"}
 _MACHINE_FAILURE_STATES = {"Failed", "Canceled"}
 _MACHINE_FAILURE_DETAIL_LIMIT = 10
-_LIST_MACHINES_PAGE_LIMIT = 50
+_LIST_MACHINES_MAX_PAGES = 50
 _MACHINE_FAILURE_CHECK_INTERVAL_SECONDS = 30
 _NODE_READINESS_POLL_INTERVAL_SECONDS = 2
 # urllib3's default ``HTTPAdapter`` (mounted implicitly by ``requests.Session``)
@@ -79,12 +79,12 @@ class MachineProvisioningFailed(RuntimeError):
     """Terminal Machine failure with readiness metadata captured before failure."""
     def __init__(
         self,
-        agentpool_name: str,
+        agent_pool_name: str,
         failed_machines: List[Dict[str, Any]],
         readiness_envelope: Dict[str, Dict[str, Any]],
     ):
         super().__init__(
-            f"machine provisioning failed in agentpool {agentpool_name}: "
+            f"machine provisioning failed in agentpool {agent_pool_name}: "
             f"failed_machines={failed_machines}"
         )
         self.failed_machines = failed_machines
@@ -164,7 +164,7 @@ class AKSMachineClient(AKSClient):
     # ---- Machine API: agent pool provisioning ----
     def create_machine_agentpool(
         self,
-        agentpool_name: str,
+        agent_pool_name: str,
         vm_size: str,
         cluster_name: Optional[str] = None,
         timeout: int = 300,
@@ -176,7 +176,7 @@ class AKSMachineClient(AKSClient):
         with traceback before the exception propagates to ``MachineCRUD``).
 
         Args:
-            agentpool_name: Target agentpool name.
+            agent_pool_name: Target agentpool name.
             vm_size: VM SKU recorded in operation metadata. The PUT body itself
                 only sets ``mode: Machines``; the SKU is informational here so
                 downstream Kusto rows can attribute the agentpool to a SKU.
@@ -194,7 +194,7 @@ class AKSMachineClient(AKSClient):
         cluster_name = cluster_name or self.get_cluster_name()
         metadata = {
             "cluster_name": cluster_name,
-            "agentpool_name": agentpool_name,
+            "agent_pool_name": agent_pool_name,
             "vm_size": vm_size,
         }
         with self._get_operation_context()(
@@ -205,7 +205,7 @@ class AKSMachineClient(AKSClient):
                 url = (
                     f"{_ARM_BASE}/subscriptions/{sub}/resourceGroups/{self.resource_group}"
                     f"/providers/Microsoft.ContainerService/managedClusters/{cluster_name}"
-                    f"/agentPools/{agentpool_name}?api-version={_AGENTPOOL_API_VERSION}"
+                    f"/agentPools/{agent_pool_name}?api-version={_AGENTPOOL_API_VERSION}"
                 )
                 body = {"properties": {"mode": "Machines"}}
                 # Cap the PUT timeout so the bulk of ``timeout`` is preserved
@@ -221,13 +221,13 @@ class AKSMachineClient(AKSClient):
                     )
                 if not self._wait_for_agentpool_provisioning(url, timeout):
                     raise RuntimeError(
-                        f"agentpool {agentpool_name} did not reach Succeeded within {timeout}s"
+                        f"agentpool {agent_pool_name} did not reach Succeeded within {timeout}s"
                     )
                 op.add_metadata("agentpool_info", self.get_node_pool(
-                    agentpool_name, cluster_name).as_dict())
+                    agent_pool_name, cluster_name).as_dict())
                 op.add_metadata("cluster_info", self.get_cluster_data(cluster_name))
             except Exception as e:
-                logger.error(f"Failed to create machine agentpool {agentpool_name}: {e}")
+                logger.error(f"Failed to create machine agentpool {agent_pool_name}: {e}")
                 raise
 
     def _wait_for_agentpool_provisioning(self, url: str, timeout: int) -> bool:
@@ -278,7 +278,7 @@ class AKSMachineClient(AKSClient):
 
     def _wait_for_machine_node_readiness(
         self,
-        agentpool_name: str,
+        agent_pool_name: str,
         expected_count: int,
         timeout: int,
         baseline_count: int = 0,
@@ -314,7 +314,7 @@ class AKSMachineClient(AKSClient):
         }
         if expected_count <= 0:
             return empty_envelope
-        label_selector = f"agentpool={agentpool_name}"
+        label_selector = f"agentpool={agent_pool_name}"
         target_total = baseline_count + expected_count
         # Each percentile target must be STRICTLY GREATER than baseline_count so
         # we count only NEW nodes -- pre-existing labeled Ready nodes alone must
@@ -331,30 +331,26 @@ class AKSMachineClient(AKSClient):
             start if cluster_name and expected_machine_names else None
         )
         logger.info(
-            f"Waiting for nodes in agentpool {agentpool_name} (label {label_selector}) - "
+            f"Waiting for nodes in agentpool {agent_pool_name} (label {label_selector}) - "
             f"targets {targets}, baseline={baseline_count}, expected={expected_count}, "
             f"timeout {timeout}s"
         )
         while time.time() < deadline and len(readiness_times) < len(targets):
-            failed_machines = None
             should_check_machines = (
                 next_machine_failure_check_at is not None
                 and time.time() >= next_machine_failure_check_at
             )
-            max_workers = 2 if should_check_machines else 1
-            with ThreadPoolExecutor(max_workers=max_workers) as ex:
-                ready_nodes = ex.submit(self._get_ready_node_count, label_selector)
-                if should_check_machines and cluster_name and expected_machine_names:
+            failed_machines_result: List[Dict[str, Any]] = []
+            if should_check_machines and cluster_name and expected_machine_names:
+                with ThreadPoolExecutor(max_workers=2) as ex:
+                    ready_nodes = ex.submit(self._get_ready_node_count, label_selector)
                     failed_machines = ex.submit(
                         self._get_terminal_machine_provisioning_failures,
                         cluster_name=cluster_name,
-                        agentpool_name=agentpool_name,
+                        agent_pool_name=agent_pool_name,
                         expected_names=expected_machine_names,
                     )
-
-            ready = ready_nodes.result()
-            failed_machines_result: List[Dict[str, Any]] = []
-            if failed_machines is not None:
+                    ready = ready_nodes.result()
                 try:
                     failed_machines_result = failed_machines.result()
                 except Exception as e:
@@ -365,11 +361,13 @@ class AKSMachineClient(AKSClient):
                 next_machine_failure_check_at = (
                     time.time() + _MACHINE_FAILURE_CHECK_INTERVAL_SECONDS
                 )
+            else:
+                ready = self._get_ready_node_count(label_selector)
             # Once all expected Machines are terminal, no more requested nodes
             # can join. Preserve lower-percentile timings before failing.
             if failed_machines_result:
                 raise MachineProvisioningFailed(
-                    agentpool_name=agentpool_name,
+                    agent_pool_name=agent_pool_name,
                     failed_machines=failed_machines_result,
                     readiness_envelope=self._build_readiness_envelope(targets, readiness_times),
                 )
@@ -397,12 +395,12 @@ class AKSMachineClient(AKSClient):
         result = self._build_readiness_envelope(targets, readiness_times)
         if not readiness_times:
             logger.warning(
-                f"No percentile target met within {timeout}s for agentpool {agentpool_name}"
+                f"No percentile target met within {timeout}s for agentpool {agent_pool_name}"
             )
             return result
         # Log percentile summary including P100, which is the wall-clock
         # elapsed until ALL target nodes are Ready.
-        logger.info(f"Node Readiness Percentile Summary for agentpool {agentpool_name}:")
+        logger.info(f"Node Readiness Percentile Summary for agentpool {agent_pool_name}:")
         for p in (50, 70, 90, 99, 100):
             if p in readiness_times:
                 logger.info(
@@ -415,12 +413,12 @@ class AKSMachineClient(AKSClient):
         if len(readiness_times) == len(targets):
             logger.info(
                 f"All target nodes became ready in {max_elapsed:.2f} seconds "
-                f"in agent pool {agentpool_name}"
+                f"in agent pool {agent_pool_name}"
             )
         else:
             missed = [f"P{p}" for p in (50, 70, 90, 99, 100) if p not in readiness_times]
             logger.warning(
-                f"Partial readiness in agent pool {agentpool_name}: "
+                f"Partial readiness in agent pool {agent_pool_name}: "
                 f"{len(readiness_times)}/{len(targets)} percentiles met within "
                 f"{timeout}s; missed {missed}; last successful percentile at "
                 f"{max_elapsed:.2f}s"
@@ -456,7 +454,7 @@ class AKSMachineClient(AKSClient):
     # ---- Machine API: scale path ----
     def scale_machine(
         self,
-        agentpool_name: str,
+        agent_pool_name: str,
         vm_size: str,
         scale_machine_count: int,
         cluster_name: Optional[str] = None,
@@ -498,7 +496,7 @@ class AKSMachineClient(AKSClient):
         cluster_name = cluster_name or self.get_cluster_name()
         metadata = {
             "cluster_name": cluster_name,
-            "agentpool_name": agentpool_name,
+            "agent_pool_name": agent_pool_name,
             "vm_size": vm_size,
             "scale_machine_count": scale_machine_count,
             "use_batch_api": use_batch_api,
@@ -507,7 +505,7 @@ class AKSMachineClient(AKSClient):
         # Bundle into a SimpleNamespace so the helpers retain the
         # ``request.foo`` shape without exposing yet another module-level data class.
         request = SimpleNamespace(
-            agentpool_name=agentpool_name,
+            agent_pool_name=agent_pool_name,
             cluster_name=cluster_name,
             resource_group=self.resource_group,
             vm_size=vm_size,
@@ -527,11 +525,11 @@ class AKSMachineClient(AKSClient):
                 try:
                     baseline_count = len(
                         self.k8s_client.get_ready_nodes(
-                            label_selector=f"agentpool={agentpool_name}"
+                            label_selector=f"agentpool={agent_pool_name}"
                         )
                     )
                     logger.info(
-                        f"baseline ready nodes in agentpool {agentpool_name}: {baseline_count}"
+                        f"baseline ready nodes in agentpool {agent_pool_name}: {baseline_count}"
                     )
                 except Exception:
                     logger.warning(
@@ -564,20 +562,20 @@ class AKSMachineClient(AKSClient):
                     f"{_ARM_BASE}/subscriptions/{self.subscription_id}/resourceGroups/"
                     f"{self.resource_group}/providers/Microsoft.ContainerService/"
                     f"managedClusters/{cluster_name}/agentPools/"
-                    f"{agentpool_name}?api-version={_AGENTPOOL_API_VERSION}"
+                    f"{agent_pool_name}?api-version={_AGENTPOOL_API_VERSION}"
                 )
                 agentpool_ok = self._wait_for_agentpool_provisioning(
                     agentpool_url, timeout
                 )
                 logger.info(
-                    f"agentpool {agentpool_name} provisioning "
+                    f"agentpool {agent_pool_name} provisioning "
                     f"{'Succeeded' if agentpool_ok else 'Failed/Timeout'}"
                 )
 
                 readiness_failure = None
                 try:
                     percentile_envelope = self._wait_for_machine_node_readiness(
-                        agentpool_name=agentpool_name,
+                        agent_pool_name=agent_pool_name,
                         expected_count=len(successful),
                         timeout=readiness_wait_timeout,
                         baseline_count=baseline_count,
@@ -599,17 +597,17 @@ class AKSMachineClient(AKSClient):
 
                 if not agentpool_ok:
                     raise RuntimeError(
-                        f"agentpool {agentpool_name} did not reach Succeeded within {timeout}s"
+                        f"agentpool {agent_pool_name} did not reach Succeeded within {timeout}s"
                     )
                 # P100 is the strictest readiness envelope (all target nodes
                 # Ready); if it succeeded, every lower percentile did too.
                 if not p100.get("success", False):
                     raise RuntimeError(
                         f"node readiness P100 did not complete within "
-                        f"{readiness_wait_timeout}s for agentpool {agentpool_name}"
+                        f"{readiness_wait_timeout}s for agentpool {agent_pool_name}"
                     )
             except Exception as e:
-                logger.error(f"Failed to scale machine agentpool {agentpool_name}: {e}")
+                logger.error(f"Failed to scale machine agentpool {agent_pool_name}: {e}")
                 raise
 
     @staticmethod
@@ -675,7 +673,7 @@ class AKSMachineClient(AKSClient):
         url = (
             f"{_ARM_BASE}/subscriptions/{sub}/resourceGroups/{request.resource_group}"
             f"/providers/Microsoft.ContainerService/managedClusters/{request.cluster_name}"
-            f"/agentPools/{request.agentpool_name}/machines/{name}"
+            f"/agentPools/{request.agent_pool_name}/machines/{name}"
             f"?api-version={_MACHINE_API_VERSION}"
         )
         body: Dict[str, Any] = {"properties": {"hardware": {"vmSize": request.vm_size}}}
@@ -688,22 +686,22 @@ class AKSMachineClient(AKSClient):
     def _list_machines(
         self,
         cluster_name: str,
-        agentpool_name: str,
+        agent_pool_name: str,
         timeout: int = 30,
     ) -> List[Dict[str, Any]]:
         """List Machine resources for an agentpool, following ARM pagination."""
         url = (
             f"{_ARM_BASE}/subscriptions/{self.subscription_id}/resourceGroups/"
             f"{self.resource_group}/providers/Microsoft.ContainerService/"
-            f"managedClusters/{cluster_name}/agentPools/{agentpool_name}/machines"
+            f"managedClusters/{cluster_name}/agentPools/{agent_pool_name}/machines"
             f"?api-version={_MACHINE_API_VERSION}"
         )
         machines: List[Dict[str, Any]] = []
-        for _ in range(_LIST_MACHINES_PAGE_LIMIT):
+        for _ in range(_LIST_MACHINES_MAX_PAGES):
             resp = self.make_request("GET", url, timeout=timeout)
             if resp.status_code != 200:
                 raise RuntimeError(
-                    f"ListMachines failed for agentpool {agentpool_name}: "
+                    f"ListMachines failed for agentpool {agent_pool_name}: "
                     f"{resp.status_code} {resp.text[:500]}"
                 )
             try:
@@ -711,7 +709,7 @@ class AKSMachineClient(AKSClient):
             except (ValueError, TypeError) as exc:
                 raise RuntimeError(
                     f"ListMachines returned invalid JSON for agentpool "
-                    f"{agentpool_name}: {exc}"
+                    f"{agent_pool_name}: {exc}"
                 ) from exc
             machines.extend(body.get("value", []))
             next_link = body.get("nextLink")
@@ -719,14 +717,14 @@ class AKSMachineClient(AKSClient):
                 return machines
             url = next_link
         raise RuntimeError(
-            f"ListMachines exceeded {_LIST_MACHINES_PAGE_LIMIT} pages for "
-            f"agentpool {agentpool_name}"
+            f"ListMachines exceeded {_LIST_MACHINES_MAX_PAGES} pages for "
+            f"agentpool {agent_pool_name}"
         )
 
     def _get_terminal_machine_provisioning_failures(
         self,
         cluster_name: str,
-        agentpool_name: str,
+        agent_pool_name: str,
         expected_names: Set[str],
     ) -> List[Dict[str, Any]]:
         """Return failed Machines once all expected Machines are terminal.
@@ -737,7 +735,7 @@ class AKSMachineClient(AKSClient):
         """
         if not expected_names:
             return []
-        machines = self._list_machines(cluster_name, agentpool_name)
+        machines = self._list_machines(cluster_name, agent_pool_name)
         machines_by_name = {
             machine.get("name"): machine
             for machine in machines
@@ -882,7 +880,7 @@ class AKSMachineClient(AKSClient):
         url = (
             f"{_ARM_BASE}/subscriptions/{sub}/resourceGroups/{request.resource_group}"
             f"/providers/Microsoft.ContainerService/managedClusters/{request.cluster_name}"
-            f"/agentPools/{request.agentpool_name}/machines/{first_machine_name}"
+            f"/agentPools/{request.agent_pool_name}/machines/{first_machine_name}"
             f"?api-version={_MACHINE_API_VERSION}"
         )
         body: Dict[str, Any] = {"properties": {"hardware": {"vmSize": request.vm_size}}}

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -56,8 +56,8 @@ _PER_REQUEST_TIMEOUT_CAP = 60
 _BATCH_429_MAX_RETRIES = 5
 _BATCH_429_INITIAL_BACKOFF_SECONDS = 1.0
 _BATCH_MAX_MACHINES_PER_REQUEST = 50
-_MACHINE_TERMINAL_STATES = {"Succeeded", "Failed", "Canceled", "Cancelled"}
-_MACHINE_FAILURE_STATES = {"Failed", "Canceled", "Cancelled"}
+_MACHINE_TERMINAL_STATES = {"Succeeded", "Failed", "Canceled"}
+_MACHINE_FAILURE_STATES = {"Failed", "Canceled"}
 _MACHINE_FAILURE_DETAIL_LIMIT = 10
 _LIST_MACHINES_PAGE_LIMIT = 50
 _MACHINE_FAILURE_CHECK_INTERVAL_SECONDS = 30
@@ -73,6 +73,22 @@ _NODE_READINESS_POLL_INTERVAL_SECONDS = 2
 # (50 individual workers, 10 batch workers) with comfortable headroom and
 # stays well below ARM's per-client connection ceilings.
 _HTTPS_POOL_SIZE = 64
+
+
+class MachineProvisioningFailed(RuntimeError):
+    """Terminal Machine failure with readiness metadata captured before failure."""
+    def __init__(
+        self,
+        agentpool_name: str,
+        failed_machines: List[Dict[str, Any]],
+        readiness_envelope: Dict[str, Dict[str, Any]],
+    ):
+        super().__init__(
+            f"machine provisioning failed in agentpool {agentpool_name}: "
+            f"failed_machines={failed_machines}"
+        )
+        self.failed_machines = failed_machines
+        self.readiness_envelope = readiness_envelope
 
 
 class AKSMachineClient(AKSClient):
@@ -258,7 +274,6 @@ class AKSMachineClient(AKSClient):
         logger.error(f"agentpool provisioning timed out after {timeout}s")
         return False
 
-    # ---- Machine API: node readiness ----
     def _wait_for_machine_node_readiness(
         self,
         agentpool_name: str,
@@ -271,29 +286,17 @@ class AKSMachineClient(AKSClient):
         """Wait for ``expected_count`` NEW Ready nodes; return nested percentile dict.
 
         AKS Machine ARM resource names (e.g. ``scale100-machine-1``) are NOT the
-        same as the underlying k8s Node names (``aks-<pool>-<rand>-vmss<i>``), so
-        we cannot look up Nodes by Machine name. Instead we poll Nodes labelled
-        ``agentpool=<pool>`` and record the wall-clock elapsed when each percentile
-        ready threshold is hit.
-
-        ``baseline_count`` is the number of Ready+labeled nodes that already
-        existed BEFORE scale_machine ran. Percentile targets are computed against
-        ``baseline_count + expected_count`` and clamped to ``> baseline_count``
-        so a target never fires on pre-existing nodes alone. Without this, an
-        agentpool that already has 1 Ready node and is being scaled by 1 more
-        would report P50/P70/P90/P99/P100 = ~0.7s (the first poll) even though the
-        new node had not yet provisioned.
+        same as underlying k8s Node names, so readiness is measured from Nodes
+        labelled ``agentpool=<pool>``. Percentile targets are computed against
+        ``baseline_count + expected_count`` and clamped above ``baseline_count``
+        so pre-existing Ready nodes never satisfy a new-node threshold.
 
         ``timeout`` is wall-clock seconds from invocation. Returns the nested
         empty-state envelope (``elapsed_time_seconds=None``, ``success=False``)
         if ``k8s_client`` is unavailable, ``expected_count`` <= 0, or no
-        percentile target is met within ``timeout``. Kubernetes polling
-        exceptions are logged and treated as 0 ready this tick. Raises only if
-        every expected Machine is terminal and at least one failed.
+        percentile target is met within ``timeout``. Raises only after every
+        expected Machine is terminal and at least one failed.
         """
-        # Empty-state envelope: nested dict per P-key with
-        # `target_nodes`, `elapsed_time_seconds`, `percentage`, `success` so
-        # the Kusto schema sees consistent shape regardless of outcome.
         empty_envelope: Dict[str, Dict[str, Any]] = {
             f"P{p}": {
                 "target_nodes": 0,
@@ -321,7 +324,7 @@ class AKSMachineClient(AKSClient):
             p: max(baseline_count + 1, math.ceil((p / 100.0) * target_total))
             for p in (50, 70, 90, 99, 100)
         }
-        elapsed: Dict[int, float] = {}
+        readiness_times: Dict[int, float] = {}
         start = time.time()
         deadline = start + timeout
         next_machine_failure_check_at: Optional[float] = (
@@ -332,35 +335,35 @@ class AKSMachineClient(AKSClient):
             f"targets {targets}, baseline={baseline_count}, expected={expected_count}, "
             f"timeout {timeout}s"
         )
-        while time.time() < deadline and len(elapsed) < len(targets):
+        while time.time() < deadline and len(readiness_times) < len(targets):
             (
                 ready,
                 failed_machines_result,
                 next_machine_failure_check_at,
             ) = self._get_readiness_poll_results(
-                kc=kc,
                 label_selector=label_selector,
                 cluster_name=cluster_name,
                 agentpool_name=agentpool_name,
                 expected_machine_names=expected_machine_names,
                 next_machine_failure_check_at=next_machine_failure_check_at,
             )
-            # Once Machine provisioning is terminal-failed, waiting for node
-            # readiness can only end in a less useful P100 timeout.
+            # Once all expected Machines are terminal, no more requested nodes
+            # can join. Preserve lower-percentile timings before failing.
             if failed_machines_result:
-                raise RuntimeError(
-                    f"machine provisioning failed in agentpool {agentpool_name}: "
-                    f"failed_machines={failed_machines_result}"
+                raise MachineProvisioningFailed(
+                    agentpool_name=agentpool_name,
+                    failed_machines=failed_machines_result,
+                    readiness_envelope=self._build_readiness_envelope(targets, readiness_times),
                 )
             now_elapsed = time.time() - start
             for p, target in targets.items():
-                if p not in elapsed and ready >= target:
-                    elapsed[p] = now_elapsed
+                if p not in readiness_times and ready >= target:
+                    readiness_times[p] = now_elapsed
                     logger.info(
                         f"P{p} hit: {ready}/{target_total} ready "
                         f"(target={target}, baseline={baseline_count}) at {now_elapsed:.2f}s"
                     )
-            if len(elapsed) < len(targets):
+            if len(readiness_times) < len(targets):
                 now = time.time()
                 # Wake for the next node poll, next ListMachines check, or
                 # overall timeout, whichever comes first.
@@ -373,56 +376,58 @@ class AKSMachineClient(AKSClient):
                 sleep_seconds = max(0.0, next_wake_at - now)
                 if sleep_seconds > 0:
                     time.sleep(sleep_seconds)
-        if not elapsed:
+        result = self._build_readiness_envelope(targets, readiness_times)
+        if not readiness_times:
             logger.warning(
                 f"No percentile target met within {timeout}s for agentpool {agentpool_name}"
             )
-            return {
-                f"P{p}": {
-                    "target_nodes": targets[p],
-                    "elapsed_time_seconds": None,
-                    "percentage": p,
-                    "success": False,
-                }
-                for p in (50, 70, 90, 99, 100)
-            }
-        result: Dict[str, Dict[str, Any]] = {
-            f"P{p}": {
-                "target_nodes": targets[p],
-                "elapsed_time_seconds": elapsed.get(p),
-                "percentage": p,
-                "success": p in elapsed,
-            }
-            for p in (50, 70, 90, 99, 100)
-        }
+            return result
         # Log percentile summary including P100, which is the wall-clock
         # elapsed until ALL target nodes are Ready.
         logger.info(f"Node Readiness Percentile Summary for agentpool {agentpool_name}:")
         for p in (50, 70, 90, 99, 100):
-            if p in elapsed:
-                logger.info(f"  P{p} (target={targets[p]} nodes): {elapsed[p]:.2f} seconds")
+            if p in readiness_times:
+                logger.info(
+                    f"  P{p} (target={targets[p]} nodes): "
+                    f"{readiness_times[p]:.2f} seconds"
+                )
             else:
                 logger.info(f"  P{p} (target={targets[p]} nodes): TIMEOUT")
-        max_elapsed = max(elapsed.values())
-        if len(elapsed) == len(targets):
+        max_elapsed = max(readiness_times.values())
+        if len(readiness_times) == len(targets):
             logger.info(
                 f"All target nodes became ready in {max_elapsed:.2f} seconds "
                 f"in agent pool {agentpool_name}"
             )
         else:
-            missed = [f"P{p}" for p in (50, 70, 90, 99, 100) if p not in elapsed]
+            missed = [f"P{p}" for p in (50, 70, 90, 99, 100) if p not in readiness_times]
             logger.warning(
                 f"Partial readiness in agent pool {agentpool_name}: "
-                f"{len(elapsed)}/{len(targets)} percentiles met within "
+                f"{len(readiness_times)}/{len(targets)} percentiles met within "
                 f"{timeout}s; missed {missed}; last successful percentile at "
                 f"{max_elapsed:.2f}s"
             )
         logger.info(f"Percentile node readiness data: {json.dumps(result, indent=2)}")
         return result
 
+    @staticmethod
+    def _build_readiness_envelope(
+        targets: Dict[int, int],
+        readiness_times: Dict[int, float],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Build the upload-safe readiness metadata envelope."""
+        return {
+            f"P{p}": {
+                "target_nodes": targets[p],
+                "elapsed_time_seconds": readiness_times.get(p),
+                "percentage": p,
+                "success": p in readiness_times,
+            }
+            for p in (50, 70, 90, 99, 100)
+        }
+
     def _get_readiness_poll_results(
         self,
-        kc: Any,
         label_selector: str,
         cluster_name: Optional[str],
         agentpool_name: str,
@@ -439,7 +444,7 @@ class AKSMachineClient(AKSClient):
         max_workers = 2 if check_machine_failures else 1
         with ThreadPoolExecutor(max_workers=max_workers) as ex:
             ready_nodes = ex.submit(
-                kc.get_ready_nodes,
+                self.k8s_client.get_ready_nodes,
                 label_selector=label_selector,
             )
             if check_machine_failures and cluster_name and expected_machine_names:
@@ -455,12 +460,12 @@ class AKSMachineClient(AKSClient):
         try:
             ready_nodes_result = ready_nodes.result()
         except Exception as e:
-            logger.warning(f"get_ready_nodes({label_selector}) failed: {e}")
+            logger.warning(f"get_ready_nodes({label_selector}) failed; treating as 0 ready: {e}")
         if failed_machines is not None:
             try:
                 failed_machines_result = failed_machines.result()
             except Exception as e:
-                logger.warning(f"get_machine_provisioning_failures failed: {e}")
+                logger.warning(f"get_machine_provisioning_failures failed; retrying on next cadence: {e}")
             next_machine_failure_check_at = (
                 time.time() + _MACHINE_FAILURE_CHECK_INTERVAL_SECONDS
             )
@@ -589,20 +594,28 @@ class AKSMachineClient(AKSClient):
                     f"{'Succeeded' if agentpool_ok else 'Failed/Timeout'}"
                 )
 
-                percentile_envelope = self._wait_for_machine_node_readiness(
-                    agentpool_name=agentpool_name,
-                    expected_count=len(successful),
-                    timeout=readiness_wait_timeout,
-                    baseline_count=baseline_count,
-                    cluster_name=cluster_name,
-                    expected_machine_names=set(names),
-                )
+                readiness_failure = None
+                try:
+                    percentile_envelope = self._wait_for_machine_node_readiness(
+                        agentpool_name=agentpool_name,
+                        expected_count=len(successful),
+                        timeout=readiness_wait_timeout,
+                        baseline_count=baseline_count,
+                        cluster_name=cluster_name,
+                        expected_machine_names=set(names),
+                    )
+                except MachineProvisioningFailed as exc:
+                    readiness_failure = exc
+                    percentile_envelope = exc.readiness_envelope
+                    op.add_metadata("failed_machines", exc.failed_machines)
                 op.add_metadata("percentile_node_readiness_times", percentile_envelope)
                 p100 = percentile_envelope.get("P100", {})
                 op.add_metadata(
                     "node_readiness_time", p100.get("elapsed_time_seconds") or 0.0
                 )
                 op.add_metadata("cluster_info", self.get_cluster_data(cluster_name))
+                if readiness_failure:
+                    raise readiness_failure
 
                 if not agentpool_ok:
                     raise RuntimeError(
@@ -736,7 +749,12 @@ class AKSMachineClient(AKSClient):
         agentpool_name: str,
         expected_names: Set[str],
     ) -> List[Dict[str, Any]]:
-        """Return failed Machines once all expected Machines are terminal."""
+        """Return failed Machines once all expected Machines are terminal.
+
+        We intentionally do not return on the first failed Machine. Successful
+        subsets can still contribute P50/P70/P90 readiness timings before the
+        operation is marked failed.
+        """
         if not expected_names:
             return []
         machines = self._list_machines(cluster_name, agentpool_name)
@@ -751,6 +769,9 @@ class AKSMachineClient(AKSClient):
             name: machines_by_name[name].get("properties", {}).get("provisioningState")
             for name in expected_names
         }
+        # A failed Machine can never become a Ready node, but other Machines may
+        # still join and improve lower-percentile readiness telemetry. Wait for
+        # the full expected set to become terminal before returning failures.
         if not all(state in _MACHINE_TERMINAL_STATES for state in states.values()):
             return []
         failed_names = [

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -21,7 +21,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -103,6 +103,8 @@ class AKSMachineClient(AKSClient):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if self.k8s_client is None:
+            raise RuntimeError("k8s_client is required by AKSMachineClient")
         self._token_cache_value: Optional[str] = None
         self._token_cache_expiry: float = 0.0  # unix epoch seconds
         self._token_lock = threading.Lock()
@@ -291,11 +293,15 @@ class AKSMachineClient(AKSClient):
         ``baseline_count + expected_count`` and clamped above ``baseline_count``
         so pre-existing Ready nodes never satisfy a new-node threshold.
 
+        ``cluster_name`` and ``expected_machine_names`` enable the periodic
+        ListMachines terminal-failure check. If either is omitted, the helper
+        preserves the node-readiness-only behavior and skips ARM failure polling.
+
         ``timeout`` is wall-clock seconds from invocation. Returns the nested
         empty-state envelope (``elapsed_time_seconds=None``, ``success=False``)
-        if ``k8s_client`` is unavailable, ``expected_count`` <= 0, or no
-        percentile target is met within ``timeout``. Raises only after every
-        expected Machine is terminal and at least one failed.
+        if ``expected_count`` <= 0 or no percentile target is met within
+        ``timeout``. Raises only after every expected Machine is terminal and at
+        least one failed.
         """
         empty_envelope: Dict[str, Dict[str, Any]] = {
             f"P{p}": {
@@ -306,12 +312,6 @@ class AKSMachineClient(AKSClient):
             }
             for p in (50, 70, 90, 99, 100)
         }
-        kc = self.k8s_client
-        if kc is None:
-            logger.error(
-                "k8s_client is None on AKSClient; cannot wait for machine readiness"
-            )
-            return empty_envelope
         if expected_count <= 0:
             return empty_envelope
         label_selector = f"agentpool={agentpool_name}"
@@ -336,17 +336,35 @@ class AKSMachineClient(AKSClient):
             f"timeout {timeout}s"
         )
         while time.time() < deadline and len(readiness_times) < len(targets):
-            (
-                ready,
-                failed_machines_result,
-                next_machine_failure_check_at,
-            ) = self._get_readiness_poll_results(
-                label_selector=label_selector,
-                cluster_name=cluster_name,
-                agentpool_name=agentpool_name,
-                expected_machine_names=expected_machine_names,
-                next_machine_failure_check_at=next_machine_failure_check_at,
+            failed_machines = None
+            should_check_machines = (
+                next_machine_failure_check_at is not None
+                and time.time() >= next_machine_failure_check_at
             )
+            max_workers = 2 if should_check_machines else 1
+            with ThreadPoolExecutor(max_workers=max_workers) as ex:
+                ready_nodes = ex.submit(self._get_ready_node_count, label_selector)
+                if should_check_machines and cluster_name and expected_machine_names:
+                    failed_machines = ex.submit(
+                        self._get_terminal_machine_provisioning_failures,
+                        cluster_name=cluster_name,
+                        agentpool_name=agentpool_name,
+                        expected_names=expected_machine_names,
+                    )
+
+            ready = ready_nodes.result()
+            failed_machines_result: List[Dict[str, Any]] = []
+            if failed_machines is not None:
+                try:
+                    failed_machines_result = failed_machines.result()
+                except Exception as e:
+                    logger.warning(
+                        "get_machine_provisioning_failures failed; "
+                        f"retrying on next cadence: {e}"
+                    )
+                next_machine_failure_check_at = (
+                    time.time() + _MACHINE_FAILURE_CHECK_INTERVAL_SECONDS
+                )
             # Once all expected Machines are terminal, no more requested nodes
             # can join. Preserve lower-percentile timings before failing.
             if failed_machines_result:
@@ -426,50 +444,14 @@ class AKSMachineClient(AKSClient):
             for p in (50, 70, 90, 99, 100)
         }
 
-    def _get_readiness_poll_results(
-        self,
-        label_selector: str,
-        cluster_name: Optional[str],
-        agentpool_name: str,
-        expected_machine_names: Optional[Set[str]],
-        next_machine_failure_check_at: Optional[float],
-    ) -> Tuple[int, List[Dict[str, Any]], Optional[float]]:
-        """Poll ready nodes and due Machine provisioning failures concurrently."""
-        now = time.time()
-        check_machine_failures = (
-            next_machine_failure_check_at is not None
-            and now >= next_machine_failure_check_at
-        )
-        failed_machines = None
-        max_workers = 2 if check_machine_failures else 1
-        with ThreadPoolExecutor(max_workers=max_workers) as ex:
-            ready_nodes = ex.submit(
-                self.k8s_client.get_ready_nodes,
-                label_selector=label_selector,
-            )
-            if check_machine_failures and cluster_name and expected_machine_names:
-                failed_machines = ex.submit(
-                    self._get_machine_provisioning_failures,
-                    cluster_name=cluster_name,
-                    agentpool_name=agentpool_name,
-                    expected_names=expected_machine_names,
-                )
-
-        ready_nodes_result = []
-        failed_machines_result: List[Dict[str, Any]] = []
+    def _get_ready_node_count(self, label_selector: str) -> int:
+        """Return Ready node count for the pool, treating transient list failures as 0."""
         try:
-            ready_nodes_result = ready_nodes.result()
+            ready_nodes = self.k8s_client.get_ready_nodes(label_selector=label_selector)
         except Exception as e:
             logger.warning(f"get_ready_nodes({label_selector}) failed; treating as 0 ready: {e}")
-        if failed_machines is not None:
-            try:
-                failed_machines_result = failed_machines.result()
-            except Exception as e:
-                logger.warning(f"get_machine_provisioning_failures failed; retrying on next cadence: {e}")
-            next_machine_failure_check_at = (
-                time.time() + _MACHINE_FAILURE_CHECK_INTERVAL_SECONDS
-            )
-        return len(ready_nodes_result), failed_machines_result, next_machine_failure_check_at
+            return 0
+        return len(ready_nodes)
 
     # ---- Machine API: scale path ----
     def scale_machine(
@@ -541,22 +523,20 @@ class AKSMachineClient(AKSClient):
             try:
                 # Snapshot baseline BEFORE any PUTs so the readiness watcher
                 # counts only NEW nodes.
-                kc = self.k8s_client
                 baseline_count = 0
-                if kc is not None:
-                    try:
-                        baseline_count = len(
-                            kc.get_ready_nodes(
-                                label_selector=f"agentpool={agentpool_name}"
-                            )
+                try:
+                    baseline_count = len(
+                        self.k8s_client.get_ready_nodes(
+                            label_selector=f"agentpool={agentpool_name}"
                         )
-                        logger.info(
-                            f"baseline ready nodes in agentpool {agentpool_name}: {baseline_count}"
-                        )
-                    except Exception:
-                        logger.warning(
-                            "baseline node snapshot failed; readiness count may be inflated"
-                        )
+                    )
+                    logger.info(
+                        f"baseline ready nodes in agentpool {agentpool_name}: {baseline_count}"
+                    )
+                except Exception:
+                    logger.warning(
+                        "baseline node snapshot failed; readiness count may be inflated"
+                    )
 
                 prefix = self._get_machine_name_prefix(scale_machine_count)
                 names = [
@@ -743,7 +723,7 @@ class AKSMachineClient(AKSClient):
             f"agentpool {agentpool_name}"
         )
 
-    def _get_machine_provisioning_failures(
+    def _get_terminal_machine_provisioning_failures(
         self,
         cluster_name: str,
         agentpool_name: str,

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -59,6 +59,8 @@ _BATCH_MAX_MACHINES_PER_REQUEST = 50
 _MACHINE_TERMINAL_STATES = {"Succeeded", "Failed", "Canceled"}
 _MACHINE_FAILURE_STATES = {"Failed", "Canceled"}
 _MACHINE_FAILURE_DETAIL_LIMIT = 10
+# ARM ListMachines returns up to 50 Machines per page. Following up to 50 pages
+# covers 2,500 Machines before failing the list operation.
 _LIST_MACHINES_MAX_PAGES = 50
 _MACHINE_FAILURE_CHECK_INTERVAL_SECONDS = 30
 _NODE_READINESS_POLL_INTERVAL_SECONDS = 2

--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -11,9 +11,8 @@ metadata is enriched with ``op.add_metadata`` along the way, success returns
 None, failures are logged and re-raised so ``OperationContext`` records them.
 ``MachineCRUD`` therefore stays a thin try/except wrapper.
 
-This revision adds the non-batch scale path. The batch dispatch
-(``use_batch_api=True``) still raises ``NotImplementedError`` and will land in a
-follow-up PR.
+The non-batch scale path PUTs machines one at a time. The batch dispatch
+(``use_batch_api=True``) uses the private ``BatchPutMachine`` header contract.
 """
 import json
 import logging
@@ -22,7 +21,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -56,6 +55,13 @@ _PER_REQUEST_TIMEOUT_CAP = 60
 # ballooning the chunk's wall-time.
 _BATCH_429_MAX_RETRIES = 5
 _BATCH_429_INITIAL_BACKOFF_SECONDS = 1.0
+_BATCH_MAX_MACHINES_PER_REQUEST = 50
+_MACHINE_TERMINAL_STATES = {"Succeeded", "Failed", "Canceled", "Cancelled"}
+_MACHINE_FAILURE_STATES = {"Failed", "Canceled", "Cancelled"}
+_MACHINE_FAILURE_DETAIL_LIMIT = 10
+_LIST_MACHINES_PAGE_LIMIT = 50
+_MACHINE_FAILURE_CHECK_INTERVAL_SECONDS = 30
+_NODE_READINESS_POLL_INTERVAL_SECONDS = 2
 # urllib3's default ``HTTPAdapter`` (mounted implicitly by ``requests.Session``)
 # caps each host's connection pool at ``pool_maxsize=10``. The parallel scale
 # paths fan out far beyond that (up to ``machine_workers`` concurrent PUTs
@@ -64,7 +70,7 @@ _BATCH_429_INITIAL_BACKOFF_SECONDS = 1.0
 # urllib3 to tear down and re-establish TLS for every excess request.
 # We mount an explicitly-sized adapter so the pool can retain one warm
 # connection per worker thread; 64 covers the current pipeline maxima
-# (50 individual workers, 4 batch workers) with comfortable headroom and
+# (50 individual workers, 10 batch workers) with comfortable headroom and
 # stays well below ARM's per-client connection ceilings.
 _HTTPS_POOL_SIZE = 64
 
@@ -259,6 +265,8 @@ class AKSMachineClient(AKSClient):
         expected_count: int,
         timeout: int,
         baseline_count: int = 0,
+        cluster_name: Optional[str] = None,
+        expected_machine_names: Optional[Set[str]] = None,
     ) -> Dict[str, Dict[str, Any]]:
         """Wait for ``expected_count`` NEW Ready nodes; return nested percentile dict.
 
@@ -279,8 +287,9 @@ class AKSMachineClient(AKSClient):
         ``timeout`` is wall-clock seconds from invocation. Returns the nested
         empty-state envelope (``elapsed_time_seconds=None``, ``success=False``)
         if ``k8s_client`` is unavailable, ``expected_count`` <= 0, or no
-        percentile target is met within ``timeout``. Polling exceptions are
-        logged and treated as 0 ready this tick. Never raises.
+        percentile target is met within ``timeout``. Kubernetes polling
+        exceptions are logged and treated as 0 ready this tick. Raises only if
+        every expected Machine is terminal and at least one failed.
         """
         # Empty-state envelope: nested dict per P-key with
         # `target_nodes`, `elapsed_time_seconds`, `percentage`, `success` so
@@ -315,17 +324,34 @@ class AKSMachineClient(AKSClient):
         elapsed: Dict[int, float] = {}
         start = time.time()
         deadline = start + timeout
+        next_machine_failure_check_at: Optional[float] = (
+            start if cluster_name and expected_machine_names else None
+        )
         logger.info(
             f"Waiting for nodes in agentpool {agentpool_name} (label {label_selector}) - "
             f"targets {targets}, baseline={baseline_count}, expected={expected_count}, "
             f"timeout {timeout}s"
         )
         while time.time() < deadline and len(elapsed) < len(targets):
-            try:
-                ready = len(kc.get_ready_nodes(label_selector=label_selector))
-            except Exception as e:
-                logger.warning(f"get_ready_nodes({label_selector}) failed: {e}")
-                ready = 0
+            (
+                ready,
+                failed_machines_result,
+                next_machine_failure_check_at,
+            ) = self._get_readiness_poll_results(
+                kc=kc,
+                label_selector=label_selector,
+                cluster_name=cluster_name,
+                agentpool_name=agentpool_name,
+                expected_machine_names=expected_machine_names,
+                next_machine_failure_check_at=next_machine_failure_check_at,
+            )
+            # Once Machine provisioning is terminal-failed, waiting for node
+            # readiness can only end in a less useful P100 timeout.
+            if failed_machines_result:
+                raise RuntimeError(
+                    f"machine provisioning failed in agentpool {agentpool_name}: "
+                    f"failed_machines={failed_machines_result}"
+                )
             now_elapsed = time.time() - start
             for p, target in targets.items():
                 if p not in elapsed and ready >= target:
@@ -335,7 +361,18 @@ class AKSMachineClient(AKSClient):
                         f"(target={target}, baseline={baseline_count}) at {now_elapsed:.2f}s"
                     )
             if len(elapsed) < len(targets):
-                time.sleep(2)
+                now = time.time()
+                # Wake for the next node poll, next ListMachines check, or
+                # overall timeout, whichever comes first.
+                next_wake_at = min(
+                    now + _NODE_READINESS_POLL_INTERVAL_SECONDS,
+                    deadline,
+                )
+                if next_machine_failure_check_at is not None:
+                    next_wake_at = min(next_wake_at, next_machine_failure_check_at)
+                sleep_seconds = max(0.0, next_wake_at - now)
+                if sleep_seconds > 0:
+                    time.sleep(sleep_seconds)
         if not elapsed:
             logger.warning(
                 f"No percentile target met within {timeout}s for agentpool {agentpool_name}"
@@ -382,6 +419,52 @@ class AKSMachineClient(AKSClient):
             )
         logger.info(f"Percentile node readiness data: {json.dumps(result, indent=2)}")
         return result
+
+    def _get_readiness_poll_results(
+        self,
+        kc: Any,
+        label_selector: str,
+        cluster_name: Optional[str],
+        agentpool_name: str,
+        expected_machine_names: Optional[Set[str]],
+        next_machine_failure_check_at: Optional[float],
+    ) -> Tuple[int, List[Dict[str, Any]], Optional[float]]:
+        """Poll ready nodes and due Machine provisioning failures concurrently."""
+        now = time.time()
+        check_machine_failures = (
+            next_machine_failure_check_at is not None
+            and now >= next_machine_failure_check_at
+        )
+        failed_machines = None
+        max_workers = 2 if check_machine_failures else 1
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            ready_nodes = ex.submit(
+                kc.get_ready_nodes,
+                label_selector=label_selector,
+            )
+            if check_machine_failures and cluster_name and expected_machine_names:
+                failed_machines = ex.submit(
+                    self._get_machine_provisioning_failures,
+                    cluster_name=cluster_name,
+                    agentpool_name=agentpool_name,
+                    expected_names=expected_machine_names,
+                )
+
+        ready_nodes_result = []
+        failed_machines_result: List[Dict[str, Any]] = []
+        try:
+            ready_nodes_result = ready_nodes.result()
+        except Exception as e:
+            logger.warning(f"get_ready_nodes({label_selector}) failed: {e}")
+        if failed_machines is not None:
+            try:
+                failed_machines_result = failed_machines.result()
+            except Exception as e:
+                logger.warning(f"get_machine_provisioning_failures failed: {e}")
+            next_machine_failure_check_at = (
+                time.time() + _MACHINE_FAILURE_CHECK_INTERVAL_SECONDS
+            )
+        return len(ready_nodes_result), failed_machines_result, next_machine_failure_check_at
 
     # ---- Machine API: scale path ----
     def scale_machine(
@@ -480,7 +563,7 @@ class AKSMachineClient(AKSClient):
                 else:
                     successful = self._scale_machine_individually(request, names)
                 op.add_metadata("command_execution_time", time.time() - command_t0)
-                op.add_metadata("successful_machines", successful)
+                op.add_metadata("successful_machines", len(successful))
 
                 # Fail fast on partial landing BEFORE waiting on the agentpool
                 # or readiness against a reduced count -- otherwise the recorded
@@ -511,6 +594,8 @@ class AKSMachineClient(AKSClient):
                     expected_count=len(successful),
                     timeout=readiness_wait_timeout,
                     baseline_count=baseline_count,
+                    cluster_name=cluster_name,
+                    expected_machine_names=set(names),
                 )
                 op.add_metadata("percentile_node_readiness_times", percentile_envelope)
                 p100 = percentile_envelope.get("P100", {})
@@ -607,6 +692,91 @@ class AKSMachineClient(AKSClient):
             return False
         return True
 
+    def _list_machines(
+        self,
+        cluster_name: str,
+        agentpool_name: str,
+        timeout: int = 30,
+    ) -> List[Dict[str, Any]]:
+        """List Machine resources for an agentpool, following ARM pagination."""
+        url = (
+            f"{_ARM_BASE}/subscriptions/{self.subscription_id}/resourceGroups/"
+            f"{self.resource_group}/providers/Microsoft.ContainerService/"
+            f"managedClusters/{cluster_name}/agentPools/{agentpool_name}/machines"
+            f"?api-version={_MACHINE_API_VERSION}"
+        )
+        machines: List[Dict[str, Any]] = []
+        for _ in range(_LIST_MACHINES_PAGE_LIMIT):
+            resp = self.make_request("GET", url, timeout=timeout)
+            if resp.status_code != 200:
+                raise RuntimeError(
+                    f"ListMachines failed for agentpool {agentpool_name}: "
+                    f"{resp.status_code} {resp.text[:500]}"
+                )
+            try:
+                body = resp.json()
+            except (ValueError, TypeError) as exc:
+                raise RuntimeError(
+                    f"ListMachines returned invalid JSON for agentpool "
+                    f"{agentpool_name}: {exc}"
+                ) from exc
+            machines.extend(body.get("value", []))
+            next_link = body.get("nextLink")
+            if not next_link:
+                return machines
+            url = next_link
+        raise RuntimeError(
+            f"ListMachines exceeded {_LIST_MACHINES_PAGE_LIMIT} pages for "
+            f"agentpool {agentpool_name}"
+        )
+
+    def _get_machine_provisioning_failures(
+        self,
+        cluster_name: str,
+        agentpool_name: str,
+        expected_names: Set[str],
+    ) -> List[Dict[str, Any]]:
+        """Return failed Machines once all expected Machines are terminal."""
+        if not expected_names:
+            return []
+        machines = self._list_machines(cluster_name, agentpool_name)
+        machines_by_name = {
+            machine.get("name"): machine
+            for machine in machines
+            if machine.get("name") in expected_names
+        }
+        if set(machines_by_name) != expected_names:
+            return []
+        states = {
+            name: machines_by_name[name].get("properties", {}).get("provisioningState")
+            for name in expected_names
+        }
+        if not all(state in _MACHINE_TERMINAL_STATES for state in states.values()):
+            return []
+        failed_names = [
+            name for name, state in states.items() if state in _MACHINE_FAILURE_STATES
+        ]
+        return [
+            self._get_machine_failure_detail(machines_by_name[name])
+            for name in sorted(failed_names)[:_MACHINE_FAILURE_DETAIL_LIMIT]
+        ]
+
+    @staticmethod
+    def _get_machine_failure_detail(machine: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract compact failure details from a Machine resource."""
+        properties = machine.get("properties", {})
+        status = properties.get("status", {})
+        provisioning_error = status.get("provisioningError") or {}
+        message = provisioning_error.get("message")
+        if isinstance(message, str):
+            message = message[:300]
+        return {
+            "name": machine.get("name"),
+            "provisioningState": properties.get("provisioningState"),
+            "error_code": provisioning_error.get("code"),
+            "error_message": message,
+        }
+
     # ---- Machine API: batch scale path ----
     def _scale_machine_batch(
         self,
@@ -615,14 +785,14 @@ class AKSMachineClient(AKSClient):
     ) -> List[str]:
         """Dispatch ``names`` across ``machine_workers`` worker slices via the Batch API.
 
-        Each worker submits exactly one ``BatchPutMachine``-headered PUT carrying a
-        contiguous slice of ``names``. Slices are computed by arithmetic from the
-        ``worker_id``.
+        Each worker submits exactly one ``BatchPutMachine``-headered PUT carrying
+        a contiguous slice of ``names``. Slices are computed by arithmetic from
+        the ``worker_id``.
 
-        ``scale_machine_count`` MUST be an exact multiple of ``machine_workers``;
-        ``ValueError`` is raised otherwise so the failure surfaces at the
-        ``MachineCRUD`` boundary instead of producing a short final chunk that
-        would skew per-chunk latency dashboards.
+        ``scale_machine_count`` MUST be an exact multiple of ``machine_workers``
+        and the resulting per-worker batch size MUST be no larger than
+        ``_BATCH_MAX_MACHINES_PER_REQUEST``. ``ValueError`` is raised otherwise
+        so the failure surfaces before any partial batch submission reaches ARM.
 
         Per-worker exceptions are caught and logged; the worker's slice is
         excluded from the returned ``successful`` list. The input ``request``
@@ -639,6 +809,12 @@ class AKSMachineClient(AKSClient):
                 f"got remainder {n % workers}"
             )
         per_worker = n // workers
+        if per_worker > _BATCH_MAX_MACHINES_PER_REQUEST:
+            raise ValueError(
+                f"calculated batch size ({per_worker}) exceeds "
+                f"BatchPutMachine limit ({_BATCH_MAX_MACHINES_PER_REQUEST}); "
+                f"increase machine_workers for scale_machine_count ({n})"
+            )
         successful: List[str] = []
 
         def run_worker(worker_id: int) -> List[str]:
@@ -694,6 +870,12 @@ class AKSMachineClient(AKSClient):
         """
         if not chunk:
             return []
+        if len(chunk) > _BATCH_MAX_MACHINES_PER_REQUEST:
+            raise ValueError(
+                f"BatchPutMachine supports at most "
+                f"{_BATCH_MAX_MACHINES_PER_REQUEST} machines per request; "
+                f"got {len(chunk)}"
+            )
         sub = self.subscription_id
         first_machine_name = chunk[0]
         url = (

--- a/modules/python/crud/azure/machine_crud.py
+++ b/modules/python/crud/azure/machine_crud.py
@@ -45,21 +45,21 @@ class MachineCRUD:
         self.result_dir = result_dir
         self.step_timeout = step_timeout
 
-    def create_machine_agentpool(self, agentpool_name, vm_size):
+    def create_machine_agentpool(self, agent_pool_name, vm_size):
         """Create a machine-mode agent pool. Returns True on success, False on failure."""
         try:
             self.aks_client.create_machine_agentpool(
-                agentpool_name=agentpool_name,
+                agent_pool_name=agent_pool_name,
                 vm_size=vm_size,
                 cluster_name=self.cluster_name,
                 timeout=self.step_timeout,
             )
             return True
         except Exception as e:
-            logger.error(f"create_machine_agentpool failed for {agentpool_name}: {e}")
+            logger.error(f"create_machine_agentpool failed for {agent_pool_name}: {e}")
             return False
 
-    def scale_machine(self, agentpool_name, vm_size, scale_machine_count,
+    def scale_machine(self, agent_pool_name, vm_size, scale_machine_count,
                       use_batch_api=False, machine_workers=1,
                       readiness_wait_timeout=1200, tags=None):
         """Scale a machine-mode agent pool by ``scale_machine_count`` machines.
@@ -70,7 +70,7 @@ class MachineCRUD:
         """
         try:
             self.aks_client.scale_machine(
-                agentpool_name=agentpool_name,
+                agent_pool_name=agent_pool_name,
                 vm_size=vm_size,
                 scale_machine_count=scale_machine_count,
                 cluster_name=self.cluster_name,
@@ -82,5 +82,5 @@ class MachineCRUD:
             )
             return True
         except Exception as e:
-            logger.error(f"scale_machine failed for {agentpool_name}: {e}")
+            logger.error(f"scale_machine failed for {agent_pool_name}: {e}")
             return False

--- a/modules/python/crud/main.py
+++ b/modules/python/crud/main.py
@@ -261,7 +261,7 @@ def handle_machine_operation(machine_crud, args):
     try:
         if command == "create-machine":
             create_kwargs = {
-                "agentpool_name": args.node_pool_name,
+                "agent_pool_name": args.node_pool_name,
                 "vm_size": args.vm_size,
             }
 
@@ -276,7 +276,7 @@ def handle_machine_operation(machine_crud, args):
                     logger.warning(f"Failed to parse --tags {args.tags!r} as JSON: {e}")
 
             scale_kwargs = {
-                "agentpool_name": args.node_pool_name,
+                "agent_pool_name": args.node_pool_name,
                 "vm_size": args.vm_size,
                 "scale_machine_count": args.scale_machine_count,
                 "use_batch_api": args.use_batch_api,

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -39,12 +39,12 @@ class TestAKSMachineClient(unittest.TestCase):
 
         self.cs_client_patcher.start()
         self.mi_cred_patcher.start()
-        mock_k8s_class = self.k8s_client_patcher.start()
+        self.mock_k8s_class = self.k8s_client_patcher.start()
         mock_get_operation_context = self.operation_context_getter_patcher.start()
         self.mock_operation_context = mock.MagicMock()
         mock_get_operation_context.return_value = self.mock_operation_context
 
-        self.mock_k8s = mock_k8s_class.return_value
+        self.mock_k8s = self.mock_k8s_class.return_value
         self.mock_operation = mock.MagicMock()
         self.mock_operation_context.return_value.__enter__.return_value = (
             self.mock_operation
@@ -430,7 +430,7 @@ class TestAKSMachineClient(unittest.TestCase):
         with mock.patch.object(
             AKSMachineClient, "_list_machines", return_value=machines
         ):
-            failures = self.client._get_machine_provisioning_failures(
+            failures = self.client._get_terminal_machine_provisioning_failures(
                 cluster_name="fake-cluster",
                 agentpool_name="apool",
                 expected_names={"scale2-machine-1", "scale2-machine-2"},
@@ -453,7 +453,7 @@ class TestAKSMachineClient(unittest.TestCase):
         with mock.patch.object(
             AKSMachineClient, "_list_machines", return_value=machines
         ):
-            failures = self.client._get_machine_provisioning_failures(
+            failures = self.client._get_terminal_machine_provisioning_failures(
                 cluster_name="fake-cluster",
                 agentpool_name="apool",
                 expected_names={"scale2-machine-1", "scale2-machine-2"},
@@ -462,7 +462,7 @@ class TestAKSMachineClient(unittest.TestCase):
         with mock.patch.object(
             AKSMachineClient, "_list_machines", return_value=machines[:1]
         ):
-            failures = self.client._get_machine_provisioning_failures(
+            failures = self.client._get_terminal_machine_provisioning_failures(
                 cluster_name="fake-cluster",
                 agentpool_name="apool",
                 expected_names={"scale2-machine-1", "scale2-machine-2"},
@@ -632,18 +632,16 @@ class TestAKSMachineClient(unittest.TestCase):
             self.assertEqual(env[f"P{p}"]["target_nodes"], 0)
         self.mock_k8s.get_ready_nodes.assert_not_called()
 
-    def test_wait_readiness_no_k8s_client_short_circuits(self):
-        """k8s_client is None -> empty envelope, no polling."""
-        self.client.k8s_client = None
-        env = self.client._wait_for_machine_node_readiness(
-            agentpool_name="apool",
-            expected_count=5,
-            timeout=600,
-            baseline_count=0,
-        )
-        for p in (50, 70, 90, 99, 100):
-            self.assertFalse(env[f"P{p}"]["success"])
-            self.assertEqual(env[f"P{p}"]["target_nodes"], 0)
+    def test_init_requires_k8s_client(self):
+        """Parent init may leave k8s_client unset; AKSMachineClient fails early."""
+        self.mock_k8s_class.side_effect = RuntimeError("kubeconfig missing")
+        with self.assertRaisesRegex(RuntimeError, "k8s_client is required"):
+            AKSMachineClient(
+                subscription_id="fake-sub",
+                resource_group="fake-rg",
+                use_managed_identity=True,
+                result_dir=self.test_result_dir,
+            )
 
     def test_wait_readiness_propagates_terminal_machine_failures(self):
         """Terminal Machine failures are checked in the same tick as ListNodes."""
@@ -651,7 +649,7 @@ class TestAKSMachineClient(unittest.TestCase):
         self.mock_k8s.get_ready_nodes.return_value = []
         with mock.patch.object(
             AKSMachineClient,
-            "_get_machine_provisioning_failures",
+            "_get_terminal_machine_provisioning_failures",
             return_value=[{"name": "m1"}],
         ) as mock_check, mock.patch(
             "clients.aks_machine_client.time.time",
@@ -691,7 +689,7 @@ class TestAKSMachineClient(unittest.TestCase):
         self.mock_k8s.get_ready_nodes.return_value = []
         with mock.patch.object(
             AKSMachineClient,
-            "_get_machine_provisioning_failures",
+            "_get_terminal_machine_provisioning_failures",
             return_value=[],
         ) as mock_check, mock.patch(
             "clients.aks_machine_client.time.time",

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -7,10 +7,7 @@ result file via ``Operation.save_to_file`` on context exit. Tests verify:
   the right keys
 - failure path raises (so the OperationContext records ``success=False``)
 
-This revision adds tests for both scale paths (non-batch individual PUTs and
-the BatchPutMachine-headered chunked path) plus the batch-path helpers
-``_scale_machine_batch``, ``_create_batch_machines``, and
-``_make_batch_request``.
+Tests also cover both scale paths and the batch-path helpers.
 """
 # pylint: disable=protected-access
 # Tests intentionally exercise private helpers directly; the leading underscore
@@ -21,7 +18,7 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
-from clients.aks_machine_client import AKSMachineClient
+from clients.aks_machine_client import AKSMachineClient, MachineProvisioningFailed
 
 
 class TestAKSMachineClient(unittest.TestCase):
@@ -660,7 +657,7 @@ class TestAKSMachineClient(unittest.TestCase):
             "clients.aks_machine_client.time.time",
             side_effect=lambda: next(ticks),
         ):
-            with self.assertRaisesRegex(RuntimeError, "machine provisioning failed"):
+            with self.assertRaises(MachineProvisioningFailed) as cm:
                 self.client._wait_for_machine_node_readiness(
                     agentpool_name="apool",
                     expected_count=1,
@@ -669,6 +666,9 @@ class TestAKSMachineClient(unittest.TestCase):
                     cluster_name="fake-cluster",
                     expected_machine_names={"m1"},
                 )
+        self.assertEqual(cm.exception.failed_machines, [{"name": "m1"}])
+        self.assertFalse(cm.exception.readiness_envelope["P50"]["success"])
+        self.assertFalse(cm.exception.readiness_envelope["P100"]["success"])
         mock_check.assert_called_once_with(
             cluster_name="fake-cluster",
             agentpool_name="apool",

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -184,6 +184,7 @@ class TestAKSMachineClient(unittest.TestCase):
             call.args[0] for call in self.mock_operation.add_metadata.call_args_list
         }
         self.assertIn("successful_machines", metadata_keys)
+        self.mock_operation.add_metadata.assert_any_call("successful_machines", 2)
         self.assertIn("percentile_node_readiness_times", metadata_keys)
         self.assertIn("node_readiness_time", metadata_keys)
         self.assertIn("cluster_info", metadata_keys)
@@ -216,12 +217,14 @@ class TestAKSMachineClient(unittest.TestCase):
         # have been reached.
         mock_wait_ap.assert_not_called()
         mock_wait_ready.assert_not_called()
-        # successful_machines metadata IS recorded so operators can see which
-        # PUTs landed; downstream readiness/cluster_info metadata is not.
+        # Machine names are intentionally not uploaded; only the successful count
+        # is recorded. Downstream readiness/cluster_info metadata is not recorded
+        # on partial landing.
         metadata_keys = {
             call.args[0] for call in self.mock_operation.add_metadata.call_args_list
         }
         self.assertIn("successful_machines", metadata_keys)
+        self.mock_operation.add_metadata.assert_any_call("successful_machines", 1)
         self.assertNotIn("percentile_node_readiness_times", metadata_keys)
         self.assertNotIn("node_readiness_time", metadata_keys)
         self.assertNotIn("cluster_info", metadata_keys)
@@ -256,6 +259,47 @@ class TestAKSMachineClient(unittest.TestCase):
         mock_wait_ready.assert_called_once()
         self.assertEqual(mock_wait_ready.call_args.kwargs["baseline_count"], 3)
         self.assertEqual(mock_wait_ready.call_args.kwargs["expected_count"], 1)
+
+    def test_scale_machine_consumes_timeout_budgets(self):
+        """scale_machine forwards the caller's timeout budgets to dispatch and waits."""
+        names = ["scale2-machine-1", "scale2-machine-2"]
+        readiness_envelope = {
+            f"P{p}": {
+                "target_nodes": 2,
+                "elapsed_time_seconds": 10.0,
+                "percentage": p,
+                "success": True,
+            }
+            for p in (50, 70, 90, 99, 100)
+        }
+        with mock.patch.object(
+            AKSMachineClient,
+            "_scale_machine_individually",
+            return_value=names,
+        ) as mock_individual, mock.patch.object(
+            AKSMachineClient,
+            "_wait_for_agentpool_provisioning",
+            return_value=True,
+        ) as mock_wait_ap, mock.patch.object(
+            AKSMachineClient,
+            "_wait_for_machine_node_readiness",
+            return_value=readiness_envelope,
+        ) as mock_wait_ready:
+            self.mock_k8s.get_ready_nodes.return_value = []
+
+            self.client.scale_machine(
+                agentpool_name="apool",
+                vm_size="Standard_D2_v3",
+                scale_machine_count=2,
+                timeout=900,
+                readiness_wait_timeout=900,
+            )
+
+        request = mock_individual.call_args.args[0]
+        self.assertEqual(request.timeout, 900)
+        self.assertEqual(request.readiness_wait_timeout, 900)
+        self.assertEqual(mock_wait_ap.call_args.args[1], 900)
+        self.assertEqual(mock_wait_ready.call_args.kwargs["timeout"], 900)
 
     def test_scale_machine_batch_path_dispatches_to_batch(self):
         """The use_batch_api=True branch calls _scale_machine_batch (not _individually)
@@ -311,13 +355,21 @@ class TestAKSMachineClient(unittest.TestCase):
             timeout=60,
         )
         for code in (200, 201, 202):
-            with self.subTest(status=code):
+            with self.subTest(code=code):
                 mock_resp = mock.MagicMock()
                 mock_resp.status_code = code
                 mock_make_request.return_value = mock_resp
                 self.assertTrue(
                     self.client._create_single_machine("m1", request)
                 )
+        call_args = mock_make_request.call_args
+        self.assertEqual(call_args.args[0], "PUT")
+        self.assertIn("/machines/m1?", call_args.args[1])
+        self.assertEqual(
+            call_args.kwargs["data"],
+            {"properties": {"hardware": {"vmSize": "Standard_D2_v3"}}},
+        )
+        self.assertEqual(call_args.kwargs["timeout"], 60)
 
     @mock.patch.object(AKSMachineClient, "make_request")
     def test_create_single_machine_non_2xx_returns_false(self, mock_make_request):
@@ -334,6 +386,91 @@ class TestAKSMachineClient(unittest.TestCase):
         mock_resp.text = "boom"
         mock_make_request.return_value = mock_resp
         self.assertFalse(self.client._create_single_machine("m1", request))
+
+    # ---- ListMachines terminal failure checks ----
+
+    @mock.patch.object(AKSMachineClient, "make_request")
+    def test_list_machines_follows_next_link(self, mock_make_request):
+        """ListMachines follows ARM nextLink pagination and aggregates values."""
+        first_resp = mock.MagicMock()
+        first_resp.status_code = 200
+        first_resp.json.return_value = {
+            "value": [{"name": "m1"}],
+            "nextLink": "https://management.azure.com/next-page",
+        }
+        second_resp = mock.MagicMock()
+        second_resp.status_code = 200
+        second_resp.json.return_value = {"value": [{"name": "m2"}]}
+        mock_make_request.side_effect = [first_resp, second_resp]
+
+        machines = self.client._list_machines("fake-cluster", "apool")
+
+        self.assertEqual(machines, [{"name": "m1"}, {"name": "m2"}])
+        self.assertEqual(mock_make_request.call_count, 2)
+        self.assertEqual(mock_make_request.call_args_list[1].args[1],
+                         "https://management.azure.com/next-page")
+
+    def test_machine_provisioning_failures_return_when_all_expected_terminal(self):
+        """Return failed Machines only after every expected Machine is terminal."""
+        machines = [
+            {
+                "name": "scale2-machine-1",
+                "properties": {"provisioningState": "Succeeded"},
+            },
+            {
+                "name": "scale2-machine-2",
+                "properties": {
+                    "provisioningState": "Failed",
+                    "status": {
+                        "provisioningError": {
+                            "code": "FailedToCreateOrUpdateVirtualMachineExtension",
+                            "message": "CSE failed with exit code 50",
+                        }
+                    },
+                },
+            },
+        ]
+        with mock.patch.object(
+            AKSMachineClient, "_list_machines", return_value=machines
+        ):
+            failures = self.client._get_machine_provisioning_failures(
+                cluster_name="fake-cluster",
+                agentpool_name="apool",
+                expected_names={"scale2-machine-1", "scale2-machine-2"},
+            )
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]["name"], "scale2-machine-2")
+
+    def test_terminal_machine_check_waits_for_missing_or_nonterminal_machines(self):
+        """Do not fail early until all expected Machines are present and terminal."""
+        machines = [
+            {
+                "name": "scale2-machine-1",
+                "properties": {"provisioningState": "Succeeded"},
+            },
+            {
+                "name": "scale2-machine-2",
+                "properties": {"provisioningState": "Creating"},
+            },
+        ]
+        with mock.patch.object(
+            AKSMachineClient, "_list_machines", return_value=machines
+        ):
+            failures = self.client._get_machine_provisioning_failures(
+                cluster_name="fake-cluster",
+                agentpool_name="apool",
+                expected_names={"scale2-machine-1", "scale2-machine-2"},
+            )
+        self.assertEqual(failures, [])
+        with mock.patch.object(
+            AKSMachineClient, "_list_machines", return_value=machines[:1]
+        ):
+            failures = self.client._get_machine_provisioning_failures(
+                cluster_name="fake-cluster",
+                agentpool_name="apool",
+                expected_names={"scale2-machine-1", "scale2-machine-2"},
+            )
+        self.assertEqual(failures, [])
 
     # ---- _wait_for_machine_node_readiness ----
 
@@ -443,21 +580,23 @@ class TestAKSMachineClient(unittest.TestCase):
         self.mock_k8s.get_ready_nodes.side_effect = lambda label_selector: next(
             ready_seq, [object()] * 2
         )
-        # The function calls time.time() ~3 times per loop iteration plus once
-        # for `start`. Provide a long monotonic sequence so P50 (target=2) is
-        # met while well under the 100s deadline, then jump past it.
-        ticks = itertools.chain(
-            iter([0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 200.0, 200.0]),
-            itertools.repeat(200.0),
-        )
-        with mock.patch("clients.aks_machine_client.time.sleep"), \
+        clock = {"now": 0.0}
+
+        def fake_time():
+            return clock["now"]
+
+        def fake_sleep(seconds):
+            clock["now"] += seconds
+
+        with mock.patch("clients.aks_machine_client.time.sleep",
+                        side_effect=fake_sleep), \
              mock.patch("clients.aks_machine_client.time.time",
-                        side_effect=lambda: next(ticks)), \
+                        side_effect=fake_time), \
              mock.patch("clients.aks_machine_client.logger") as mock_logger:
             env = self.client._wait_for_machine_node_readiness(
                 agentpool_name="apool",
                 expected_count=3,
-                timeout=100,
+                timeout=5,
                 baseline_count=0,
             )
         # P50 (target=2) was hit; P70/P90/P99/P100 (target=3) were not.
@@ -509,10 +648,77 @@ class TestAKSMachineClient(unittest.TestCase):
             self.assertFalse(env[f"P{p}"]["success"])
             self.assertEqual(env[f"P{p}"]["target_nodes"], 0)
 
+    def test_wait_readiness_propagates_terminal_machine_failures(self):
+        """Terminal Machine failures are checked in the same tick as ListNodes."""
+        ticks = itertools.chain(iter([0.0, 1.0, 1.0]), itertools.repeat(1.0))
+        self.mock_k8s.get_ready_nodes.return_value = []
+        with mock.patch.object(
+            AKSMachineClient,
+            "_get_machine_provisioning_failures",
+            return_value=[{"name": "m1"}],
+        ) as mock_check, mock.patch(
+            "clients.aks_machine_client.time.time",
+            side_effect=lambda: next(ticks),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "machine provisioning failed"):
+                self.client._wait_for_machine_node_readiness(
+                    agentpool_name="apool",
+                    expected_count=1,
+                    timeout=10,
+                    baseline_count=0,
+                    cluster_name="fake-cluster",
+                    expected_machine_names={"m1"},
+                )
+        mock_check.assert_called_once_with(
+            cluster_name="fake-cluster",
+            agentpool_name="apool",
+            expected_names={"m1"},
+        )
+        self.mock_k8s.get_ready_nodes.assert_called_once_with(
+            label_selector="agentpool=apool"
+        )
+
+    def test_wait_readiness_machine_failure_check_uses_bounded_cadence(self):
+        """ListMachines is not called on every 2s ListNodes poll."""
+        clock = {"now": 0.0}
+
+        def fake_time():
+            return clock["now"]
+
+        def fake_sleep(seconds):
+            clock["now"] += seconds
+
+        self.mock_k8s.get_ready_nodes.return_value = []
+        with mock.patch.object(
+            AKSMachineClient,
+            "_get_machine_provisioning_failures",
+            return_value=[],
+        ) as mock_check, mock.patch(
+            "clients.aks_machine_client.time.time",
+            side_effect=fake_time,
+        ), mock.patch(
+            "clients.aks_machine_client.time.sleep",
+            side_effect=fake_sleep,
+        ):
+            self.client._wait_for_machine_node_readiness(
+                agentpool_name="apool",
+                expected_count=1,
+                timeout=5,
+                baseline_count=0,
+                cluster_name="fake-cluster",
+                expected_machine_names={"m1"},
+            )
+        mock_check.assert_called_once_with(
+            cluster_name="fake-cluster",
+            agentpool_name="apool",
+            expected_names={"m1"},
+        )
+        self.assertGreater(self.mock_k8s.get_ready_nodes.call_count, 1)
+
     # ---- _scale_machine_batch ----
 
     def test_scale_machine_batch_partitions_and_aggregates(self):
-        """Names sharded across machine_workers; all successful slices aggregated."""
+        """Names sharded across workers; all successful slices aggregated."""
         request = SimpleNamespace(
             agentpool_name="apool",
             cluster_name="fake-cluster",
@@ -529,8 +735,11 @@ class TestAKSMachineClient(unittest.TestCase):
         ) as mock_create_batch:
             successful = self.client._scale_machine_batch(request, names)
         self.assertEqual(set(successful), set(names))
-        # 2 workers, each handling per_worker = 4 // 2 = 2 names
         self.assertEqual(mock_create_batch.call_count, 2)
+        chunk_lengths = [
+            len(call.args[1]) for call in mock_create_batch.call_args_list
+        ]
+        self.assertEqual(sorted(chunk_lengths), [2, 2])
 
     def test_scale_machine_batch_per_worker_failure_isolated(self):
         """One worker raising does not poison the other worker's success list."""
@@ -570,6 +779,60 @@ class TestAKSMachineClient(unittest.TestCase):
         names = ["m-1", "m-2", "m-3", "m-4"]  # 4 not divisible by 3
         with self.assertRaises(ValueError):
             self.client._scale_machine_batch(request, names)
+
+    def test_scale_machine_batch_rejects_non_positive_workers(self):
+        """machine_workers must be positive."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+            machine_workers=0,
+        )
+        with self.assertRaises(ValueError):
+            self.client._scale_machine_batch(request, ["m-1"])
+
+    def test_scale_machine_batch_rejects_calculated_batch_over_limit(self):
+        """Fail fast before ARM when calculated per-worker batch size exceeds 50."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+            machine_workers=10,
+        )
+        names = [f"m-{i}" for i in range(1, 1001)]
+        with mock.patch.object(
+            AKSMachineClient, "_create_batch_machines"
+        ) as mock_create_batch:
+            with self.assertRaisesRegex(ValueError, "calculated batch size"):
+                self.client._scale_machine_batch(request, names)
+        mock_create_batch.assert_not_called()
+
+    def test_scale_machine_batch_allows_calculated_batch_at_limit(self):
+        """A calculated per-worker batch size of exactly 50 is allowed."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+            machine_workers=20,
+        )
+        names = [f"m-{i}" for i in range(1, 1001)]
+        with mock.patch.object(
+            AKSMachineClient,
+            "_create_batch_machines",
+            side_effect=lambda req, chunk, worker_id: list(chunk),
+        ) as mock_create_batch:
+            successful = self.client._scale_machine_batch(request, names)
+        self.assertEqual(set(successful), set(names))
+        self.assertEqual(mock_create_batch.call_count, 20)
+        self.assertTrue(
+            all(len(call.args[1]) == 50 for call in mock_create_batch.call_args_list)
+        )
 
     # ---- _create_batch_machines ----
 
@@ -625,6 +888,23 @@ class TestAKSMachineClient(unittest.TestCase):
             parsed["batchMachines"],
             [{"machineName": "m-2"}, {"machineName": "m-3"}],
         )
+
+    def test_create_batch_machines_rejects_oversized_chunk(self):
+        """BatchPutMachine rejects more than 50 machines per request client-side."""
+        request = SimpleNamespace(
+            agentpool_name="apool",
+            cluster_name="fake-cluster",
+            resource_group="fake-rg",
+            vm_size="Standard_D2_v3",
+            timeout=60,
+        )
+        names = [f"m-{i}" for i in range(1, 52)]
+        with mock.patch.object(
+            AKSMachineClient, "_make_batch_request"
+        ) as mock_make_batch:
+            with self.assertRaises(ValueError):
+                self.client._create_batch_machines(request, names, chunk_idx=0)
+        mock_make_batch.assert_not_called()
 
     # ---- _make_batch_request ----
 

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -90,7 +90,7 @@ class TestAKSMachineClient(unittest.TestCase):
         mock_make_request.return_value = mock_resp
 
         self.client.create_machine_agentpool(
-            agentpool_name="apool", vm_size="Standard_D2_v3"
+            agent_pool_name="apool", vm_size="Standard_D2_v3"
         )
 
         mock_make_request.assert_called_once()
@@ -113,7 +113,7 @@ class TestAKSMachineClient(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             self.client.create_machine_agentpool(
-                agentpool_name="apool", vm_size="Standard_D2_v3"
+                agent_pool_name="apool", vm_size="Standard_D2_v3"
             )
 
     @mock.patch.object(AKSMachineClient, "_wait_for_agentpool_provisioning",
@@ -129,7 +129,7 @@ class TestAKSMachineClient(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             self.client.create_machine_agentpool(
-                agentpool_name="apool", vm_size="Standard_D2_v3"
+                agent_pool_name="apool", vm_size="Standard_D2_v3"
             )
 
     # ---- _get_machine_name_prefix ----
@@ -171,7 +171,7 @@ class TestAKSMachineClient(unittest.TestCase):
         self.mock_k8s.get_ready_nodes.return_value = []
 
         self.client.scale_machine(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             vm_size="Standard_D2_v3",
             scale_machine_count=2,
             machine_workers=2,
@@ -204,7 +204,7 @@ class TestAKSMachineClient(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             self.client.scale_machine(
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 vm_size="Standard_D2_v3",
                 scale_machine_count=2,
                 machine_workers=1,
@@ -247,7 +247,7 @@ class TestAKSMachineClient(unittest.TestCase):
         }
 
         self.client.scale_machine(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             vm_size="Standard_D2_v3",
             scale_machine_count=1,
             machine_workers=1,
@@ -285,7 +285,7 @@ class TestAKSMachineClient(unittest.TestCase):
             self.mock_k8s.get_ready_nodes.return_value = []
 
             self.client.scale_machine(
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 vm_size="Standard_D2_v3",
                 scale_machine_count=2,
                 timeout=900,
@@ -325,7 +325,7 @@ class TestAKSMachineClient(unittest.TestCase):
         ):
             self.mock_k8s.get_ready_nodes.return_value = []
             self.client.scale_machine(
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 vm_size="Standard_D2_v3",
                 scale_machine_count=2,
                 use_batch_api=True,
@@ -345,7 +345,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_create_single_machine_2xx_returns_true(self, mock_make_request):
         """Any 200/201/202 response counts as a successful PUT."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -372,7 +372,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_create_single_machine_non_2xx_returns_false(self, mock_make_request):
         """Non-2xx responses are logged and return False (never raise)."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -432,7 +432,7 @@ class TestAKSMachineClient(unittest.TestCase):
         ):
             failures = self.client._get_terminal_machine_provisioning_failures(
                 cluster_name="fake-cluster",
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 expected_names={"scale2-machine-1", "scale2-machine-2"},
             )
         self.assertEqual(len(failures), 1)
@@ -455,7 +455,7 @@ class TestAKSMachineClient(unittest.TestCase):
         ):
             failures = self.client._get_terminal_machine_provisioning_failures(
                 cluster_name="fake-cluster",
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 expected_names={"scale2-machine-1", "scale2-machine-2"},
             )
         self.assertEqual(failures, [])
@@ -464,7 +464,7 @@ class TestAKSMachineClient(unittest.TestCase):
         ):
             failures = self.client._get_terminal_machine_provisioning_failures(
                 cluster_name="fake-cluster",
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 expected_names={"scale2-machine-1", "scale2-machine-2"},
             )
         self.assertEqual(failures, [])
@@ -507,7 +507,7 @@ class TestAKSMachineClient(unittest.TestCase):
         with mock.patch("clients.aks_machine_client.time.sleep"), \
              mock.patch("clients.aks_machine_client.time.time", side_effect=fake_time):
             env = self.client._wait_for_machine_node_readiness(
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 expected_count=3,
                 timeout=600,
                 baseline_count=0,
@@ -532,7 +532,7 @@ class TestAKSMachineClient(unittest.TestCase):
         with mock.patch("clients.aks_machine_client.time.sleep"), \
              mock.patch("clients.aks_machine_client.time.time", side_effect=fake_time):
             env = self.client._wait_for_machine_node_readiness(
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 expected_count=1,
                 timeout=600,
                 baseline_count=10,
@@ -553,7 +553,7 @@ class TestAKSMachineClient(unittest.TestCase):
              mock.patch("clients.aks_machine_client.time.time",
                         side_effect=lambda: next(time_seq, 1000.0)):
             env = self.client._wait_for_machine_node_readiness(
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 expected_count=3,
                 timeout=10,
                 baseline_count=0,
@@ -591,7 +591,7 @@ class TestAKSMachineClient(unittest.TestCase):
                         side_effect=fake_time), \
              mock.patch("clients.aks_machine_client.logger") as mock_logger:
             env = self.client._wait_for_machine_node_readiness(
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 expected_count=3,
                 timeout=5,
                 baseline_count=0,
@@ -622,7 +622,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_wait_readiness_expected_count_zero_short_circuits(self):
         """expected_count<=0 -> empty envelope, no Kubernetes calls."""
         env = self.client._wait_for_machine_node_readiness(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             expected_count=0,
             timeout=600,
             baseline_count=0,
@@ -657,7 +657,7 @@ class TestAKSMachineClient(unittest.TestCase):
         ):
             with self.assertRaises(MachineProvisioningFailed) as cm:
                 self.client._wait_for_machine_node_readiness(
-                    agentpool_name="apool",
+                    agent_pool_name="apool",
                     expected_count=1,
                     timeout=10,
                     baseline_count=0,
@@ -669,7 +669,7 @@ class TestAKSMachineClient(unittest.TestCase):
         self.assertFalse(cm.exception.readiness_envelope["P100"]["success"])
         mock_check.assert_called_once_with(
             cluster_name="fake-cluster",
-            agentpool_name="apool",
+            agent_pool_name="apool",
             expected_names={"m1"},
         )
         self.mock_k8s.get_ready_nodes.assert_called_once_with(
@@ -699,7 +699,7 @@ class TestAKSMachineClient(unittest.TestCase):
             side_effect=fake_sleep,
         ):
             self.client._wait_for_machine_node_readiness(
-                agentpool_name="apool",
+                agent_pool_name="apool",
                 expected_count=1,
                 timeout=5,
                 baseline_count=0,
@@ -708,7 +708,7 @@ class TestAKSMachineClient(unittest.TestCase):
             )
         mock_check.assert_called_once_with(
             cluster_name="fake-cluster",
-            agentpool_name="apool",
+            agent_pool_name="apool",
             expected_names={"m1"},
         )
         self.assertGreater(self.mock_k8s.get_ready_nodes.call_count, 1)
@@ -718,7 +718,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_scale_machine_batch_partitions_and_aggregates(self):
         """Names sharded across workers; all successful slices aggregated."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -742,7 +742,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_scale_machine_batch_per_worker_failure_isolated(self):
         """One worker raising does not poison the other worker's success list."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -767,7 +767,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_scale_machine_batch_rejects_non_exact_multiple(self):
         """scale_machine_count must be an exact multiple of machine_workers."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -781,7 +781,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_scale_machine_batch_rejects_non_positive_workers(self):
         """machine_workers must be positive."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -794,7 +794,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_scale_machine_batch_rejects_calculated_batch_over_limit(self):
         """Fail fast before ARM when calculated per-worker batch size exceeds 50."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -812,7 +812,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_scale_machine_batch_allows_calculated_batch_at_limit(self):
         """A calculated per-worker batch size of exactly 50 is allowed."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -837,7 +837,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_create_batch_machines_empty_chunk_returns_empty(self):
         """Empty chunk -> early return, no HTTP call."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -854,7 +854,7 @@ class TestAKSMachineClient(unittest.TestCase):
         """BatchPutMachine header carries vmSkus envelope + batchMachines
         using machineName (NOT name) keys for the *additional* machines only."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",
@@ -890,7 +890,7 @@ class TestAKSMachineClient(unittest.TestCase):
     def test_create_batch_machines_rejects_oversized_chunk(self):
         """BatchPutMachine rejects more than 50 machines per request client-side."""
         request = SimpleNamespace(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             cluster_name="fake-cluster",
             resource_group="fake-rg",
             vm_size="Standard_D2_v3",

--- a/modules/python/tests/test_crud_main.py
+++ b/modules/python/tests/test_crud_main.py
@@ -51,7 +51,7 @@ class TestHandleMachineOperation(unittest.TestCase):
         crud.create_machine_agentpool.return_value = True
         self.assertEqual(handle_machine_operation(crud, self._make_args()), 0)
         crud.create_machine_agentpool.assert_called_once_with(
-            agentpool_name="apool", vm_size="Standard_D2_v3",
+            agent_pool_name="apool", vm_size="Standard_D2_v3",
         )
 
     def test_create_machine_false_returns_one(self):
@@ -69,7 +69,7 @@ class TestHandleMachineOperation(unittest.TestCase):
         )
         crud.scale_machine.assert_called_once()
         kwargs = crud.scale_machine.call_args.kwargs
-        self.assertEqual(kwargs["agentpool_name"], "apool")
+        self.assertEqual(kwargs["agent_pool_name"], "apool")
         self.assertEqual(kwargs["scale_machine_count"], 2)
 
     def test_scale_machine_unknown_command_returns_one(self):

--- a/modules/python/tests/test_machine_crud.py
+++ b/modules/python/tests/test_machine_crud.py
@@ -44,12 +44,12 @@ class TestMachineCRUD(unittest.TestCase):
         self.mock_client.create_machine_agentpool.return_value = True
 
         result = self.crud.create_machine_agentpool(
-            agentpool_name="apool", vm_size="Standard_D2_v3"
+            agent_pool_name="apool", vm_size="Standard_D2_v3"
         )
 
         self.assertTrue(result)
         self.mock_client.create_machine_agentpool.assert_called_once_with(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             vm_size="Standard_D2_v3",
             cluster_name="fake-cluster",
             timeout=900,
@@ -58,7 +58,7 @@ class TestMachineCRUD(unittest.TestCase):
     def test_create_machine_agentpool_swallows_exception(self):
         self.mock_client.create_machine_agentpool.side_effect = RuntimeError("boom")
         result = self.crud.create_machine_agentpool(
-            agentpool_name="apool", vm_size="Standard_D2_v3"
+            agent_pool_name="apool", vm_size="Standard_D2_v3"
         )
         self.assertFalse(result)
 
@@ -68,7 +68,7 @@ class TestMachineCRUD(unittest.TestCase):
         self.mock_client.scale_machine.return_value = True
 
         result = self.crud.scale_machine(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             vm_size="Standard_D2_v3",
             scale_machine_count=50,
             use_batch_api=True,
@@ -79,7 +79,7 @@ class TestMachineCRUD(unittest.TestCase):
 
         self.assertTrue(result)
         self.mock_client.scale_machine.assert_called_once_with(
-            agentpool_name="apool",
+            agent_pool_name="apool",
             vm_size="Standard_D2_v3",
             scale_machine_count=50,
             cluster_name="fake-cluster",
@@ -94,7 +94,7 @@ class TestMachineCRUD(unittest.TestCase):
         self.mock_client.scale_machine.return_value = True
 
         self.crud.scale_machine(
-            agentpool_name="apool", vm_size="Standard_D2_v3",
+            agent_pool_name="apool", vm_size="Standard_D2_v3",
             scale_machine_count=1,
         )
 
@@ -107,7 +107,7 @@ class TestMachineCRUD(unittest.TestCase):
     def test_scale_machine_swallows_exception(self):
         self.mock_client.scale_machine.side_effect = RuntimeError("boom")
         result = self.crud.scale_machine(
-            agentpool_name="apool", vm_size="Standard_D2_v3",
+            agent_pool_name="apool", vm_size="Standard_D2_v3",
             scale_machine_count=1,
         )
         self.assertFalse(result)


### PR DESCRIPTION
## Summary
- add ListMachines polling during machine readiness waits to fail early when expected machines terminally fail
- keep BatchPutMachine request sizing within the 50-machine service limit
- record successful_machines as a count instead of uploading machine names
- add focused unit coverage for timeout propagation, ListMachines pagination, terminal failure detection, and batch sizing

## Validation
- python3 -m pytest modules/python/tests/test_aks_machine_client.py modules/python/tests/test_machine_crud.py modules/python/tests/test_crud_main.py -q
- python3 -m py_compile modules/python/clients/aks_machine_client.py modules/python/tests/test_aks_machine_client.py
- PYTHONPATH=modules/python python3 -m pylint modules/python/tests/test_aks_machine_client.py modules/python/clients/aks_machine_client.py modules/python/crud/azure/machine_crud.py modules/python/crud/main.py
- git diff --check