### PR TITLE
Dipowell/node readiness timing

### DIFF
--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -119,8 +119,8 @@ class AKSClient:
                 k8s_status = f"FAILED: {k8s_result}" if k8s_failed else "succeeded"
                 elapsed = completion_time - start_time
                 logger.error(
-                    f"Concurrent operation failed after {elapsed:.2f}s - "
-                    f"ARM: {arm_status}, K8s readiness: {k8s_status}"
+                    "Concurrent operation failed after %.2fs - ARM: %s, K8s readiness: %s",
+                    elapsed, arm_status, k8s_status
                 )
                 # Raise the first exception encountered
                 if arm_failed:
@@ -412,25 +412,34 @@ class AKSClient:
                     f"Creating node pool {node_pool_name} in cluster {cluster_name}"
                 )
 
-                # Create the node pool
-                self.aks_client.agent_pools.begin_create_or_update(
-                    resource_group_name=self.resource_group,
-                    resource_name=cluster_name,
-                    agent_pool_name=node_pool_name,
-                    parameters=parameters,
-                ).result()
-
+                # Capture start time for timing measurements
+                start_time = time.time()
                 label_selector = f"agentpool={node_pool_name}"
 
-                # Wait for nodes to be ready
-                ready_nodes = self.k8s_client.wait_for_nodes_ready(
-                    node_count=node_count,
-                    operation_timeout_in_minutes=self.operation_timeout_minutes,
-                    label_selector=label_selector,
-                )
+                # Run ARM and K8s readiness concurrently to capture both timings
+                _, ready_nodes, node_readiness_time, command_execution_time = \
+                    self._run_concurrent_arm_and_readiness(
+                        self.aks_client.agent_pools.begin_create_or_update(
+                            resource_group_name=self.resource_group,
+                            resource_name=cluster_name,
+                            agent_pool_name=node_pool_name,
+                            parameters=parameters,
+                        ),
+                        node_count, label_selector, start_time
+                    )
 
                 logger.info(
                     f"All {node_count} nodes in pool {node_pool_name} are ready"
+                )
+
+                # Add timing metadata for regression analysis
+                op.add_metadata("node_readiness_time", node_readiness_time)
+                op.add_metadata("command_execution_time", command_execution_time)
+
+                # Log timing - analysis happens in ADX/dashboards
+                logger.info(
+                    "[%s] Timing: K8s nodes ready in %.2fs, ARM completed in %.2fs",
+                    node_pool_name, node_readiness_time, command_execution_time
                 )
 
                 # Verify NVIDIA drivers if this is a GPU node pool
@@ -554,27 +563,39 @@ class AKSClient:
                 node_pool.count = node_count
 
                 logger.info(f"Scaling node pool {node_pool_name} to {node_count} nodes")
-                self.aks_client.agent_pools.begin_create_or_update(
-                    resource_group_name=self.resource_group,
-                    resource_name=cluster_name,
-                    agent_pool_name=node_pool_name,
-                    parameters=node_pool,
-                ).result()
+
+                # Capture start time for timing measurements
+                start_time = time.time()
+                label_selector = f"agentpool={node_pool_name}"
 
                 logger.info(
                     f"Waiting for {node_count} nodes in pool {node_pool_name} to be ready..."
                 )
 
-                # Use agentpool=node_pool_name as default label if not specified
-                label_selector = f"agentpool={node_pool_name}"
+                # Run ARM and K8s readiness concurrently to capture both timings
+                _, ready_nodes, node_readiness_time, command_execution_time = \
+                    self._run_concurrent_arm_and_readiness(
+                        self.aks_client.agent_pools.begin_create_or_update(
+                            resource_group_name=self.resource_group,
+                            resource_name=cluster_name,
+                            agent_pool_name=node_pool_name,
+                            parameters=node_pool,
+                        ),
+                        node_count, label_selector, start_time
+                    )
 
-                ready_nodes = self.k8s_client.wait_for_nodes_ready(
-                    node_count=node_count,
-                    operation_timeout_in_minutes=self.operation_timeout_minutes,
-                    label_selector=label_selector,
-                )
                 logger.info(
                     f"All {node_count} nodes in pool {node_pool_name} are ready"
+                )
+
+                # Add timing metadata for regression analysis
+                op.add_metadata("node_readiness_time", node_readiness_time)
+                op.add_metadata("command_execution_time", command_execution_time)
+
+                # Log timing - analysis happens in ADX/dashboards
+                logger.info(
+                    "[%s] Timing: K8s nodes ready in %.2fs, ARM completed in %.2fs",
+                    node_pool_name, node_readiness_time, command_execution_time
                 )
 
                 pod_logs = None
@@ -766,22 +787,34 @@ class AKSClient:
                         "cluster_info", self.get_cluster_data(cluster_name)
                     )
                     node_pool.count = step  # Update node count in the node pool object
-                    result = self.aks_client.agent_pools.begin_create_or_update(
-                        resource_group_name=self.resource_group,
-                        resource_name=cluster_name,
-                        agent_pool_name=node_pool_name,
-                        parameters=node_pool,
-                    ).result()
 
-                    # Use agentpool=node_pool_name as default label if not specified
+                    # Capture start time for timing measurements
+                    start_time = time.time()
                     label_selector = f"agentpool={node_pool_name}"
 
-                    ready_nodes = self.k8s_client.wait_for_nodes_ready(
-                        node_count=step,
-                        operation_timeout_in_minutes=self.operation_timeout_minutes,
-                        label_selector=label_selector,
-                    )
+                    # Run ARM and K8s readiness concurrently to capture both timings
+                    result, ready_nodes, node_readiness_time, command_execution_time = \
+                        self._run_concurrent_arm_and_readiness(
+                            self.aks_client.agent_pools.begin_create_or_update(
+                                resource_group_name=self.resource_group,
+                                resource_name=cluster_name,
+                                agent_pool_name=node_pool_name,
+                                parameters=node_pool,
+                            ),
+                            step, label_selector, start_time
+                        )
+
                     logger.info(f"All {step} nodes in pool {node_pool_name} are ready")
+
+                    # Add timing metadata for regression analysis
+                    op.add_metadata("node_readiness_time", node_readiness_time)
+                    op.add_metadata("command_execution_time", command_execution_time)
+
+                    # Log timing - analysis happens in ADX/dashboards
+                    logger.info(
+                        "[%s] Timing: K8s nodes ready in %.2fs, ARM completed in %.2fs",
+                        node_pool_name, node_readiness_time, command_execution_time
+                    )
 
                     if result is None:
                         logger.error(f"Progressive scaling failed at step {step}")

--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -84,8 +84,7 @@ class AKSClient:
         Returns:
             Tuple of (arm_result, ready_nodes, node_readiness_time, command_execution_time)
             - node_readiness_time: seconds from start until K8s nodes were ready
-            - command_execution_time: seconds from start until both tasks complete
-              (i.e., the longer of ARM or K8s readiness)
+            - command_execution_time: seconds from start until ARM operation completed
 
         Raises:
             Exception: If either ARM or K8s readiness fails. Both tasks run to

--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -92,9 +92,14 @@ class AKSClient:
                 completion (or failure) so we can capture timing for whichever
                 succeeded, enabling better diagnosis of which layer caused the failure.
         """
+        def _poll_arm_with_timestamp():
+            """Run ARM poller and return (result, completion_timestamp)."""
+            result = poller.result()
+            return result, time.time()
+
         async def _run():
             # Run ARM polling and K8s readiness check concurrently
-            arm_task = asyncio.to_thread(poller.result)
+            arm_task = asyncio.to_thread(_poll_arm_with_timestamp)
             k8s_task = asyncio.to_thread(
                 self.k8s_client.wait_for_nodes_ready,
                 node_count=node_count,
@@ -107,8 +112,6 @@ class AKSClient:
             results = await asyncio.gather(arm_task, k8s_task, return_exceptions=True)
             arm_result, k8s_result = results
 
-            completion_time = time.time()
-
             # Check for failures and build diagnostic message
             arm_failed = isinstance(arm_result, Exception)
             k8s_failed = isinstance(k8s_result, Exception)
@@ -117,7 +120,7 @@ class AKSClient:
                 # Build diagnostic info for logging
                 arm_status = f"FAILED: {arm_result}" if arm_failed else "succeeded"
                 k8s_status = f"FAILED: {k8s_result}" if k8s_failed else "succeeded"
-                elapsed = completion_time - start_time
+                elapsed = time.time() - start_time
                 logger.error(
                     "Concurrent operation failed after %.2fs - ARM: %s, K8s readiness: %s",
                     elapsed, arm_status, k8s_status
@@ -127,14 +130,15 @@ class AKSClient:
                     raise arm_result
                 raise k8s_result
 
-            # Both succeeded - unpack k8s result
+            # Both succeeded - unpack results
+            arm_response, arm_timestamp = arm_result
             ready_nodes, ready_timestamp = k8s_result
 
             # Calculate times relative to start
             node_readiness_time = ready_timestamp - start_time
-            command_execution_time = completion_time - start_time
+            command_execution_time = arm_timestamp - start_time
 
-            return arm_result, ready_nodes, node_readiness_time, command_execution_time
+            return arm_response, ready_nodes, node_readiness_time, command_execution_time
 
         # Handle both sync and async calling contexts
         try:

--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -12,10 +12,12 @@ Operations are tracked using the Operation and OperationContext classes for metr
 and troubleshooting.
 """
 
+import asyncio
+import concurrent.futures
 import logging
 import os
 import time
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, Tuple
 
 # Third party imports
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
@@ -59,6 +61,92 @@ class AKSClient:
         from crud.operation import OperationContext # pylint: disable=import-outside-toplevel
 
         return OperationContext
+
+    def _run_concurrent_arm_and_readiness(
+        self,
+        poller,
+        node_count: int,
+        label_selector: str,
+        start_time: float
+    ) -> Tuple[Any, list, float, float]:
+        """
+        Run ARM operation and K8s node readiness check concurrently.
+
+        This allows accurate measurement of both ARM completion time and node readiness time
+        independently, enabling identification of which layer is causing latency.
+
+        Args:
+            poller: Azure ARM LROPoller from begin_create_or_update (thread-safe)
+            node_count: Expected number of nodes to be ready
+            label_selector: K8s label selector for filtering nodes
+            start_time: Operation start timestamp for calculating durations
+
+        Returns:
+            Tuple of (arm_result, ready_nodes, node_readiness_time, command_execution_time)
+            - node_readiness_time: seconds from start until K8s nodes were ready
+            - command_execution_time: seconds from start until both tasks complete
+              (i.e., the longer of ARM or K8s readiness)
+
+        Raises:
+            Exception: If either ARM or K8s readiness fails. Both tasks run to
+                completion (or failure) so we can capture timing for whichever
+                succeeded, enabling better diagnosis of which layer caused the failure.
+        """
+        async def _run():
+            # Run ARM polling and K8s readiness check concurrently
+            arm_task = asyncio.to_thread(poller.result)
+            k8s_task = asyncio.to_thread(
+                self.k8s_client.wait_for_nodes_ready,
+                node_count=node_count,
+                operation_timeout_in_minutes=self.operation_timeout_minutes,
+                label_selector=label_selector,
+                return_timestamp=True,
+            )
+
+            # Use return_exceptions=True to capture both results even if one fails
+            results = await asyncio.gather(arm_task, k8s_task, return_exceptions=True)
+            arm_result, k8s_result = results
+
+            completion_time = time.time()
+
+            # Check for failures and build diagnostic message
+            arm_failed = isinstance(arm_result, Exception)
+            k8s_failed = isinstance(k8s_result, Exception)
+
+            if arm_failed or k8s_failed:
+                # Build diagnostic info for logging
+                arm_status = f"FAILED: {arm_result}" if arm_failed else "succeeded"
+                k8s_status = f"FAILED: {k8s_result}" if k8s_failed else "succeeded"
+                elapsed = completion_time - start_time
+                logger.error(
+                    f"Concurrent operation failed after {elapsed:.2f}s - "
+                    f"ARM: {arm_status}, K8s readiness: {k8s_status}"
+                )
+                # Raise the first exception encountered
+                if arm_failed:
+                    raise arm_result
+                raise k8s_result
+
+            # Both succeeded - unpack k8s result
+            ready_nodes, ready_timestamp = k8s_result
+
+            # Calculate times relative to start
+            node_readiness_time = ready_timestamp - start_time
+            command_execution_time = completion_time - start_time
+
+            return arm_result, ready_nodes, node_readiness_time, command_execution_time
+
+        # Handle both sync and async calling contexts
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop - safe to use asyncio.run()
+            return asyncio.run(_run())
+
+        # Already in async context - run in separate thread pool
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future = executor.submit(asyncio.run, _run())
+            return future.result()
 
     def __init__(
         self,

--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -237,15 +237,16 @@ class KubernetesClient:
             else:
                 raise Exception(f"Error deleting Node '{node_name}': {str(e)}") from e
 
-    def wait_for_nodes_ready(self, node_count, operation_timeout_in_minutes, label_selector=None):
+    def wait_for_nodes_ready(self, node_count, operation_timeout_in_minutes, label_selector=None, return_timestamp=False):
         """
         Waits for a specific number of nodes with a given label to be ready within a specified timeout.
         Raises an exception if the expected number of nodes are not ready within the timeout.
 
-        :param node_label: The label to filter nodes.
         :param node_count: The expected number of nodes to be ready.
         :param operation_timeout_in_minutes: The timeout in minutes to wait for the nodes to be ready.
-        :return: None
+        :param label_selector: The label to filter nodes.
+        :param return_timestamp: If True, returns (ready_nodes, ready_timestamp) tuple for timing measurement.
+        :return: List of ready nodes, or (ready_nodes, timestamp) if return_timestamp=True.
         """
         ready_nodes = []
         ready_node_count = 0
@@ -256,6 +257,8 @@ class KubernetesClient:
             ready_node_count = len(ready_nodes)
             logger.info(f"Currently {ready_node_count} nodes are ready.")
             if ready_node_count == node_count:
+                if return_timestamp:
+                    return ready_nodes, time.time()
                 return ready_nodes
             logger.info(f"Waiting for {node_count} nodes to be ready.")
             time.sleep(10)

--- a/modules/python/tests/clients/test_aks_client.py
+++ b/modules/python/tests/clients/test_aks_client.py
@@ -174,13 +174,17 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         vm_size = "Standard_DS2_v2"
         node_count = 2
 
-        mock_time.time.side_effect = [100, 150]  # Start and end times
+        # Define timestamps for clarity
+        start_time = 100
+        nodes_ready_time = 130
+        arm_done_time = 150
+        mock_time.time.side_effect = [start_time, arm_done_time]
 
         mock_operation = mock.MagicMock()
         self.mock_agent_pools.begin_create_or_update.return_value = mock_operation
 
         ready_nodes = [mock.MagicMock(), mock.MagicMock()]
-        self.mock_k8s.wait_for_nodes_ready.return_value = ready_nodes
+        self.mock_k8s.wait_for_nodes_ready.return_value = (ready_nodes, nodes_ready_time)
 
         # Mock the node pool that will be retrieved after creation
         mock_created_node_pool = mock.MagicMock()
@@ -217,7 +221,14 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
             node_count=node_count,
             operation_timeout_in_minutes=10,
             label_selector=f"agentpool={node_pool_name}",
+            return_timestamp=True,
         )
+
+        # Verify timing measurements are calculated and stored correctly
+        # node_readiness_time = nodes_ready_time - start_time = 130 - 100 = 30
+        # command_execution_time = arm_done_time - start_time = 150 - 100 = 50
+        self.mock_operation.add_metadata.assert_any_call("node_readiness_time", 30)
+        self.mock_operation.add_metadata.assert_any_call("command_execution_time", 50)
 
     @mock.patch("clients.aks_client.time")
     def test_create_node_pool_gpu(self, mock_time):
@@ -227,13 +238,17 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         vm_size = "Standard_NC6s_v3"  # GPU VM size
         node_count = 1
 
-        mock_time.time.side_effect = [100, 150]  # Start and end times
+        # Define timestamps for clarity
+        start_time = 100
+        nodes_ready_time = 130
+        arm_done_time = 150
+        mock_time.time.side_effect = [start_time, arm_done_time]
 
         mock_operation = mock.MagicMock()
         self.mock_agent_pools.begin_create_or_update.return_value = mock_operation
 
         ready_nodes = [mock.MagicMock()]
-        self.mock_k8s.wait_for_nodes_ready.return_value = ready_nodes
+        self.mock_k8s.wait_for_nodes_ready.return_value = (ready_nodes, nodes_ready_time)
 
         # Add nvidia-smi verification mock
         self.mock_k8s.verify_nvidia_smi_on_node = mock.MagicMock(
@@ -275,6 +290,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
             node_count=node_count,
             operation_timeout_in_minutes=10,
             label_selector=f"agentpool={node_pool_name}",
+            return_timestamp=True,
         )
 
         # Check that NVIDIA verification was performed
@@ -287,7 +303,11 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         node_pool_name = "test-pool"
         node_count = 3
 
-        mock_time.time.side_effect = [100, 150]  # Start and end times
+        # Define timestamps for clarity
+        start_time = 100
+        nodes_ready_time = 130
+        arm_done_time = 150
+        mock_time.time.side_effect = [start_time, arm_done_time]
 
         mock_node_pool = mock.MagicMock()
         mock_node_pool.count = 1  # Current count
@@ -299,7 +319,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         self.mock_agent_pools.begin_create_or_update.return_value = mock_operation
 
         ready_nodes = [mock.MagicMock(), mock.MagicMock(), mock.MagicMock()]
-        self.mock_k8s.wait_for_nodes_ready.return_value = ready_nodes
+        self.mock_k8s.wait_for_nodes_ready.return_value = (ready_nodes, nodes_ready_time)
 
         # Mock get_cluster_data to return a dictionary for JSON serialization
         self.aks_client.get_cluster_data = mock.MagicMock(
@@ -321,8 +341,15 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
             node_count=node_count,
             operation_timeout_in_minutes=10,
             label_selector=f"agentpool={node_pool_name}",
+            return_timestamp=True,
         )
         self.assertEqual(mock_node_pool.count, node_count)
+
+        # Verify timing measurements are calculated and stored correctly
+        # node_readiness_time = nodes_ready_time - start_time = 130 - 100 = 30
+        # command_execution_time = arm_done_time - start_time = 150 - 100 = 50
+        self.mock_operation.add_metadata.assert_any_call("node_readiness_time", 30)
+        self.mock_operation.add_metadata.assert_any_call("command_execution_time", 50)
 
     @mock.patch("clients.aks_client.time")
     def test_scale_node_pool_down(self, mock_time):
@@ -331,7 +358,11 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         node_pool_name = "test-pool"
         node_count = 1
 
-        mock_time.time.side_effect = [100, 150]  # Start and end times
+        # Define timestamps for clarity
+        start_time = 100
+        nodes_ready_time = 130
+        arm_done_time = 150
+        mock_time.time.side_effect = [start_time, arm_done_time]
 
         mock_node_pool = mock.MagicMock()
         mock_node_pool.count = 3  # Current count
@@ -348,7 +379,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         self.mock_agent_pools.begin_create_or_update.return_value = mock_operation
 
         ready_nodes = [mock.MagicMock()]
-        self.mock_k8s.wait_for_nodes_ready.return_value = ready_nodes
+        self.mock_k8s.wait_for_nodes_ready.return_value = (ready_nodes, nodes_ready_time)
 
         # Mock get_node_pool to return the node pool with as_dict method
         self.aks_client.get_node_pool = mock.MagicMock(return_value=mock_node_pool)
@@ -365,6 +396,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
             node_count=node_count,
             operation_timeout_in_minutes=10,
             label_selector=f"agentpool={node_pool_name}",
+            return_timestamp=True,
         )
         self.assertEqual(mock_node_pool.count, node_count)
 
@@ -412,7 +444,11 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         # Set VM size that triggers NVIDIA verification
         self.aks_client.vm_size = "Standard_NC40ads_H100_v5"
 
-        mock_time.time.side_effect = [100, 150]  # Start and end times
+        # Define timestamps for clarity
+        start_time = 100
+        nodes_ready_time = 130
+        arm_done_time = 150
+        mock_time.time.side_effect = [start_time, arm_done_time]
 
         mock_node_pool = mock.MagicMock()
         mock_node_pool.count = 1  # Current count
@@ -435,7 +471,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         self.mock_agent_pools.begin_create_or_update.return_value = mock_operation
 
         ready_nodes = [mock.MagicMock(), mock.MagicMock(), mock.MagicMock()]
-        self.mock_k8s.wait_for_nodes_ready.return_value = ready_nodes
+        self.mock_k8s.wait_for_nodes_ready.return_value = (ready_nodes, nodes_ready_time)
 
         # Add nvidia-smi verification mock
         self.mock_k8s.verify_nvidia_smi_on_node = mock.MagicMock(
@@ -456,6 +492,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
             node_count=node_count,
             operation_timeout_in_minutes=10,
             label_selector=f"agentpool={node_pool_name}",
+            return_timestamp=True,
         )
         self.assertEqual(mock_node_pool.count, node_count)
 
@@ -472,12 +509,15 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         # Set VM size that triggers NVIDIA verification
         self.aks_client.vm_size = "Standard_NC40ads_H100_v5"
 
-        mock_time.time.side_effect = [
-            100,
-            150,
-            200,
-            250,
-        ]  # Start and end times including progressive scaling
+        # Define timestamps for clarity (progressive has multiple steps)
+        # Each step calls time.time() twice: once for start, once for arm completion
+        step1_start = 100
+        step1_nodes_ready = 130
+        step1_arm_done = 150
+        step2_start = 200
+        step2_nodes_ready = 230
+        step2_arm_done = 250
+        mock_time.time.side_effect = [step1_start, step1_arm_done, step2_start, step2_arm_done]
 
         mock_node_pool = mock.MagicMock()
         mock_node_pool.count = 1  # Current count
@@ -506,7 +546,10 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
             mock.MagicMock(),
             mock.MagicMock(),
         ]  # Second step to 3 nodes
-        self.mock_k8s.wait_for_nodes_ready.side_effect = [ready_nodes1, ready_nodes2]
+        self.mock_k8s.wait_for_nodes_ready.side_effect = [
+            (ready_nodes1, step1_nodes_ready),
+            (ready_nodes2, step2_nodes_ready)
+        ]
 
         # Add nvidia-smi verification mock
         self.mock_k8s.verify_nvidia_smi_on_node = mock.MagicMock(
@@ -542,7 +585,11 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         node_pool_name = "gpu-pool"
         node_count = 1
 
-        mock_time.time.side_effect = [100, 150]  # Start and end times
+        # Define timestamps for clarity
+        start_time = 100
+        nodes_ready_time = 130
+        arm_done_time = 150
+        mock_time.time.side_effect = [start_time, arm_done_time]
 
         mock_node_pool = mock.MagicMock()
         mock_node_pool.count = 3  # Current count
@@ -560,7 +607,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         self.mock_agent_pools.begin_create_or_update.return_value = mock_operation
 
         ready_nodes = [mock.MagicMock()]
-        self.mock_k8s.wait_for_nodes_ready.return_value = ready_nodes
+        self.mock_k8s.wait_for_nodes_ready.return_value = (ready_nodes, nodes_ready_time)
 
         # Add nvidia-smi verification mock
         self.mock_k8s.verify_nvidia_smi_on_node = mock.MagicMock(
@@ -581,6 +628,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
             node_count=node_count,
             operation_timeout_in_minutes=10,
             label_selector=f"agentpool={node_pool_name}",
+            return_timestamp=True,
         )
         self.assertEqual(mock_node_pool.count, node_count)
 

--- a/modules/python/tests/clients/test_kubernetes_client.py
+++ b/modules/python/tests/clients/test_kubernetes_client.py
@@ -1202,6 +1202,28 @@ class TestKubernetesClient(unittest.TestCase):
         self.assertIn("Only 1 nodes are ready, expected 2 nodes!", str(context.exception))
         mock_sleep.assert_called()
 
+    @patch('time.time')
+    @patch('clients.kubernetes_client.KubernetesClient.get_ready_nodes')
+    @patch("time.sleep", return_value=None)
+    def test_wait_for_nodes_ready_with_timestamp(self, mock_sleep, mock_get_ready_nodes, mock_time):
+        """Test waiting for nodes with return_timestamp=True returns tuple."""
+        mock_get_ready_nodes.side_effect = [[], ["node1", "node2"]]
+        mock_time.return_value = 1234567890.123  # Fixed timestamp for assertion
+        node_count = 2
+        timeout = 0.01
+
+        result = self.client.wait_for_nodes_ready(
+            node_count, timeout, return_timestamp=True
+        )
+
+        # Should return (ready_nodes, timestamp) tuple
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        ready_nodes, timestamp = result
+        self.assertEqual(ready_nodes, ["node1", "node2"])
+        self.assertEqual(timestamp, 1234567890.123)
+        mock_sleep.assert_called()
+
     @patch('clients.kubernetes_client.KubernetesClient.get_pods_by_namespace')
     @patch('clients.kubernetes_client.KubernetesClient.get_ready_pods_by_namespace')
     @patch("time.sleep", return_value=None)

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -13,7 +13,7 @@ stages:
           cloud: azure
           regions:
             - australiaeast
-          topology: k8s-gpu-cluster-crud
+          topology: k8s-crud-gpu
           engine: python
           matrix:
             crud_test:

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -14,7 +14,7 @@ stages:
           regions:
             - australiaeast
           topology: k8s-crud-gpu
-          engine: python
+          engine: crud
           matrix:
             crud_test:
               SUBSCRIPTION_ID: c0d4b923-b5ea-4f8f-9b56-5390a9bf2248

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,25 +1,34 @@
 trigger: none
 
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: k8s-gpu-cluster-crud
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: azure_australiaeast
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml # must keep as is
+      - template: /jobs/competitive-test.yml
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
-          credential_type: service_connection # required
+          cloud: azure
+          regions:
+            - australiaeast
+          topology: k8s-gpu-cluster-crud
+          engine: python
+          matrix:
+            crud_test:
+              SUBSCRIPTION_ID: c0d4b923-b5ea-4f8f-9b56-5390a9bf2248
+              RESOURCE_GROUP: telescope-rg
+              CLUSTER_NAME: gpu-cluster
+              NODE_POOL_NAME: testnodepool
+              NODE_COUNT: 3
+              VM_SIZE: Standard_D4s_v3
+              SCALE_NODE_COUNT: 5
+              GPU_NODE_POOL: ""
+              COMPLETIONS: 1
+              REPLICAS: 1
+              MANIFEST_DIR: modules/python/manifests
+          max_parallel: 1
+          credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 60 # if not specified, default is 60
+          timeout_in_minutes: 60


### PR DESCRIPTION
### Summary

Adds `node_readiness_time` as a separate metric in the open-source CRUD module to match internal repo behavior. The internal repo captures how long K8s nodes take to become Ready independently from when the ARM API completes. The open-source repo was missing this - it only had combined duration.

Azure API says "done" when the control plane finishes, but nodes might not be schedulable yet. Capturing both timestamps separately enables regression analysis:

- `command_execution_time > node_readiness_time` → ARM layer is the bottleneck
- `node_readiness_time > command_execution_time` → K8s layer is the bottleneck

### Changes

**kubernetes_client.py**
- Added `return_timestamp=False` parameter to `wait_for_nodes_ready()`
- When `True`, returns `(ready_nodes, timestamp)` tuple instead of just `ready_nodes`

**aks_client.py**
- Added `_run_concurrent_arm_and_readiness()` helper using `asyncio.gather()`
- Updated `create_node_pool()`, `scale_node_pool()`, and `_progressive_scale()` to capture concurrent timing

**Timing metadata** stored via `op.add_metadata()`:
- `node_readiness_time`: seconds from start until K8s nodes were Ready
- `command_execution_time`: seconds from start until ARM operation completed

**Implementation notes**
- Uses `asyncio.to_thread()` to run sync calls concurrently
- `return_exceptions=True` ensures both tasks complete even if one fails, enabling partial diagnostics
- Handles both sync and async calling contexts with ThreadPoolExecutor fallback