### PR TITLE
Add 15K node cluster creation pipeline

### DIFF
--- a/kcl/ccp_team/15K_cluster/firewall-policy.json
+++ b/kcl/ccp_team/15K_cluster/firewall-policy.json
@@ -1,0 +1,788 @@
+{
+    "location": "eastasia",
+    "properties": {
+        "networkRuleCollections": [
+            {
+                "name": "imds",
+                "properties": {
+                    "priority": 101,
+                    "action": {
+                        "type": "Allow"
+                    },
+                    "rules": [
+                        {
+                            "name": "imds",
+                            "protocols": [
+                                "Any"
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "destinationAddresses": [
+                                "169.254.169.254"
+                            ],
+                            "destinationPorts": [
+                                "80"
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "applicationRuleCollections": [
+            {
+                "name": "k8s",
+                "properties": {
+                    "priority": 101,
+                    "action": {
+                        "type": "Allow"
+                    },
+                    "rules": [
+                        {
+                            "fqdnTags": [],
+                            "name": "registry.k8s.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "registry.k8s.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "k8s.gcr.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "k8s.gcr.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "gcr.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "gcr.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "storage.googleapis.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "storage.googleapis.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.googleapis.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.googleapis.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.pkg.dev",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.pkg.dev"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.docker.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.docker.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.gcr.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.gcr.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.googleusercontent.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.googleusercontent.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.lz4.dev",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.lz4.dev"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.s3.dualstack.us-east-1.amazonaws.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.s3.dualstack.us-east-1.amazonaws.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.s3.amazonaws.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.s3.amazonaws.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.amazonaws.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.amazonaws.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.s3.dualstack.us-west-2.amazonaws.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.s3.dualstack.us-west-2.amazonaws.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.s3.dualstack.eu-west-1.amazonaws.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.s3.dualstack.eu-west-1.amazonaws.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.s3.dualstack.ap-southeast-1.amazonaws.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.s3.dualstack.ap-southeast-1.amazonaws.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.s3.dualstack.ap-northeast-1.amazonaws.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.s3.dualstack.ap-northeast-1.amazonaws.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.cloudfront.net",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.cloudfront.net"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "ghcr.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "ghcr.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.ghcr.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.ghcr.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "pkg-containers.githubusercontent.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "pkg-containers.githubusercontent.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.pkg-containers.githubusercontent.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.pkg-containers.githubusercontent.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "quay.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "quay.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.quay.io",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.quay.io"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "production.cloudflare.docker.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "production.cloudflare.docker.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.production.cloudflare.docker.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.production.cloudflare.docker.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.r2.cloudflarestorage.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.r2.cloudflarestorage.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.quaycdn.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.quaycdn.com"
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "Azure-Global-required-FQDN",
+                "properties": {
+                    "priority": 100,
+                    "action": {
+                        "type": "Allow"
+                    },
+                    "rules": [
+                        {
+                            "fqdnTags": [],
+                            "name": "mcr.microsoft.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "mcr.microsoft.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.data.mcr.microsoft.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.data.mcr.microsoft.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "mcr-0001.mcr-msedge.net",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "mcr-0001.mcr-msedge.net"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "management.azure.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "management.azure.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "login.microsoftonline.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "login.microsoftonline.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "packages.microsoft.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "packages.microsoft.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "acs-mirror.azureedge.net",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "acs-mirror.azureedge.net"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "packages.aks.azure.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "packages.aks.azure.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "security.ubuntu.com",
+                            "protocols": [
+                                {
+                                    "port": 80,
+                                    "protocolType": "Http"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "security.ubuntu.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "azure.archive.ubuntu.com",
+                            "protocols": [
+                                {
+                                    "port": 80,
+                                    "protocolType": "Http"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "azure.archive.ubuntu.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "changelogs.ubuntu.com",
+                            "protocols": [
+                                {
+                                    "port": 80,
+                                    "protocolType": "Http"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "changelogs.ubuntu.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "snapshot.ubuntu.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "snapshot.ubuntu.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.azure.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.azure.com"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.windows.net",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.windows.net"
+                            ]
+                        },
+                        {
+                            "fqdnTags": [],
+                            "name": "*.blob.core.windows.net",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.1.0.0/18"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "*.blob.core.windows.net"
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/kcl/ccp_team/15K_cluster/firewall-policy.json
+++ b/kcl/ccp_team/15K_cluster/firewall-policy.json
@@ -1,5 +1,4 @@
 {
-    "location": "eastasia",
     "properties": {
         "networkRuleCollections": [
             {

--- a/kcl/ccp_team/15K_cluster/firewall-policy.json
+++ b/kcl/ccp_team/15K_cluster/firewall-policy.json
@@ -781,6 +781,34 @@
                         }
                     ]
                 }
+            },
+            {
+                "name": "deny-app-insights",
+                "properties": {
+                    "priority": 103,
+                    "action": {
+                        "type": "Deny"
+                    },
+                    "rules": [
+                        {
+                            "fqdnTags": [],
+                            "name": "dc.services.visualstudio.com",
+                            "protocols": [
+                                {
+                                    "port": 443,
+                                    "protocolType": "Https"
+                                }
+                            ],
+                            "sourceAddresses": [
+                                "10.0.0.0/8"
+                            ],
+                            "sourceIpGroups": [],
+                            "targetFqdns": [
+                                "dc.services.visualstudio.com"
+                            ]
+                        }
+                    ]
+                }
             }
         ]
     }

--- a/kcl/ccp_team/15K_cluster/jumpbox.k
+++ b/kcl/ccp_team/15K_cluster/jumpbox.k
@@ -1,0 +1,64 @@
+createJumpboxScript = """
+cat > /tmp/cloud-init.yaml << 'CLOUDINIT'
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - git
+  - ca-certificates
+  - curl
+  - apt-transport-https
+  - lsb-release
+  - gnupg
+runcmd:
+  - curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+  - wget -q https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -O /tmp/go.tar.gz
+  - tar -C /usr/local -xzf /tmp/go.tar.gz
+  - echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
+  - rm /tmp/go.tar.gz
+CLOUDINIT
+
+az vm create \\
+  --resource-group "${RESOURCE_GROUP}" \\
+  --name "${JUMPBOX_NAME}" \\
+  --image Ubuntu2204 \\
+  --size Standard_D48s_v3 \\
+  --vnet-name "${VNET_NAME}" \\
+  --subnet jumpbox \\
+  --public-ip-address "${JUMPBOX_NAME}-pip" \\
+  --admin-username azureuser \\
+  --admin-password "$(JUMPBOX_ADMIN_PASSWORD)" \\
+  --authentication-type password \\
+  --custom-data /tmp/cloud-init.yaml \\
+  --subscription "${SUBSCRIPTION_ID}"
+
+az vm open-port \\
+  --resource-group "${RESOURCE_GROUP}" \\
+  --name "${JUMPBOX_NAME}" \\
+  --port 22 \\
+  --priority 1001 \\
+  --subscription "${SUBSCRIPTION_ID}"
+
+JUMPBOX_PRINCIPAL_ID=$(az vm identity assign \\
+  --resource-group "${RESOURCE_GROUP}" \\
+  --name "${JUMPBOX_NAME}" \\
+  --subscription "${SUBSCRIPTION_ID}" \\
+  --query systemAssignedIdentity -o tsv)
+
+RG_ID=$(az group show \\
+  --name "${RESOURCE_GROUP}" \\
+  --subscription "${SUBSCRIPTION_ID}" \\
+  --query id -o tsv)
+
+for role in \\
+  "Azure Kubernetes Service Cluster Admin Role" \\
+  "Azure Kubernetes Service Cluster User Role" \\
+  "Azure Kubernetes Service Contributor Role" \\
+  "Azure Kubernetes Service RBAC Cluster Admin"; do
+  az role assignment create \\
+    --assignee $JUMPBOX_PRINCIPAL_ID \\
+    --role "$role" \\
+    --scope $RG_ID \\
+    --subscription "${SUBSCRIPTION_ID}"
+done
+"""

--- a/kcl/ccp_team/15K_cluster/jumpbox.k
+++ b/kcl/ccp_team/15K_cluster/jumpbox.k
@@ -16,6 +16,9 @@ runcmd:
   - tar -C /usr/local -xzf /tmp/go.tar.gz
   - echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
   - rm /tmp/go.tar.gz
+  - curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+  - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+  - rm kubectl
 CLOUDINIT
 
 az vm create \\

--- a/kcl/ccp_team/15K_cluster/jumpbox.k
+++ b/kcl/ccp_team/15K_cluster/jumpbox.k
@@ -25,7 +25,7 @@ az vm create \\
   --resource-group "${RESOURCE_GROUP}" \\
   --name "${JUMPBOX_NAME}" \\
   --image Ubuntu2204 \\
-  --size Standard_D48s_v3 \\
+  --size Standard_D16ds_v5 \\
   --vnet-name "${VNET_NAME}" \\
   --subnet jumpbox \\
   --public-ip-address "${JUMPBOX_NAME}-pip" \\

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -62,7 +62,7 @@ cat > /tmp/aks-body.json << EOF
       {
         "name": "system",
         "count": 3,
-        "vmSize": "Standard_D48s_v3",
+        "vmSize": "Standard_D48ds_v5",
         "maxPods": 60,
         "osType": "Linux",
         "osSKU": "Ubuntu",

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -177,25 +177,25 @@ output = ap.Pipeline {
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "nodes", NODES_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
+                    SUBSCRIPTION_ID, "$(IDENTITY_PRINCIPAL_ID)"
                 ),
                 azure.CreateSubnetAndRoleAssignment(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "apiserver", APISERVER_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
+                    SUBSCRIPTION_ID, "$(IDENTITY_PRINCIPAL_ID)"
                 ),
                 azure.CreateSubnetAndRoleAssignment(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "AzureFirewallSubnet", FIREWALL_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
+                    SUBSCRIPTION_ID, "$(IDENTITY_PRINCIPAL_ID)"
                 ),
                 azure.CreateSubnetAndRoleAssignment(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "jumpbox", JUMPBOX_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
+                    SUBSCRIPTION_ID, "$(IDENTITY_PRINCIPAL_ID)"
                 ),
                 azure.SetupFirewallForSubnet(
                     const.DEFAULT_SERVICE_CONNECTION,

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -9,11 +9,9 @@ RESOURCE_GROUP = "$(RUN_ID)"
 LOCATION = "$(location)"
 CLUSTER_NAME = "$(cluster_name)"
 SERVICE_CONNECTION = "$(AZURE_SERVICE_CONNECTION)"
-K8S_VERSION = "1.33.0"
+K8S_VERSION = "1.35.0"
 
 VNET_NAME = "${CLUSTER_NAME}-net"
-IDENTITY_NAME = "${CLUSTER_NAME}-identity"
-FW_NAME = "${CLUSTER_NAME}-firewall"
 JUMPBOX_NAME = "${CLUSTER_NAME}-jumpbox"
 
 # Small values for small scare e2e testing; replace with the lines below for full 15K run
@@ -22,7 +20,7 @@ JUMPBOX_NAME = "${CLUSTER_NAME}-jumpbox"
 USER_TOTAL_NODES = 100
 MAX_NODES_PER_POOL = 20
 
-_userPools = [azure.NodePool {
+userPools = [azure.NodePool {
     name = pool.name
     sku = pool.sku
     count = pool.count
@@ -32,41 +30,40 @@ _userPools = [azure.NodePool {
 
 
 createClusterScript = """
-NETWORK_DATAPLANE="$(network_dataplane)"
-NETWORK_DATAPLANE_FLAG=""
-if [ -n "$NETWORK_DATAPLANE" ]; then
-  NETWORK_DATAPLANE_FLAG="--network-dataplane $NETWORK_DATAPLANE"
-fi
-
 az extension add --name aks-preview --allow-preview true --upgrade --yes
 
-az aks create \\
-  --subscription "${SUBSCRIPTION_ID}" \\
-  --resource-group "${RESOURCE_GROUP}" \\
-  --name "${CLUSTER_NAME}" \\
-  --location "${LOCATION}" \\
-  --kubernetes-version "${K8S_VERSION}" \\
-  --dns-name-prefix "${CLUSTER_NAME}-dns" \\
-  --tier standard \\
-  --assign-identity "$(IDENTITY_ID)" \\
-  --tags SkipAKSCluster=true \\
-  --nodepool-name system \\
-  --node-count 3 \\
-  --node-vm-size Standard_D48ds_v5 \\
-  --max-pods 60 \\
-  --os-sku Ubuntu \\
-  --vnet-subnet-id "$(NODES_SUBNET_ID)" \\
-  --network-plugin azure \\
-  --network-plugin-mode overlay \\
-  --pod-cidr 10.64.0.0/10 \\
-  --outbound-type userDefinedRouting \\
-  --enable-private-cluster \\
-  --enable-apiserver-vnet-integration \\
-  --apiserver-subnet-id "$(APISERVER_SUBNET_ID)" \\
-  --generate-ssh-keys \\
-  --control-plane-scaling-size H8 \\
-  --yes \\
-  $NETWORK_DATAPLANE_FLAG
+CREATE_ARGS=(
+  --subscription "${SUBSCRIPTION_ID}"
+  --resource-group "${RESOURCE_GROUP}"
+  --name "${CLUSTER_NAME}"
+  --location "${LOCATION}"
+  --kubernetes-version "1.35.0"
+  --dns-name-prefix "${CLUSTER_NAME}-dns"
+  --tier standard
+  --assign-identity "$(IDENTITY_ID)"
+  --tags SkipAKSCluster=true
+  --control-plane-scaling-size H8
+  --nodepool-name system
+  --node-count 3
+  --node-vm-size Standard_D48ds_v5
+  --max-pods 60
+  --os-sku Ubuntu
+  --vnet-subnet-id "$(NODES_SUBNET_ID)"
+  --network-plugin azure
+  --network-plugin-mode overlay
+  --pod-cidr 10.64.0.0/10
+  --outbound-type userDefinedRouting
+  --enable-private-cluster
+  --enable-apiserver-vnet-integration
+  --apiserver-subnet-id "$(APISERVER_SUBNET_ID)"
+  --auto-upgrade-channel none
+  --node-os-upgrade-channel None
+  --generate-ssh-keys
+  --yes
+)
+[[ -n "$(network_dataplane)" ]] && CREATE_ARGS+=(--network-dataplane "$(network_dataplane)")
+
+az aks create "\${CREATE_ARGS[@]}"
 """
 
 output = ap.Pipeline {
@@ -140,7 +137,7 @@ output = ap.Pipeline {
                     SERVICE_CONNECTION,
                     SUBSCRIPTION_ID,
                     RESOURCE_GROUP,
-                    IDENTITY_NAME
+                    "${CLUSTER_NAME}-identity"
                 ),
                 azure.CreateVNet(
                     SERVICE_CONNECTION,
@@ -187,7 +184,7 @@ output = ap.Pipeline {
                     SUBSCRIPTION_ID,
                     RESOURCE_GROUP,
                     LOCATION,
-                    FW_NAME,
+                    "${CLUSTER_NAME}-firewall",
                     VNET_NAME,
                     "nodes",
                     "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json"
@@ -214,7 +211,7 @@ output = ap.Pipeline {
                     RESOURCE_GROUP,
                     SUBSCRIPTION_ID,
                     pool
-                ) for pool in _userPools],
+                ) for pool in userPools],
             ]
         }
     ]

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -29,7 +29,7 @@ _userPools = [azure.NodePool {
     name = pool.name
     sku = pool.sku
     count = pool.count
-    vnetSubnetId = "$(NODE_SUBNET_ID)"
+    vnetSubnetId = "$(NODES_SUBNET_ID)"
     osSKU = "Ubuntu"
 } for pool in azure.PlanNodePools({"$(user_pool_vm_size)": USER_TOTAL_NODES}, MAX_NODES_PER_POOL)]
 
@@ -56,19 +56,18 @@ cat > /tmp/aks-body.json << EOF
     "agentPoolProfiles": [
       {
         "name": "system",
-        "count": 10,
+        "count": 3,
         "vmSize": "Standard_D48s_v3",
         "maxPods": 60,
         "osType": "Linux",
         "osSKU": "Ubuntu",
         "mode": "System",
-        "vnetSubnetID": "$(NODE_SUBNET_ID)"
+        "vnetSubnetID": "$(NODES_SUBNET_ID)"
       }
     ],
     "networkProfile": {
       "networkPlugin": "azure",
       "networkPluginMode": "overlay",
-      "networkDataplane": "cilium",
       "podCidr": "10.64.0.0/10",
       "outboundType": "userDefinedRouting"
     },
@@ -100,6 +99,8 @@ output = ap.Pipeline {
         location = "eastasia"
         cluster_name = "15k-private-cluster"
         user_pool_vm_size = "Standard_D4s_v3"
+        network_dataplane = "cilium"
+        kms_key_id = ""
     }
 
     jobs = [
@@ -123,9 +124,9 @@ output = ap.Pipeline {
                 ),
                 azure.CreateManagedIdentity(
                     const.DEFAULT_SERVICE_CONNECTION,
+                    SUBSCRIPTION_ID,
                     RESOURCE_GROUP,
-                    IDENTITY_NAME,
-                    SUBSCRIPTION_ID
+                    IDENTITY_NAME
                 ),
                 azure.CreateVNet(
                     const.DEFAULT_SERVICE_CONNECTION,
@@ -134,70 +135,43 @@ output = ap.Pipeline {
                     VNET_CIDR,
                     SUBSCRIPTION_ID
                 ),
-                azure.CreateSubnet(
+                azure.CreateSubnetAndRoleAssignment(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "nodes", NODES_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "NODE_SUBNET_ID"
+                    SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
                 ),
-                azure.CreateRoleAssignment(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    "$(NODE_SUBNET_ID)", "Network Contributor",
-                    "$(IDENTITY_CLIENT_ID)", SUBSCRIPTION_ID
-                ),
-                azure.CreateSubnet(
+                azure.CreateSubnetAndRoleAssignment(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "apiserver", APISERVER_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "APISERVER_SUBNET_ID"
+                    SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
                 ),
-                azure.CreateRoleAssignment(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    "$(APISERVER_SUBNET_ID)", "Network Contributor",
-                    "$(IDENTITY_CLIENT_ID)", SUBSCRIPTION_ID
-                ),
-                azure.CreateSubnet(
+                azure.CreateSubnetAndRoleAssignment(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "AzureFirewallSubnet", FIREWALL_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "FIREWALL_SUBNET_ID"
+                    SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
                 ),
-                azure.CreateRoleAssignment(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    "$(FIREWALL_SUBNET_ID)", "Network Contributor",
-                    "$(IDENTITY_CLIENT_ID)", SUBSCRIPTION_ID
-                ),
-                azure.CreateSubnet(
+                azure.CreateSubnetAndRoleAssignment(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "jumpbox", JUMPBOX_SUBNET_CIDR,
-                    SUBSCRIPTION_ID
+                    SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
                 ),
                 azure.CreateFirewall(
                     const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, FW_NAME, LOCATION,
-                    VNET_NAME, FW_PUBLIC_IP_NAME, SUBSCRIPTION_ID
+                    SUBSCRIPTION_ID,RESOURCE_GROUP, FW_NAME, LOCATION,
+                    VNET_NAME, FW_PUBLIC_IP_NAME
                 ),
-                azure.CreateRouteTable(
+                azure.UpdateSubnetRouteTable(
                     const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, RT_NAME, LOCATION,
-                    SUBSCRIPTION_ID
-                ),
-                azure.CreateRoute(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, RT_NAME,
-                    "egress", "0.0.0.0/0",
-                    "VirtualAppliance", "$(FWPRIVATE_IP)",
-                    SUBSCRIPTION_ID
-                ),
-                azure.AssociateRouteTable(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, VNET_NAME,
-                    "nodes", RT_NAME, SUBSCRIPTION_ID
+                    RESOURCE_GROUP, RT_NAME, LOCATION, VNET_NAME,
+                    "nodes","$(FIREWALL_PRIVATE_IP)", SUBSCRIPTION_ID
                 ),
                 azure.UpdateFirewallPolicy(
                     const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, FW_NAME, SUBSCRIPTION_ID,
+                    SUBSCRIPTION_ID, RESOURCE_GROUP, FW_NAME,
                     "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json",
                     LOCATION
                 ),

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -8,18 +8,13 @@ SUBSCRIPTION_ID = "$(subscription_id)"
 RESOURCE_GROUP = "$(RUN_ID)"
 LOCATION = "$(location)"
 CLUSTER_NAME = "$(cluster_name)"
+SERVICE_CONNECTION = "$(service_connection)"
 K8S_VERSION = "1.33.0"
 
 VNET_NAME = "${CLUSTER_NAME}-net"
 IDENTITY_NAME = "${CLUSTER_NAME}-identity"
 FW_NAME = "${CLUSTER_NAME}-firewall"
 JUMPBOX_NAME = "${CLUSTER_NAME}-jumpbox"
-
-VNET_CIDR = "10.0.0.0/8"
-NODES_SUBNET_CIDR = "10.1.0.0/18"
-APISERVER_SUBNET_CIDR = "10.240.0.0/28"
-FIREWALL_SUBNET_CIDR = "10.2.0.0/16"
-JUMPBOX_SUBNET_CIDR = "10.3.0.0/16"
 
 # Small values for small scare e2e testing; replace with the lines below for full 15K run
 # USER_TOTAL_NODES = 14997
@@ -101,6 +96,12 @@ output = ap.Pipeline {
 
     parameters = [
         ap.Parameter {
+            name = "service_connection"
+            displayName = "Azure service connection"
+            type = "string"
+            default = SERVICE_CONNECTION
+        }
+        ap.Parameter {
             name = "subscription_id"
             displayName = "Subscription ID"
             type = "string"
@@ -133,6 +134,7 @@ output = ap.Pipeline {
     ]
 
     variables = {
+        service_connection = "\${{ parameters.service_connection }}"
         subscription_id = "\${{ parameters.subscription_id }}"
         location = "\${{ parameters.location }}"
         cluster_name = "\${{ parameters.cluster_name }}"
@@ -148,80 +150,92 @@ output = ap.Pipeline {
 
             steps = [
                 azure.Login(
-                    const.DEFAULT_SERVICE_CONNECTION,
+                    SERVICE_CONNECTION,
                     SUBSCRIPTION_ID,
                     LOCATION
                 ),
                 common.SetRunId(),
                 azure.CreateResourceGroup(
-                    const.DEFAULT_SERVICE_CONNECTION,
+                    SERVICE_CONNECTION,
                     RESOURCE_GROUP,
                     LOCATION,
                     SUBSCRIPTION_ID,
                     "SkipAKSCluster=true"
                 ),
                 azure.CreateManagedIdentity(
-                    const.DEFAULT_SERVICE_CONNECTION,
+                    SERVICE_CONNECTION,
                     SUBSCRIPTION_ID,
                     RESOURCE_GROUP,
                     IDENTITY_NAME
                 ),
                 azure.CreateVNet(
-                    const.DEFAULT_SERVICE_CONNECTION,
+                    SERVICE_CONNECTION,
                     RESOURCE_GROUP,
                     VNET_NAME,
-                    VNET_CIDR,
+                    "10.0.0.0/8",
                     SUBSCRIPTION_ID,
                     "$(IDENTITY_PRINCIPAL_ID)"
                 ),
                 azure.CreateSubnet(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, VNET_NAME,
-                    "nodes", NODES_SUBNET_CIDR,
+                    SERVICE_CONNECTION,
+                    RESOURCE_GROUP,
+                    VNET_NAME,
+                    "nodes",
+                    "10.1.0.0/18",
                     SUBSCRIPTION_ID
                 ),
                 azure.CreateSubnet(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, VNET_NAME,
-                    "apiserver", APISERVER_SUBNET_CIDR,
+                    SERVICE_CONNECTION,
+                    RESOURCE_GROUP,
+                    VNET_NAME,
+                    "apiserver",
+                    "10.240.0.0/28",
                     SUBSCRIPTION_ID
                 ),
                 azure.CreateSubnet(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, VNET_NAME,
-                    "AzureFirewallSubnet", FIREWALL_SUBNET_CIDR,
+                    SERVICE_CONNECTION,
+                    RESOURCE_GROUP,
+                    VNET_NAME,
+                    "AzureFirewallSubnet",
+                    "10.2.0.0/16",
                     SUBSCRIPTION_ID
                 ),
                 azure.CreateSubnet(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, VNET_NAME,
-                    "jumpbox", JUMPBOX_SUBNET_CIDR,
+                    SERVICE_CONNECTION,
+                    RESOURCE_GROUP,
+                    VNET_NAME,
+                    "jumpbox",
+                    "10.3.0.0/16",
                     SUBSCRIPTION_ID
                 ),
                 azure.SetupFirewallForSubnet(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    SUBSCRIPTION_ID, RESOURCE_GROUP, LOCATION,
-                    FW_NAME, VNET_NAME, "nodes",
+                    SERVICE_CONNECTION,
+                    SUBSCRIPTION_ID,
+                    RESOURCE_GROUP,
+                    LOCATION,
+                    FW_NAME,
+                    VNET_NAME,
+                    "nodes",
                     "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json"
                 ),
                 azure.AzCli(
-                    const.DEFAULT_SERVICE_CONNECTION,
+                    SERVICE_CONNECTION,
                     "Create jumpbox",
                     createJumpboxScript
                 ),
                 azure.AzCli(
-                    const.DEFAULT_SERVICE_CONNECTION,
+                    SERVICE_CONNECTION,
                     "Create AKS cluster",
                     createClusterScript
                 ),
                 azure.WaitForClusterSucceeded(
-                    const.DEFAULT_SERVICE_CONNECTION,
+                    SERVICE_CONNECTION,
                     CLUSTER_NAME,
                     RESOURCE_GROUP,
                     SUBSCRIPTION_ID
                 ),
                 *[azure.CreateNodePool(
-                    const.DEFAULT_SERVICE_CONNECTION,
+                    SERVICE_CONNECTION,
                     CLUSTER_NAME,
                     RESOURCE_GROUP,
                     SUBSCRIPTION_ID,

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -171,31 +171,32 @@ output = ap.Pipeline {
                     RESOURCE_GROUP,
                     VNET_NAME,
                     VNET_CIDR,
-                    SUBSCRIPTION_ID
+                    SUBSCRIPTION_ID,
+                    "$(IDENTITY_PRINCIPAL_ID)"
                 ),
-                azure.CreateSubnetAndRoleAssignment(
+                azure.CreateSubnet(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "nodes", NODES_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "$(IDENTITY_PRINCIPAL_ID)"
+                    SUBSCRIPTION_ID
                 ),
-                azure.CreateSubnetAndRoleAssignment(
+                azure.CreateSubnet(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "apiserver", APISERVER_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "$(IDENTITY_PRINCIPAL_ID)"
+                    SUBSCRIPTION_ID
                 ),
-                azure.CreateSubnetAndRoleAssignment(
+                azure.CreateSubnet(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "AzureFirewallSubnet", FIREWALL_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "$(IDENTITY_PRINCIPAL_ID)"
+                    SUBSCRIPTION_ID
                 ),
-                azure.CreateSubnetAndRoleAssignment(
+                azure.CreateSubnet(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP, VNET_NAME,
                     "jumpbox", JUMPBOX_SUBNET_CIDR,
-                    SUBSCRIPTION_ID, "$(IDENTITY_PRINCIPAL_ID)"
+                    SUBSCRIPTION_ID
                 ),
                 azure.SetupFirewallForSubnet(
                     const.DEFAULT_SERVICE_CONNECTION,

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -26,19 +26,6 @@ userPools = [azure.NodePool {
 } for pool in azure.PlanNodePools({"$(user_pool_vm_size)": USER_TOTAL_NODES}, MAX_NODES_PER_POOL)]
 
 
-createJumpboxScript = """
-az vm create \
-  --resource-group "${RESOURCE_GROUP}" \
-  --name "${JUMPBOX_NAME}" \
-  --image UbuntuLTS \
-  --size Standard_D2s_v3 \
-  --subnet "$(JUMPBOX_SUBNET_ID)" \
-  --public-ip-sku Standard \
-  --admin-username azureuser \
-  --generate-ssh-keys \
-  --nsg-rule SSH
-"""
-
 createClusterScript = """
 az extension add --name aks-preview --allow-preview true --upgrade --yes
 

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -50,7 +50,6 @@ az aks create \\
   --tier standard \\
   --assign-identity "$(IDENTITY_ID)" \\
   --tags SkipAKSCluster=true \\
-  --control-plane-scaling-size H8 \\
   --nodepool-name system \\
   --node-count 3 \\
   --node-vm-size Standard_D48ds_v5 \\
@@ -65,6 +64,8 @@ az aks create \\
   --enable-apiserver-vnet-integration \\
   --apiserver-subnet-id "$(APISERVER_SUBNET_ID)" \\
   --generate-ssh-keys \\
+  --control-plane-scaling-size H8 \\
+  --yes \\
   $NETWORK_DATAPLANE_FLAG
 """
 

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -8,7 +8,7 @@ SUBSCRIPTION_ID = "$(subscription_id)"
 RESOURCE_GROUP = "$(RUN_ID)"
 LOCATION = "$(location)"
 CLUSTER_NAME = "$(cluster_name)"
-SERVICE_CONNECTION = "$(service_connection)"
+SERVICE_CONNECTION = "$(AZURE_SERVICE_CONNECTION)"
 K8S_VERSION = "1.33.0"
 
 VNET_NAME = "${CLUSTER_NAME}-net"
@@ -96,12 +96,6 @@ output = ap.Pipeline {
 
     parameters = [
         ap.Parameter {
-            name = "service_connection"
-            displayName = "Azure service connection"
-            type = "string"
-            default = SERVICE_CONNECTION
-        }
-        ap.Parameter {
             name = "subscription_id"
             displayName = "Subscription ID"
             type = "string"
@@ -134,7 +128,6 @@ output = ap.Pipeline {
     ]
 
     variables = {
-        service_connection = "\${{ parameters.service_connection }}"
         subscription_id = "\${{ parameters.subscription_id }}"
         location = "\${{ parameters.location }}"
         cluster_name = "\${{ parameters.cluster_name }}"

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -2,18 +2,17 @@ import azure_pipelines.ap
 import azure_pipelines.ap.jobs.job
 import lib.const
 import lib.steps.azure
+import lib.steps.common
 
 SUBSCRIPTION_ID = "$(subscription_id)"
-RESOURCE_GROUP = "$(resource_group)"
+RESOURCE_GROUP = "$(RUN_ID)"
 LOCATION = "$(location)"
 CLUSTER_NAME = "$(cluster_name)"
 K8S_VERSION = "1.33.0"
 
 VNET_NAME = "${CLUSTER_NAME}-net"
 IDENTITY_NAME = "${CLUSTER_NAME}-identity"
-FW_PUBLIC_IP_NAME = "${CLUSTER_NAME}-firewall-pip"
 FW_NAME = "${CLUSTER_NAME}-firewall"
-RT_NAME = "${CLUSTER_NAME}-rt"
 JUMPBOX_NAME = "${CLUSTER_NAME}-jumpbox"
 
 VNET_CIDR = "10.0.0.0/8"
@@ -22,8 +21,11 @@ APISERVER_SUBNET_CIDR = "10.240.0.0/28"
 FIREWALL_SUBNET_CIDR = "10.2.0.0/16"
 JUMPBOX_SUBNET_CIDR = "10.3.0.0/16"
 
-USER_TOTAL_NODES = 14997    # KCL constant: change here to adjust total
-MAX_NODES_PER_POOL = 800    # KCL constant: change here to adjust split
+# Small values for small scare e2e testing; replace with the lines below for full 15K run
+# USER_TOTAL_NODES = 14997
+# MAX_NODES_PER_POOL = 800
+USER_TOTAL_NODES = 100
+MAX_NODES_PER_POOL = 20
 
 _userPools = [azure.NodePool {
     name = pool.name
@@ -35,6 +37,12 @@ _userPools = [azure.NodePool {
 
 
 createClusterScript = """
+NETWORK_DATAPLANE="$(network_dataplane)"
+NETWORK_DATAPLANE_JSON_FIELD=""
+if [ -n "$NETWORK_DATAPLANE" ]; then
+  NETWORK_DATAPLANE_JSON_FIELD='"networkDataplane": "'"$NETWORK_DATAPLANE"'",'
+fi
+
 cat > /tmp/aks-body.json << EOF
 {
   "location": "${LOCATION}",
@@ -44,10 +52,7 @@ cat > /tmp/aks-body.json << EOF
     "userAssignedIdentities": {"$(IDENTITY_ID)": {}}
   },
   "tags": {
-    "SkipAKSCluster": "true",
-    "SkipASMAzSecPackAutoConfig": "true",
-    "SkipLinuxAzSecPack": "true",
-    "exempted_by_qi": "36344494"
+    "SkipAKSCluster": "true"
   },
   "properties": {
     "controlPlaneScalingProfile": {"scalingSize": "H8"},
@@ -69,6 +74,7 @@ cat > /tmp/aks-body.json << EOF
       "networkPlugin": "azure",
       "networkPluginMode": "overlay",
       "podCidr": "10.64.0.0/10",
+      \${NETWORK_DATAPLANE_JSON_FIELD}
       "outboundType": "userDefinedRouting"
     },
     "apiServerAccessProfile": {
@@ -88,25 +94,23 @@ az rest \\
 """
 
 output = ap.Pipeline {
-    name = "15K Cilium VNet Cluster Creation"
+    name = "15K Nodes Cluster Creation"
 
     trigger = "none"
     pool = const.DEFAULT_POOL
 
     variables = {
         subscription_id = "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"
-        resource_group = "xinwei-15k-cilium-vnet"
         location = "eastasia"
-        cluster_name = "15k-private-cluster"
+        cluster_name = "15k"
         user_pool_vm_size = "Standard_D4s_v3"
         network_dataplane = "cilium"
-        kms_key_id = ""
     }
 
     jobs = [
         job.Job {
             job = "create_cluster"
-            displayName = "Create 15K Cilium Private Cluster"
+            displayName = "Create 15K Nodes Cluster"
             timeoutInMinutes = 600
 
             steps = [
@@ -115,12 +119,13 @@ output = ap.Pipeline {
                     SUBSCRIPTION_ID,
                     LOCATION
                 ),
+                common.SetRunId(),
                 azure.CreateResourceGroup(
                     const.DEFAULT_SERVICE_CONNECTION,
                     RESOURCE_GROUP,
                     LOCATION,
                     SUBSCRIPTION_ID,
-                    "SkipAKSCluster=true exempted_by_qi=36344494"
+                    "SkipAKSCluster=true"
                 ),
                 azure.CreateManagedIdentity(
                     const.DEFAULT_SERVICE_CONNECTION,
@@ -159,21 +164,11 @@ output = ap.Pipeline {
                     "jumpbox", JUMPBOX_SUBNET_CIDR,
                     SUBSCRIPTION_ID, "$(IDENTITY_CLIENT_ID)"
                 ),
-                azure.CreateFirewall(
+                azure.SetupFirewallForSubnet(
                     const.DEFAULT_SERVICE_CONNECTION,
-                    SUBSCRIPTION_ID,RESOURCE_GROUP, FW_NAME, LOCATION,
-                    VNET_NAME, FW_PUBLIC_IP_NAME
-                ),
-                azure.UpdateSubnetRouteTable(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    RESOURCE_GROUP, RT_NAME, LOCATION, VNET_NAME,
-                    "nodes","$(FIREWALL_PRIVATE_IP)", SUBSCRIPTION_ID
-                ),
-                azure.UpdateFirewallPolicy(
-                    const.DEFAULT_SERVICE_CONNECTION,
-                    SUBSCRIPTION_ID, RESOURCE_GROUP, FW_NAME,
-                    "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json",
-                    LOCATION
+                    SUBSCRIPTION_ID, RESOURCE_GROUP, LOCATION,
+                    FW_NAME, VNET_NAME, "nodes",
+                    "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json"
                 ),
                 azure.AzCli(
                     const.DEFAULT_SERVICE_CONNECTION,

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -99,13 +99,38 @@ output = ap.Pipeline {
     trigger = "none"
     pool = const.DEFAULT_POOL
 
-    variables = {
-        subscription_id = "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"
-        location = "eastasia"
-        cluster_name = "15k"
-        user_pool_vm_size = "Standard_D4s_v3"
-        network_dataplane = "cilium"
-    }
+    parameters = [
+        ap.Parameter {
+            name = "subscription_id"
+            displayName = "Subscription ID"
+            type = "string"
+            default = "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"
+        }
+        ap.Parameter {
+            name = "location"
+            displayName = "Azure region"
+            type = "string"
+            default = "eastasia"
+        }
+        ap.Parameter {
+            name = "cluster_name"
+            displayName = "AKS cluster name"
+            type = "string"
+            default = "15k"
+        }
+        ap.Parameter {
+            name = "user_pool_vm_size"
+            displayName = "User node pool VM size"
+            type = "string"
+            default = "Standard_D4s_v3"
+        }
+        ap.Parameter {
+            name = "network_dataplane"
+            displayName = "Network dataplane (leave empty for AKS default)"
+            type = "string"
+            default = "cilium"
+        }
+    ]
 
     jobs = [
         job.Job {

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -33,59 +33,39 @@ _userPools = [azure.NodePool {
 
 createClusterScript = """
 NETWORK_DATAPLANE="$(network_dataplane)"
-NETWORK_DATAPLANE_JSON_FIELD=""
+NETWORK_DATAPLANE_FLAG=""
 if [ -n "$NETWORK_DATAPLANE" ]; then
-  NETWORK_DATAPLANE_JSON_FIELD='"networkDataplane": "'"$NETWORK_DATAPLANE"'",'
+  NETWORK_DATAPLANE_FLAG="--network-dataplane $NETWORK_DATAPLANE"
 fi
 
-cat > /tmp/aks-body.json << EOF
-{
-  "location": "${LOCATION}",
-  "sku": {"name": "Base", "tier": "Standard"},
-  "identity": {
-    "type": "UserAssigned",
-    "userAssignedIdentities": {"$(IDENTITY_ID)": {}}
-  },
-  "tags": {
-    "SkipAKSCluster": "true"
-  },
-  "properties": {
-    "controlPlaneScalingProfile": {"scalingSize": "H8"},
-    "kubernetesVersion": "${K8S_VERSION}",
-    "dnsPrefix": "${CLUSTER_NAME}-dns",
-    "agentPoolProfiles": [
-      {
-        "name": "system",
-        "count": 3,
-        "vmSize": "Standard_D48ds_v5",
-        "maxPods": 60,
-        "osType": "Linux",
-        "osSKU": "Ubuntu",
-        "mode": "System",
-        "vnetSubnetID": "$(NODES_SUBNET_ID)"
-      }
-    ],
-    "networkProfile": {
-      "networkPlugin": "azure",
-      "networkPluginMode": "overlay",
-      "podCidr": "10.64.0.0/10",
-      \${NETWORK_DATAPLANE_JSON_FIELD}
-      "outboundType": "userDefinedRouting"
-    },
-    "apiServerAccessProfile": {
-      "enablePrivateCluster": true,
-      "enableVnetIntegration": true,
-      "subnetId": "$(APISERVER_SUBNET_ID)"
-    }
-  }
-}
-EOF
+az extension add --name aks-preview --allow-preview true --upgrade --yes
 
-az rest \\
-  --method put \\
-  --uri "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.ContainerService/managedClusters/${CLUSTER_NAME}?api-version=2026-01-02-preview" \\
-  --headers "Content-Type=application/json" \\
-  --body "@/tmp/aks-body.json"
+az aks create \\
+  --subscription "${SUBSCRIPTION_ID}" \\
+  --resource-group "${RESOURCE_GROUP}" \\
+  --name "${CLUSTER_NAME}" \\
+  --location "${LOCATION}" \\
+  --kubernetes-version "${K8S_VERSION}" \\
+  --dns-name-prefix "${CLUSTER_NAME}-dns" \\
+  --tier standard \\
+  --assign-identity "$(IDENTITY_ID)" \\
+  --tags SkipAKSCluster=true \\
+  --control-plane-scaling-size H8 \\
+  --nodepool-name system \\
+  --node-count 3 \\
+  --node-vm-size Standard_D48ds_v5 \\
+  --max-pods 60 \\
+  --os-sku Ubuntu \\
+  --vnet-subnet-id "$(NODES_SUBNET_ID)" \\
+  --network-plugin azure \\
+  --network-plugin-mode overlay \\
+  --pod-cidr 10.64.0.0/10 \\
+  --outbound-type userDefinedRouting \\
+  --enable-private-cluster \\
+  --enable-apiserver-vnet-integration \\
+  --apiserver-subnet-id "$(APISERVER_SUBNET_ID)" \\
+  --generate-ssh-keys \\
+  $NETWORK_DATAPLANE_FLAG
 """
 
 output = ap.Pipeline {

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -132,6 +132,14 @@ output = ap.Pipeline {
         }
     ]
 
+    variables = {
+        subscription_id = "\${{ parameters.subscription_id }}"
+        location = "\${{ parameters.location }}"
+        cluster_name = "\${{ parameters.cluster_name }}"
+        user_pool_vm_size = "\${{ parameters.user_pool_vm_size }}"
+        network_dataplane = "\${{ parameters.network_dataplane }}"
+    }
+
     jobs = [
         job.Job {
             job = "create_cluster"

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -1,0 +1,230 @@
+import azure_pipelines.ap
+import azure_pipelines.ap.jobs.job
+import lib.const
+import lib.steps.azure
+
+SUBSCRIPTION_ID = "$(subscription_id)"
+RESOURCE_GROUP = "$(resource_group)"
+LOCATION = "$(location)"
+CLUSTER_NAME = "$(cluster_name)"
+K8S_VERSION = "1.33.0"
+
+VNET_NAME = "${CLUSTER_NAME}-net"
+IDENTITY_NAME = "${CLUSTER_NAME}-identity"
+FW_PUBLIC_IP_NAME = "${CLUSTER_NAME}-firewall-pip"
+FW_NAME = "${CLUSTER_NAME}-firewall"
+RT_NAME = "${CLUSTER_NAME}-rt"
+JUMPBOX_NAME = "${CLUSTER_NAME}-jumpbox"
+
+VNET_CIDR = "10.0.0.0/8"
+NODES_SUBNET_CIDR = "10.1.0.0/18"
+APISERVER_SUBNET_CIDR = "10.240.0.0/28"
+FIREWALL_SUBNET_CIDR = "10.2.0.0/16"
+JUMPBOX_SUBNET_CIDR = "10.3.0.0/16"
+
+USER_TOTAL_NODES = 14997    # KCL constant: change here to adjust total
+MAX_NODES_PER_POOL = 800    # KCL constant: change here to adjust split
+
+_userPools = [azure.NodePool {
+    name = pool.name
+    sku = pool.sku
+    count = pool.count
+    vnetSubnetId = "$(NODE_SUBNET_ID)"
+    osSKU = "Ubuntu"
+} for pool in azure.PlanNodePools({"$(user_pool_vm_size)": USER_TOTAL_NODES}, MAX_NODES_PER_POOL)]
+
+
+createClusterScript = """
+cat > /tmp/aks-body.json << EOF
+{
+  "location": "${LOCATION}",
+  "sku": {"name": "Base", "tier": "Standard"},
+  "identity": {
+    "type": "UserAssigned",
+    "userAssignedIdentities": {"$(IDENTITY_ID)": {}}
+  },
+  "tags": {
+    "SkipAKSCluster": "true",
+    "SkipASMAzSecPackAutoConfig": "true",
+    "SkipLinuxAzSecPack": "true",
+    "exempted_by_qi": "36344494"
+  },
+  "properties": {
+    "controlPlaneScalingProfile": {"scalingSize": "H8"},
+    "kubernetesVersion": "${K8S_VERSION}",
+    "dnsPrefix": "${CLUSTER_NAME}-dns",
+    "agentPoolProfiles": [
+      {
+        "name": "system",
+        "count": 10,
+        "vmSize": "Standard_D48s_v3",
+        "maxPods": 60,
+        "osType": "Linux",
+        "osSKU": "Ubuntu",
+        "mode": "System",
+        "vnetSubnetID": "$(NODE_SUBNET_ID)"
+      }
+    ],
+    "networkProfile": {
+      "networkPlugin": "azure",
+      "networkPluginMode": "overlay",
+      "networkDataplane": "cilium",
+      "podCidr": "10.64.0.0/10",
+      "outboundType": "userDefinedRouting"
+    },
+    "apiServerAccessProfile": {
+      "enablePrivateCluster": true,
+      "enableVnetIntegration": true,
+      "subnetId": "$(APISERVER_SUBNET_ID)"
+    }
+  }
+}
+EOF
+
+az rest \\
+  --method put \\
+  --uri "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.ContainerService/managedClusters/${CLUSTER_NAME}?api-version=2026-01-02-preview" \\
+  --headers "Content-Type=application/json" \\
+  --body "@/tmp/aks-body.json"
+"""
+
+output = ap.Pipeline {
+    name = "15K Cilium VNet Cluster Creation"
+
+    trigger = "none"
+    pool = const.DEFAULT_POOL
+
+    variables = {
+        subscription_id = "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"
+        resource_group = "xinwei-15k-cilium-vnet"
+        location = "eastasia"
+        cluster_name = "15k-private-cluster"
+        user_pool_vm_size = "Standard_D4s_v3"
+    }
+
+    jobs = [
+        job.Job {
+            job = "create_cluster"
+            displayName = "Create 15K Cilium Private Cluster"
+            timeoutInMinutes = 600
+
+            steps = [
+                azure.Login(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    SUBSCRIPTION_ID,
+                    LOCATION
+                ),
+                azure.CreateResourceGroup(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP,
+                    LOCATION,
+                    SUBSCRIPTION_ID,
+                    "SkipAKSCluster=true exempted_by_qi=36344494"
+                ),
+                azure.CreateManagedIdentity(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP,
+                    IDENTITY_NAME,
+                    SUBSCRIPTION_ID
+                ),
+                azure.CreateVNet(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP,
+                    VNET_NAME,
+                    VNET_CIDR,
+                    SUBSCRIPTION_ID
+                ),
+                azure.CreateSubnet(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, VNET_NAME,
+                    "nodes", NODES_SUBNET_CIDR,
+                    SUBSCRIPTION_ID, "NODE_SUBNET_ID"
+                ),
+                azure.CreateRoleAssignment(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    "$(NODE_SUBNET_ID)", "Network Contributor",
+                    "$(IDENTITY_CLIENT_ID)", SUBSCRIPTION_ID
+                ),
+                azure.CreateSubnet(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, VNET_NAME,
+                    "apiserver", APISERVER_SUBNET_CIDR,
+                    SUBSCRIPTION_ID, "APISERVER_SUBNET_ID"
+                ),
+                azure.CreateRoleAssignment(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    "$(APISERVER_SUBNET_ID)", "Network Contributor",
+                    "$(IDENTITY_CLIENT_ID)", SUBSCRIPTION_ID
+                ),
+                azure.CreateSubnet(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, VNET_NAME,
+                    "AzureFirewallSubnet", FIREWALL_SUBNET_CIDR,
+                    SUBSCRIPTION_ID, "FIREWALL_SUBNET_ID"
+                ),
+                azure.CreateRoleAssignment(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    "$(FIREWALL_SUBNET_ID)", "Network Contributor",
+                    "$(IDENTITY_CLIENT_ID)", SUBSCRIPTION_ID
+                ),
+                azure.CreateSubnet(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, VNET_NAME,
+                    "jumpbox", JUMPBOX_SUBNET_CIDR,
+                    SUBSCRIPTION_ID
+                ),
+                azure.CreateFirewall(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, FW_NAME, LOCATION,
+                    VNET_NAME, FW_PUBLIC_IP_NAME, SUBSCRIPTION_ID
+                ),
+                azure.CreateRouteTable(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, RT_NAME, LOCATION,
+                    SUBSCRIPTION_ID
+                ),
+                azure.CreateRoute(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, RT_NAME,
+                    "egress", "0.0.0.0/0",
+                    "VirtualAppliance", "$(FWPRIVATE_IP)",
+                    SUBSCRIPTION_ID
+                ),
+                azure.AssociateRouteTable(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, VNET_NAME,
+                    "nodes", RT_NAME, SUBSCRIPTION_ID
+                ),
+                azure.UpdateFirewallPolicy(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    RESOURCE_GROUP, FW_NAME, SUBSCRIPTION_ID,
+                    "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json",
+                    LOCATION
+                ),
+                azure.AzCli(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    "Create jumpbox",
+                    createJumpboxScript
+                ),
+                azure.AzCli(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    "Create AKS cluster",
+                    createClusterScript
+                ),
+                azure.WaitForClusterSucceeded(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    CLUSTER_NAME,
+                    RESOURCE_GROUP,
+                    SUBSCRIPTION_ID
+                ),
+                *[azure.CreateNodePool(
+                    const.DEFAULT_SERVICE_CONNECTION,
+                    CLUSTER_NAME,
+                    RESOURCE_GROUP,
+                    SUBSCRIPTION_ID,
+                    pool
+                ) for pool in _userPools],
+            ]
+        }
+    ]
+}

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -14,11 +14,8 @@ K8S_VERSION = "1.35.0"
 VNET_NAME = "${CLUSTER_NAME}-net"
 JUMPBOX_NAME = "${CLUSTER_NAME}-jumpbox"
 
-# Small values for small scare e2e testing; replace with the lines below for full 15K run
-# USER_TOTAL_NODES = 14997
-# MAX_NODES_PER_POOL = 800
-USER_TOTAL_NODES = 100
-MAX_NODES_PER_POOL = 20
+USER_TOTAL_NODES = 14997
+MAX_NODES_PER_POOL = 800
 
 userPools = [azure.NodePool {
     name = pool.name
@@ -28,6 +25,19 @@ userPools = [azure.NodePool {
     osSKU = "Ubuntu"
 } for pool in azure.PlanNodePools({"$(user_pool_vm_size)": USER_TOTAL_NODES}, MAX_NODES_PER_POOL)]
 
+
+createJumpboxScript = """
+az vm create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${JUMPBOX_NAME}" \
+  --image UbuntuLTS \
+  --size Standard_D2s_v3 \
+  --subnet "$(JUMPBOX_SUBNET_ID)" \
+  --public-ip-sku Standard \
+  --admin-username azureuser \
+  --generate-ssh-keys \
+  --nsg-rule SSH
+"""
 
 createClusterScript = """
 az extension add --name aks-preview --allow-preview true --upgrade --yes
@@ -54,14 +64,14 @@ CREATE_ARGS=(
   --pod-cidr 10.64.0.0/10
   --outbound-type userDefinedRouting
   --enable-private-cluster
-  --enable-apiserver-vnet-integration
-  --apiserver-subnet-id "$(APISERVER_SUBNET_ID)"
   --auto-upgrade-channel none
   --node-os-upgrade-channel None
   --generate-ssh-keys
   --yes
 )
 [[ -n "$(network_dataplane)" ]] && CREATE_ARGS+=(--network-dataplane "$(network_dataplane)")
+[[ "$(apiserver_vnet_integration)" == "true" ]] && CREATE_ARGS+=(--enable-apiserver-vnet-integration --apiserver-subnet-id "$(APISERVER_SUBNET_ID)")
+
 
 az aks create "\${CREATE_ARGS[@]}"
 """
@@ -103,6 +113,12 @@ output = ap.Pipeline {
             type = "string"
             default = "cilium"
         }
+        ap.Parameter {
+            name = "apiserver_vnet_integration"
+            displayName = "Enable API server vNet integration (leave empty to disable)"
+            type = "string"
+            default = "true"
+        }
     ]
 
     variables = {
@@ -111,6 +127,7 @@ output = ap.Pipeline {
         cluster_name = "\${{ parameters.cluster_name }}"
         user_pool_vm_size = "\${{ parameters.user_pool_vm_size }}"
         network_dataplane = "\${{ parameters.network_dataplane }}"
+        apiserver_vnet_integration = "\${{ parameters.apiserver_vnet_integration }}"
     }
 
     jobs = [

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -191,7 +191,9 @@ output = ap.Pipeline {
                     "${CLUSTER_NAME}-firewall",
                     VNET_NAME,
                     "nodes",
-                    "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json"
+                    "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json",
+                    minCapacity="45",
+                    maxCapacity="45"
                 ),
                 azure.AzCli(
                     SERVICE_CONNECTION,

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -58,9 +58,27 @@ CREATE_ARGS=(
 )
 [[ -n "$(network_dataplane)" ]] && CREATE_ARGS+=(--network-dataplane "$(network_dataplane)")
 [[ "$(apiserver_vnet_integration)" == "true" ]] && CREATE_ARGS+=(--enable-apiserver-vnet-integration --apiserver-subnet-id "$(APISERVER_SUBNET_ID)")
+[[ -n "$(kms_key_id)" ]] && CREATE_ARGS+=(--enable-azure-keyvault-kms --azure-keyvault-kms-key-id "$(kms_key_id)" --azure-keyvault-kms-key-vault-network-access Public)
 
 
 az aks create "\${CREATE_ARGS[@]}"
+"""
+
+grantKmsAccessScript = """
+KEY_ID="$(kms_key_id)"
+HOST="\${KEY_ID#https://}"
+VAULT_NAME="\${HOST%%.*}"
+
+KEY_VAULT_RESOURCE_ID=$(az keyvault show \\
+  --subscription "${SUBSCRIPTION_ID}" \\
+  --name "\${VAULT_NAME}" \\
+  --query id -o tsv)
+
+az role assignment create \\
+  --role "Key Vault Crypto User" \\
+  --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \\
+  --assignee-principal-type ServicePrincipal \\
+  --scope "\${KEY_VAULT_RESOURCE_ID}"
 """
 
 output = ap.Pipeline {
@@ -106,6 +124,12 @@ output = ap.Pipeline {
             type = "string"
             default = "true"
         }
+        ap.Parameter {
+            name = "kms_key_id"
+            displayName = "Azure Key Vault KMS key ID (versioned key URI; leave empty to disable KMS)"
+            type = "string"
+            default = ""
+        }
     ]
 
     variables = {
@@ -115,6 +139,7 @@ output = ap.Pipeline {
         user_pool_vm_size = "\${{ parameters.user_pool_vm_size }}"
         network_dataplane = "\${{ parameters.network_dataplane }}"
         apiserver_vnet_integration = "\${{ parameters.apiserver_vnet_integration }}"
+        kms_key_id = "\${{ parameters.kms_key_id }}"
     }
 
     jobs = [
@@ -199,6 +224,12 @@ output = ap.Pipeline {
                     SERVICE_CONNECTION,
                     "Create jumpbox",
                     createJumpboxScript
+                ),
+                azure.AzCli(
+                    SERVICE_CONNECTION,
+                    "Grant KMS access to cluster identity",
+                    grantKmsAccessScript,
+                    condition = "ne(variables['kms_key_id'], '')"
                 ),
                 azure.AzCli(
                     SERVICE_CONNECTION,

--- a/kcl/ccp_team/15K_cluster/pipeline.k
+++ b/kcl/ccp_team/15K_cluster/pipeline.k
@@ -58,7 +58,7 @@ CREATE_ARGS=(
 )
 [[ -n "$(network_dataplane)" ]] && CREATE_ARGS+=(--network-dataplane "$(network_dataplane)")
 [[ "$(apiserver_vnet_integration)" == "true" ]] && CREATE_ARGS+=(--enable-apiserver-vnet-integration --apiserver-subnet-id "$(APISERVER_SUBNET_ID)")
-[[ -n "$(kms_key_id)" ]] && CREATE_ARGS+=(--enable-azure-keyvault-kms --azure-keyvault-kms-key-id "$(kms_key_id)" --azure-keyvault-kms-key-vault-network-access Public)
+[[ "$(kms_key_id)" != "none" ]] && CREATE_ARGS+=(--enable-azure-keyvault-kms --azure-keyvault-kms-key-id "$(kms_key_id)" --azure-keyvault-kms-key-vault-network-access Public)
 
 
 az aks create "\${CREATE_ARGS[@]}"
@@ -126,9 +126,9 @@ output = ap.Pipeline {
         }
         ap.Parameter {
             name = "kms_key_id"
-            displayName = "Azure Key Vault KMS key ID (versioned key URI; leave empty to disable KMS)"
+            displayName = "Azure Key Vault KMS key ID (versioned key URI; use 'none' to disable KMS)"
             type = "string"
-            default = ""
+            default = "none"
         }
     ]
 
@@ -229,7 +229,7 @@ output = ap.Pipeline {
                     SERVICE_CONNECTION,
                     "Grant KMS access to cluster identity",
                     grantKmsAccessScript,
-                    condition = "ne(variables['kms_key_id'], '')"
+                    condition = "ne(variables['kms_key_id'], 'none')"
                 ),
                 azure.AzCli(
                     SERVICE_CONNECTION,

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -1,0 +1,829 @@
+name: '15K Cilium VNet Cluster Creation'
+pool: AKS-Telescope-Airlock
+trigger: none
+variables:
+  subscription_id: b8ceb4e5-f05b-4562-a9f5-14acb1f24219
+  resource_group: xinwei-15k-cilium-vnet
+  location: eastasia
+  cluster_name: '15k-private-cluster'
+  user_pool_vm_size: Standard_D4s_v3
+jobs:
+- job: create_cluster
+  displayName: Create 15K Cilium Private Cluster
+  timeoutInMinutes: 600
+  steps:
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az account set --subscription "$(subscription_id)"
+        az config set defaults.location="$(location)"
+        az account show
+    displayName: Login to Azure
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az group create \
+          --name "$(resource_group)" \
+          --location "$(location)" \
+          --subscription "$(subscription_id)" \
+          --tags SkipAKSCluster=true exempted_by_qi=36344494
+    displayName: Create resource group in $(location) ($(subscription_id))
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az identity create \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-identity" \
+          --subscription "$(subscription_id)"
+
+        IDENTITY_CLIENT_ID=$(az identity show \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-identity" \
+          --subscription "$(subscription_id)" \
+          --query clientId -o tsv)
+        echo "##vso[task.setvariable variable=IDENTITY_CLIENT_ID]$IDENTITY_CLIENT_ID"
+
+        IDENTITY_ID=$(az identity show \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-identity" \
+          --subscription "$(subscription_id)" \
+          --query id -o tsv)
+        echo "##vso[task.setvariable variable=IDENTITY_ID]$IDENTITY_ID"
+    displayName: Create managed identity $(cluster_name)-identity
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az network vnet create \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-net" \
+          --address-prefixes 10.0.0.0/8 \
+          --subscription "$(subscription_id)"
+    displayName: Create VNet $(cluster_name)-net
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az network vnet subnet create \
+          --resource-group "$(resource_group)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "nodes" \
+          --address-prefixes 10.1.0.0/18 \
+          --subscription "$(subscription_id)"
+
+        SUBNET_ID=$(az network vnet subnet show \
+          --resource-group "$(resource_group)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "nodes" \
+          --subscription "$(subscription_id)" \
+          --query id -o tsv)
+        echo "##vso[task.setvariable variable=NODE_SUBNET_ID]$SUBNET_ID"
+    displayName: Create subnet nodes
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az role assignment create \
+          --scope "$(NODE_SUBNET_ID)" \
+          --role "Network Contributor" \
+          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --subscription "$(subscription_id)"
+    displayName: Assign role Network Contributor
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az network vnet subnet create \
+          --resource-group "$(resource_group)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "apiserver" \
+          --address-prefixes 10.240.0.0/28 \
+          --subscription "$(subscription_id)"
+
+        SUBNET_ID=$(az network vnet subnet show \
+          --resource-group "$(resource_group)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "apiserver" \
+          --subscription "$(subscription_id)" \
+          --query id -o tsv)
+        echo "##vso[task.setvariable variable=APISERVER_SUBNET_ID]$SUBNET_ID"
+    displayName: Create subnet apiserver
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az role assignment create \
+          --scope "$(APISERVER_SUBNET_ID)" \
+          --role "Network Contributor" \
+          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --subscription "$(subscription_id)"
+    displayName: Assign role Network Contributor
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az network vnet subnet create \
+          --resource-group "$(resource_group)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "AzureFirewallSubnet" \
+          --address-prefixes 10.2.0.0/16 \
+          --subscription "$(subscription_id)"
+
+        SUBNET_ID=$(az network vnet subnet show \
+          --resource-group "$(resource_group)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "AzureFirewallSubnet" \
+          --subscription "$(subscription_id)" \
+          --query id -o tsv)
+        echo "##vso[task.setvariable variable=FIREWALL_SUBNET_ID]$SUBNET_ID"
+    displayName: Create subnet AzureFirewallSubnet
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az role assignment create \
+          --scope "$(FIREWALL_SUBNET_ID)" \
+          --role "Network Contributor" \
+          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --subscription "$(subscription_id)"
+    displayName: Assign role Network Contributor
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az network vnet subnet create \
+          --resource-group "$(resource_group)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "jumpbox" \
+          --address-prefixes 10.3.0.0/16 \
+          --subscription "$(subscription_id)"
+    displayName: Create subnet jumpbox
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az extension add --name azure-firewall
+
+        az network public-ip create \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-firewall-pip" \
+          --sku Standard \
+          --location "$(location)" \
+          --subscription "$(subscription_id)"
+
+        az network firewall create \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-firewall" \
+          --location "$(location)" \
+          --enable-dns-proxy true \
+          --subscription "$(subscription_id)"
+
+        az network firewall ip-config create \
+          --resource-group "$(resource_group)" \
+          --firewall-name "$(cluster_name)-firewall" \
+          --name "$(cluster_name)-firewall-ipconfig" \
+          --public-ip-address "$(cluster_name)-firewall-pip" \
+          --vnet-name "$(cluster_name)-net" \
+          --subscription "$(subscription_id)"
+
+        FWPRIVATE_IP=$(az network firewall show \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-firewall" \
+          --subscription "$(subscription_id)" \
+          --query "ipConfigurations[0].privateIPAddress" -o tsv)
+        echo "##vso[task.setvariable variable=FWPRIVATE_IP]$FWPRIVATE_IP"
+    displayName: Create firewall $(cluster_name)-firewall
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az network route-table create \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-rt" \
+          --location "$(location)" \
+          --subscription "$(subscription_id)"
+    displayName: Create route table $(cluster_name)-rt
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az network route-table route create \
+          --resource-group "$(resource_group)" \
+          --route-table-name "$(cluster_name)-rt" \
+          --name "egress" \
+          --address-prefix 0.0.0.0/0 \
+          --next-hop-type VirtualAppliance \
+          --next-hop-ip-address "$(FWPRIVATE_IP)" \
+          --subscription "$(subscription_id)"
+    displayName: Create route egress in $(cluster_name)-rt
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az network vnet subnet update \
+          --resource-group "$(resource_group)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "nodes" \
+          --route-table "$(cluster_name)-rt" \
+          --subscription "$(subscription_id)"
+    displayName: Associate route table $(cluster_name)-rt with subnet nodes
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        POLICY_TMP=$(mktemp)
+        sed 's|"location": "[^"]*"|"location": "$(location)"|g' "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json" > "$POLICY_TMP"
+        az rest \
+          --method put \
+          --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(resource_group)/providers/Microsoft.Network/azureFirewalls/$(cluster_name)-firewall?api-version=2023-09-01" \
+          --headers "Content-Type=application/json" \
+          --body "@$POLICY_TMP"
+        rm -f "$POLICY_TMP"
+    displayName: Update firewall policy $(cluster_name)-firewall
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        cat > /tmp/cloud-init.yaml << 'CLOUDINIT'
+        #cloud-config
+        package_update: true
+        package_upgrade: true
+        packages:
+          - git
+          - ca-certificates
+          - curl
+          - apt-transport-https
+          - lsb-release
+          - gnupg
+        runcmd:
+          - curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+          - wget -q https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -O /tmp/go.tar.gz
+          - tar -C /usr/local -xzf /tmp/go.tar.gz
+          - echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
+          - rm /tmp/go.tar.gz
+        CLOUDINIT
+
+        az vm create \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-jumpbox" \
+          --image Ubuntu2204 \
+          --size Standard_D48s_v3 \
+          --vnet-name "$(cluster_name)-net" \
+          --subnet jumpbox \
+          --public-ip-address "$(cluster_name)-jumpbox-pip" \
+          --admin-username azureuser \
+          --admin-password "$(JUMPBOX_ADMIN_PASSWORD)" \
+          --authentication-type password \
+          --custom-data /tmp/cloud-init.yaml \
+          --subscription "$(subscription_id)"
+
+        az vm open-port \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-jumpbox" \
+          --port 22 \
+          --priority 1001 \
+          --subscription "$(subscription_id)"
+
+        JUMPBOX_PRINCIPAL_ID=$(az vm identity assign \
+          --resource-group "$(resource_group)" \
+          --name "$(cluster_name)-jumpbox" \
+          --subscription "$(subscription_id)" \
+          --query systemAssignedIdentity -o tsv)
+
+        RG_ID=$(az group show \
+          --name "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --query id -o tsv)
+
+        for role in \
+          "Azure Kubernetes Service Cluster Admin Role" \
+          "Azure Kubernetes Service Cluster User Role" \
+          "Azure Kubernetes Service Contributor Role" \
+          "Azure Kubernetes Service RBAC Cluster Admin"; do
+          az role assignment create \
+            --assignee $JUMPBOX_PRINCIPAL_ID \
+            --role "$role" \
+            --scope $RG_ID \
+            --subscription "$(subscription_id)"
+        done
+    displayName: Create jumpbox
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        cat > /tmp/aks-body.json << EOF
+        {
+          "location": "$(location)",
+          "sku": {"name": "Base", "tier": "Standard"},
+          "identity": {
+            "type": "UserAssigned",
+            "userAssignedIdentities": {"$(IDENTITY_ID)": {}}
+          },
+          "tags": {
+            "SkipAKSCluster": "true",
+            "SkipASMAzSecPackAutoConfig": "true",
+            "SkipLinuxAzSecPack": "true",
+            "exempted_by_qi": "36344494"
+          },
+          "properties": {
+            "controlPlaneScalingProfile": {"scalingSize": "H8"},
+            "kubernetesVersion": "1.33.0",
+            "dnsPrefix": "$(cluster_name)-dns",
+            "agentPoolProfiles": [
+              {
+                "name": "system",
+                "count": 10,
+                "vmSize": "Standard_D48s_v3",
+                "maxPods": 60,
+                "osType": "Linux",
+                "osSKU": "Ubuntu",
+                "mode": "System",
+                "vnetSubnetID": "$(NODE_SUBNET_ID)"
+              }
+            ],
+            "networkProfile": {
+              "networkPlugin": "azure",
+              "networkPluginMode": "overlay",
+              "networkDataplane": "cilium",
+              "podCidr": "10.64.0.0/10",
+              "outboundType": "userDefinedRouting"
+            },
+            "apiServerAccessProfile": {
+              "enablePrivateCluster": true,
+              "enableVnetIntegration": true,
+              "subnetId": "$(APISERVER_SUBNET_ID)"
+            }
+          }
+        }
+        EOF
+
+        az rest \
+          --method put \
+          --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(resource_group)/providers/Microsoft.ContainerService/managedClusters/$(cluster_name)?api-version=2026-01-02-preview" \
+          --headers "Content-Type=application/json" \
+          --body "@/tmp/aks-body.json"
+    displayName: Create AKS cluster
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        while true; do
+          STATE=$(az aks show \
+            --name "$(cluster_name)" \
+            --resource-group "$(resource_group)" \
+            --subscription "$(subscription_id)" \
+            --query "provisioningState" \
+            --output tsv)
+          echo "Cluster provisioning state: $STATE"
+          if [ "$STATE" = "Succeeded" ]; then
+            echo "Cluster is ready."
+            break
+          elif [ "$STATE" = "Failed" ] || [ "$STATE" = "Canceled" ]; then
+            echo "Cluster failed with state: $STATE."
+            exit 1
+          else
+            echo "Provisioning state: $STATE. Retry in 30 seconds"
+          fi
+          sleep 30
+        done
+    displayName: Wait for cluster to succeed
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool0" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool0
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool1" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool1
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool2" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool2
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool3" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool3
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool4" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool4
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool5" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool5
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool6" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool6
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool7" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool7
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool8" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool8
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool9" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool9
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool10" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool10
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool11" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool11
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool12" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool12
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool13" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool13
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool14" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool14
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool15" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool15
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool16" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool16
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool17" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool17
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(resource_group)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool18" \
+          --node-count 597 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool18

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -1,15 +1,15 @@
-name: '15K Cilium VNet Cluster Creation'
+name: '15K Nodes Cluster Creation'
 pool: AKS-Telescope-Airlock
 trigger: none
 variables:
   subscription_id: b8ceb4e5-f05b-4562-a9f5-14acb1f24219
-  resource_group: xinwei-15k-cilium-vnet
   location: eastasia
-  cluster_name: '15k-private-cluster'
+  cluster_name: '15k'
   user_pool_vm_size: Standard_D4s_v3
+  network_dataplane: cilium
 jobs:
 - job: create_cluster
-  displayName: Create 15K Cilium Private Cluster
+  displayName: Create 15K Nodes Cluster
   timeoutInMinutes: 600
   steps:
   - task: AzureCLI@2
@@ -24,6 +24,16 @@ jobs:
         az config set defaults.location="$(location)"
         az account show
     displayName: Login to Azure
+  - bash: |2
+
+      set -eo pipefail
+
+      job_id="$(System.JobId)"
+      RUN_ID=$(Build.BuildId)-${job_id:0:8}
+      echo "Run ID: $RUN_ID"
+
+      echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+    displayName: Set Run ID
   - task: AzureCLI@2
     inputs:
       azureSubscription: Azure-for-Telescope-internal
@@ -33,10 +43,10 @@ jobs:
         set -exo pipefail
 
         az group create \
-          --name "$(resource_group)" \
+          --name "$(RUN_ID)" \
           --location "$(location)" \
           --subscription "$(subscription_id)" \
-          --tags SkipAKSCluster=true exempted_by_qi=36344494
+        --tags SkipAKSCluster=true
     displayName: Create resource group in $(location) ($(subscription_id))
   - task: AzureCLI@2
     inputs:
@@ -47,23 +57,16 @@ jobs:
         set -exo pipefail
 
         az identity create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-identity" \
           --subscription "$(subscription_id)"
 
-        IDENTITY_CLIENT_ID=$(az identity show \
-          --resource-group "$(resource_group)" \
+        IDENTITY=$(az identity show \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-identity" \
-          --subscription "$(subscription_id)" \
-          --query clientId -o tsv)
-        echo "##vso[task.setvariable variable=IDENTITY_CLIENT_ID]$IDENTITY_CLIENT_ID"
-
-        IDENTITY_ID=$(az identity show \
-          --resource-group "$(resource_group)" \
-          --name "$(cluster_name)-identity" \
-          --subscription "$(subscription_id)" \
-          --query id -o tsv)
-        echo "##vso[task.setvariable variable=IDENTITY_ID]$IDENTITY_ID"
+          --subscription "$(subscription_id)")
+        echo "##vso[task.setvariable variable=IDENTITY_CLIENT_ID]$(echo "$IDENTITY" | jq -r '.clientId')"
+        echo "##vso[task.setvariable variable=IDENTITY_ID]$(echo "$IDENTITY" | jq -r '.id')"
     displayName: Create managed identity $(cluster_name)-identity
   - task: AzureCLI@2
     inputs:
@@ -74,7 +77,7 @@ jobs:
         set -exo pipefail
 
         az network vnet create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-net" \
           --address-prefixes 10.0.0.0/8 \
           --subscription "$(subscription_id)"
@@ -88,19 +91,26 @@ jobs:
         set -exo pipefail
 
         az network vnet subnet create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --vnet-name "$(cluster_name)-net" \
           --name "nodes" \
           --address-prefixes 10.1.0.0/18 \
           --subscription "$(subscription_id)"
 
         SUBNET_ID=$(az network vnet subnet show \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --vnet-name "$(cluster_name)-net" \
           --name "nodes" \
           --subscription "$(subscription_id)" \
           --query id -o tsv)
-        echo "##vso[task.setvariable variable=NODE_SUBNET_ID]$SUBNET_ID"
+
+        az role assignment create \
+          --scope $SUBNET_ID \
+          --role "Network Contributor" \
+          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --subscription "$(subscription_id)"
+
+        echo "##vso[task.setvariable variable=NODES_SUBNET_ID]$SUBNET_ID"
     displayName: Create subnet nodes
   - task: AzureCLI@2
     inputs:
@@ -110,33 +120,26 @@ jobs:
       inlineScript: |
         set -exo pipefail
 
-        az role assignment create \
-          --scope "$(NODE_SUBNET_ID)" \
-          --role "Network Contributor" \
-          --assignee "$(IDENTITY_CLIENT_ID)" \
-          --subscription "$(subscription_id)"
-    displayName: Assign role Network Contributor
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
         az network vnet subnet create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --vnet-name "$(cluster_name)-net" \
           --name "apiserver" \
           --address-prefixes 10.240.0.0/28 \
           --subscription "$(subscription_id)"
 
         SUBNET_ID=$(az network vnet subnet show \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --vnet-name "$(cluster_name)-net" \
           --name "apiserver" \
           --subscription "$(subscription_id)" \
           --query id -o tsv)
+
+        az role assignment create \
+          --scope $SUBNET_ID \
+          --role "Network Contributor" \
+          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --subscription "$(subscription_id)"
+
         echo "##vso[task.setvariable variable=APISERVER_SUBNET_ID]$SUBNET_ID"
     displayName: Create subnet apiserver
   - task: AzureCLI@2
@@ -147,34 +150,27 @@ jobs:
       inlineScript: |
         set -exo pipefail
 
-        az role assignment create \
-          --scope "$(APISERVER_SUBNET_ID)" \
-          --role "Network Contributor" \
-          --assignee "$(IDENTITY_CLIENT_ID)" \
-          --subscription "$(subscription_id)"
-    displayName: Assign role Network Contributor
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
         az network vnet subnet create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --vnet-name "$(cluster_name)-net" \
           --name "AzureFirewallSubnet" \
           --address-prefixes 10.2.0.0/16 \
           --subscription "$(subscription_id)"
 
         SUBNET_ID=$(az network vnet subnet show \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --vnet-name "$(cluster_name)-net" \
           --name "AzureFirewallSubnet" \
           --subscription "$(subscription_id)" \
           --query id -o tsv)
-        echo "##vso[task.setvariable variable=FIREWALL_SUBNET_ID]$SUBNET_ID"
+
+        az role assignment create \
+          --scope $SUBNET_ID \
+          --role "Network Contributor" \
+          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --subscription "$(subscription_id)"
+
+        echo "##vso[task.setvariable variable=AZUREFIREWALLSUBNET_SUBNET_ID]$SUBNET_ID"
     displayName: Create subnet AzureFirewallSubnet
   - task: AzureCLI@2
     inputs:
@@ -184,26 +180,27 @@ jobs:
       inlineScript: |
         set -exo pipefail
 
-        az role assignment create \
-          --scope "$(FIREWALL_SUBNET_ID)" \
-          --role "Network Contributor" \
-          --assignee "$(IDENTITY_CLIENT_ID)" \
-          --subscription "$(subscription_id)"
-    displayName: Assign role Network Contributor
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
         az network vnet subnet create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --vnet-name "$(cluster_name)-net" \
           --name "jumpbox" \
           --address-prefixes 10.3.0.0/16 \
           --subscription "$(subscription_id)"
+
+        SUBNET_ID=$(az network vnet subnet show \
+          --resource-group "$(RUN_ID)" \
+          --vnet-name "$(cluster_name)-net" \
+          --name "jumpbox" \
+          --subscription "$(subscription_id)" \
+          --query id -o tsv)
+
+        az role assignment create \
+          --scope $SUBNET_ID \
+          --role "Network Contributor" \
+          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --subscription "$(subscription_id)"
+
+        echo "##vso[task.setvariable variable=JUMPBOX_SUBNET_ID]$SUBNET_ID"
     displayName: Create subnet jumpbox
   - task: AzureCLI@2
     inputs:
@@ -216,97 +213,69 @@ jobs:
         az extension add --name azure-firewall
 
         az network public-ip create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-firewall-pip" \
           --sku Standard \
           --location "$(location)" \
           --subscription "$(subscription_id)"
 
         az network firewall create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-firewall" \
           --location "$(location)" \
           --enable-dns-proxy true \
           --subscription "$(subscription_id)"
 
         az network firewall ip-config create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --firewall-name "$(cluster_name)-firewall" \
           --name "$(cluster_name)-firewall-ipconfig" \
           --public-ip-address "$(cluster_name)-firewall-pip" \
           --vnet-name "$(cluster_name)-net" \
           --subscription "$(subscription_id)"
 
-        FWPRIVATE_IP=$(az network firewall show \
-          --resource-group "$(resource_group)" \
+        FIREWALL_PRIVATE_IP=$(az network firewall show \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-firewall" \
           --subscription "$(subscription_id)" \
           --query "ipConfigurations[0].privateIPAddress" -o tsv)
-        echo "##vso[task.setvariable variable=FWPRIVATE_IP]$FWPRIVATE_IP"
-    displayName: Create firewall $(cluster_name)-firewall
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
+        echo "##vso[task.setvariable variable=FIREWALL_PRIVATE_IP]$FIREWALL_PRIVATE_IP"
 
         az network route-table create \
-          --resource-group "$(resource_group)" \
-          --name "$(cluster_name)-rt" \
+          --resource-group "$(RUN_ID)" \
+          --name "$(cluster_name)-firewall-rt" \
           --location "$(location)" \
           --subscription "$(subscription_id)"
-    displayName: Create route table $(cluster_name)-rt
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
 
         az network route-table route create \
-          --resource-group "$(resource_group)" \
-          --route-table-name "$(cluster_name)-rt" \
-          --name "egress" \
+          --resource-group "$(RUN_ID)" \
+          --route-table-name "$(cluster_name)-firewall-rt" \
+          --name egress \
           --address-prefix 0.0.0.0/0 \
           --next-hop-type VirtualAppliance \
-          --next-hop-ip-address "$(FWPRIVATE_IP)" \
+          --next-hop-ip-address "$FIREWALL_PRIVATE_IP" \
           --subscription "$(subscription_id)"
-    displayName: Create route egress in $(cluster_name)-rt
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
 
         az network vnet subnet update \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --vnet-name "$(cluster_name)-net" \
           --name "nodes" \
-          --route-table "$(cluster_name)-rt" \
+          --route-table "$(cluster_name)-firewall-rt" \
           --subscription "$(subscription_id)"
-    displayName: Associate route table $(cluster_name)-rt with subnet nodes
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
 
-        POLICY_TMP=$(mktemp)
-        sed 's|"location": "[^"]*"|"location": "$(location)"|g' "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json" > "$POLICY_TMP"
-        az rest \
-          --method put \
-          --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(resource_group)/providers/Microsoft.Network/azureFirewalls/$(cluster_name)-firewall?api-version=2023-09-01" \
-          --headers "Content-Type=application/json" \
-          --body "@$POLICY_TMP"
-        rm -f "$POLICY_TMP"
-    displayName: Update firewall policy $(cluster_name)-firewall
+        # Use az rest PUT to apply the full firewall policy in one call — handles large rule sets
+        # and is significantly faster than incremental CLI commands (az network firewall policy rule-collection-group)
+        if [ -n "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json" ]; then
+          POLICY_TMP=$(mktemp)
+          sed 's|"location": "[^"]*"|"location": "$(location)"|g' "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json" > "$POLICY_TMP"
+          az rest \
+            --method put \
+            --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(RUN_ID)/providers/Microsoft.Network/azureFirewalls/$(cluster_name)-firewall?api-version=2025-05-01" \
+            --headers "Content-Type=application/json" \
+            --body "@$POLICY_TMP"
+          rm -f "$POLICY_TMP"
+        fi
+    displayName: Setup firewall $(cluster_name)-firewall for subnet nodes
   - task: AzureCLI@2
     inputs:
       azureSubscription: Azure-for-Telescope-internal
@@ -332,10 +301,13 @@ jobs:
           - tar -C /usr/local -xzf /tmp/go.tar.gz
           - echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
           - rm /tmp/go.tar.gz
+          - curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+          - rm kubectl
         CLOUDINIT
 
         az vm create \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-jumpbox" \
           --image Ubuntu2204 \
           --size Standard_D48s_v3 \
@@ -349,20 +321,20 @@ jobs:
           --subscription "$(subscription_id)"
 
         az vm open-port \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-jumpbox" \
           --port 22 \
           --priority 1001 \
           --subscription "$(subscription_id)"
 
         JUMPBOX_PRINCIPAL_ID=$(az vm identity assign \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-jumpbox" \
           --subscription "$(subscription_id)" \
           --query systemAssignedIdentity -o tsv)
 
         RG_ID=$(az group show \
-          --name "$(resource_group)" \
+          --name "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --query id -o tsv)
 
@@ -386,6 +358,12 @@ jobs:
       inlineScript: |
         set -exo pipefail
 
+        NETWORK_DATAPLANE="$(network_dataplane)"
+        NETWORK_DATAPLANE_JSON_FIELD=""
+        if [ -n "$NETWORK_DATAPLANE" ]; then
+          NETWORK_DATAPLANE_JSON_FIELD='"networkDataplane": "'"$NETWORK_DATAPLANE"'",'
+        fi
+
         cat > /tmp/aks-body.json << EOF
         {
           "location": "$(location)",
@@ -395,10 +373,7 @@ jobs:
             "userAssignedIdentities": {"$(IDENTITY_ID)": {}}
           },
           "tags": {
-            "SkipAKSCluster": "true",
-            "SkipASMAzSecPackAutoConfig": "true",
-            "SkipLinuxAzSecPack": "true",
-            "exempted_by_qi": "36344494"
+            "SkipAKSCluster": "true"
           },
           "properties": {
             "controlPlaneScalingProfile": {"scalingSize": "H8"},
@@ -407,20 +382,20 @@ jobs:
             "agentPoolProfiles": [
               {
                 "name": "system",
-                "count": 10,
+                "count": 3,
                 "vmSize": "Standard_D48s_v3",
                 "maxPods": 60,
                 "osType": "Linux",
                 "osSKU": "Ubuntu",
                 "mode": "System",
-                "vnetSubnetID": "$(NODE_SUBNET_ID)"
+                "vnetSubnetID": "$(NODES_SUBNET_ID)"
               }
             ],
             "networkProfile": {
               "networkPlugin": "azure",
               "networkPluginMode": "overlay",
-              "networkDataplane": "cilium",
               "podCidr": "10.64.0.0/10",
+              ${NETWORK_DATAPLANE_JSON_FIELD}
               "outboundType": "userDefinedRouting"
             },
             "apiServerAccessProfile": {
@@ -434,7 +409,7 @@ jobs:
 
         az rest \
           --method put \
-          --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(resource_group)/providers/Microsoft.ContainerService/managedClusters/$(cluster_name)?api-version=2026-01-02-preview" \
+          --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(RUN_ID)/providers/Microsoft.ContainerService/managedClusters/$(cluster_name)?api-version=2026-01-02-preview" \
           --headers "Content-Type=application/json" \
           --body "@/tmp/aks-body.json"
     displayName: Create AKS cluster
@@ -449,7 +424,7 @@ jobs:
         while true; do
           STATE=$(az aks show \
             --name "$(cluster_name)" \
-            --resource-group "$(resource_group)" \
+            --resource-group "$(RUN_ID)" \
             --subscription "$(subscription_id)" \
             --query "provisioningState" \
             --output tsv)
@@ -476,13 +451,13 @@ jobs:
 
         az aks nodepool add \
           --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool0" \
-          --node-count 800 \
+          --node-count 20 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
           --os-sku Ubuntu
     displayName: Create node pool workerpool0
   - task: AzureCLI@2
@@ -495,13 +470,13 @@ jobs:
 
         az aks nodepool add \
           --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool1" \
-          --node-count 800 \
+          --node-count 20 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
           --os-sku Ubuntu
     displayName: Create node pool workerpool1
   - task: AzureCLI@2
@@ -514,13 +489,13 @@ jobs:
 
         az aks nodepool add \
           --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool2" \
-          --node-count 800 \
+          --node-count 20 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
           --os-sku Ubuntu
     displayName: Create node pool workerpool2
   - task: AzureCLI@2
@@ -533,13 +508,13 @@ jobs:
 
         az aks nodepool add \
           --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool3" \
-          --node-count 800 \
+          --node-count 20 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
           --os-sku Ubuntu
     displayName: Create node pool workerpool3
   - task: AzureCLI@2
@@ -552,278 +527,12 @@ jobs:
 
         az aks nodepool add \
           --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
+          --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool4" \
-          --node-count 800 \
+          --node-count 20 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
           --os-sku Ubuntu
     displayName: Create node pool workerpool4
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool5" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool5
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool6" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool6
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool7" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool7
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool8" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool8
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool9" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool9
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool10" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool10
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool11" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool11
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool12" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool12
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool13" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool13
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool14" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool14
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool15" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool15
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool16" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool16
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool17" \
-          --node-count 800 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool17
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks nodepool add \
-          --cluster-name "$(cluster_name)" \
-          --resource-group "$(resource_group)" \
-          --subscription "$(subscription_id)" \
-          --name "workerpool18" \
-          --node-count 597 \
-          --node-vm-size "$(user_pool_vm_size)" \
-          --mode User \
-          --vnet-subnet-id "$(NODE_SUBNET_ID)" \
-          --os-sku Ubuntu
-    displayName: Create node pool workerpool18

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -368,41 +368,40 @@ jobs:
       inlineScript: |
         set -exo pipefail
 
-        NETWORK_DATAPLANE="$(network_dataplane)"
-        NETWORK_DATAPLANE_FLAG=""
-        if [ -n "$NETWORK_DATAPLANE" ]; then
-          NETWORK_DATAPLANE_FLAG="--network-dataplane $NETWORK_DATAPLANE"
-        fi
-
         az extension add --name aks-preview --allow-preview true --upgrade --yes
 
-        az aks create \
-          --subscription "$(subscription_id)" \
-          --resource-group "$(RUN_ID)" \
-          --name "$(cluster_name)" \
-          --location "$(location)" \
-          --kubernetes-version "1.33.0" \
-          --dns-name-prefix "$(cluster_name)-dns" \
-          --tier standard \
-          --assign-identity "$(IDENTITY_ID)" \
-          --tags SkipAKSCluster=true \
-          --nodepool-name system \
-          --node-count 3 \
-          --node-vm-size Standard_D48ds_v5 \
-          --max-pods 60 \
-          --os-sku Ubuntu \
-          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
-          --network-plugin azure \
-          --network-plugin-mode overlay \
-          --pod-cidr 10.64.0.0/10 \
-          --outbound-type userDefinedRouting \
-          --enable-private-cluster \
-          --enable-apiserver-vnet-integration \
-          --apiserver-subnet-id "$(APISERVER_SUBNET_ID)" \
-          --generate-ssh-keys \
-          --control-plane-scaling-size H8 \
-          --yes \
-          $NETWORK_DATAPLANE_FLAG
+        CREATE_ARGS=(
+          --subscription "$(subscription_id)"
+          --resource-group "$(RUN_ID)"
+          --name "$(cluster_name)"
+          --location "$(location)"
+          --kubernetes-version "1.35.0"
+          --dns-name-prefix "$(cluster_name)-dns"
+          --tier standard
+          --assign-identity "$(IDENTITY_ID)"
+          --tags SkipAKSCluster=true
+          --control-plane-scaling-size H8
+          --nodepool-name system
+          --node-count 3
+          --node-vm-size Standard_D48ds_v5
+          --max-pods 60
+          --os-sku Ubuntu
+          --vnet-subnet-id "$(NODES_SUBNET_ID)"
+          --network-plugin azure
+          --network-plugin-mode overlay
+          --pod-cidr 10.64.0.0/10
+          --outbound-type userDefinedRouting
+          --enable-private-cluster
+          --enable-apiserver-vnet-integration
+          --apiserver-subnet-id "$(APISERVER_SUBNET_ID)"
+          --auto-upgrade-channel none
+          --node-os-upgrade-channel None
+          --generate-ssh-keys
+          --yes
+        )
+        [[ -n "$(network_dataplane)" ]] && CREATE_ARGS+=(--network-dataplane "$(network_dataplane)")
+
+        az aks create "${CREATE_ARGS[@]}"
     displayName: Create AKS cluster
   - task: AzureCLI@2
     inputs:

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -2,6 +2,10 @@ name: '15K Nodes Cluster Creation'
 pool: AKS-Telescope-Airlock
 trigger: none
 parameters:
+- name: service_connection
+  displayName: Azure service connection
+  type: string
+  default: $(service_connection)
 - name: subscription_id
   displayName: Subscription ID
   type: string
@@ -23,6 +27,7 @@ parameters:
   type: string
   default: cilium
 variables:
+  service_connection: ${{ parameters.service_connection }}
   subscription_id: ${{ parameters.subscription_id }}
   location: ${{ parameters.location }}
   cluster_name: ${{ parameters.cluster_name }}
@@ -35,7 +40,7 @@ jobs:
   steps:
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -57,7 +62,7 @@ jobs:
     displayName: Set Run ID
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -71,7 +76,7 @@ jobs:
     displayName: Create resource group in $(location) ($(subscription_id))
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -91,7 +96,7 @@ jobs:
     displayName: Create managed identity $(cluster_name)-identity
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -118,7 +123,7 @@ jobs:
     displayName: Create VNet $(cluster_name)-net
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -142,7 +147,7 @@ jobs:
     displayName: Create subnet nodes
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -166,7 +171,7 @@ jobs:
     displayName: Create subnet apiserver
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -190,7 +195,7 @@ jobs:
     displayName: Create subnet AzureFirewallSubnet
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -214,7 +219,7 @@ jobs:
     displayName: Create subnet jumpbox
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -288,7 +293,7 @@ jobs:
     displayName: Setup firewall $(cluster_name)-firewall for subnet nodes
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -362,7 +367,7 @@ jobs:
     displayName: Create jumpbox
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -425,7 +430,7 @@ jobs:
     displayName: Create AKS cluster
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -453,7 +458,7 @@ jobs:
     displayName: Wait for cluster to succeed
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -472,7 +477,7 @@ jobs:
     displayName: Create node pool workerpool0
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -491,7 +496,7 @@ jobs:
     displayName: Create node pool workerpool1
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -510,7 +515,7 @@ jobs:
     displayName: Create node pool workerpool2
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -529,7 +534,7 @@ jobs:
     displayName: Create node pool workerpool3
   - task: AzureCLI@2
     inputs:
-      azureSubscription: Azure-for-Telescope-internal
+      azureSubscription: $(service_connection)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -1,12 +1,27 @@
 name: '15K Nodes Cluster Creation'
 pool: AKS-Telescope-Airlock
 trigger: none
-variables:
-  subscription_id: b8ceb4e5-f05b-4562-a9f5-14acb1f24219
-  location: eastasia
-  cluster_name: '15k'
-  user_pool_vm_size: Standard_D4s_v3
-  network_dataplane: cilium
+parameters:
+- name: subscription_id
+  displayName: Subscription ID
+  type: string
+  default: b8ceb4e5-f05b-4562-a9f5-14acb1f24219
+- name: location
+  displayName: Azure region
+  type: string
+  default: eastasia
+- name: cluster_name
+  displayName: AKS cluster name
+  type: string
+  default: '15k'
+- name: user_pool_vm_size
+  displayName: User node pool VM size
+  type: string
+  default: Standard_D4s_v3
+- name: network_dataplane
+  displayName: Network dataplane (leave empty for AKS default)
+  type: string
+  default: cilium
 jobs:
 - job: create_cluster
   displayName: Create 15K Nodes Cluster

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -386,7 +386,6 @@ jobs:
           --tier standard \
           --assign-identity "$(IDENTITY_ID)" \
           --tags SkipAKSCluster=true \
-          --control-plane-scaling-size H8 \
           --nodepool-name system \
           --node-count 3 \
           --node-vm-size Standard_D48ds_v5 \
@@ -401,6 +400,8 @@ jobs:
           --enable-apiserver-vnet-integration \
           --apiserver-subnet-id "$(APISERVER_SUBNET_ID)" \
           --generate-ssh-keys \
+          --control-plane-scaling-size H8 \
+          --yes \
           $NETWORK_DATAPLANE_FLAG
     displayName: Create AKS cluster
   - task: AzureCLI@2

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -22,12 +22,17 @@ parameters:
   displayName: Network dataplane (leave empty for AKS default)
   type: string
   default: cilium
+- name: apiserver_vnet_integration
+  displayName: Enable API server vNet integration (leave empty to disable)
+  type: string
+  default: 'true'
 variables:
   subscription_id: ${{ parameters.subscription_id }}
   location: ${{ parameters.location }}
   cluster_name: ${{ parameters.cluster_name }}
   user_pool_vm_size: ${{ parameters.user_pool_vm_size }}
   network_dataplane: ${{ parameters.network_dataplane }}
+  apiserver_vnet_integration: ${{ parameters.apiserver_vnet_integration }}
 jobs:
 - job: create_cluster
   displayName: Create 15K Nodes Cluster
@@ -306,71 +311,7 @@ jobs:
       inlineScript: |
         set -exo pipefail
 
-        cat > /tmp/cloud-init.yaml << 'CLOUDINIT'
-        #cloud-config
-        package_update: true
-        package_upgrade: true
-        packages:
-          - git
-          - ca-certificates
-          - curl
-          - apt-transport-https
-          - lsb-release
-          - gnupg
-        runcmd:
-          - curl -sL https://aka.ms/InstallAzureCLIDeb | bash
-          - wget -q https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -O /tmp/go.tar.gz
-          - tar -C /usr/local -xzf /tmp/go.tar.gz
-          - echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
-          - rm /tmp/go.tar.gz
-          - curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-          - rm kubectl
-        CLOUDINIT
-
-        az vm create \
-          --resource-group "$(RUN_ID)" \
-          --name "$(cluster_name)-jumpbox" \
-          --image Ubuntu2204 \
-          --size Standard_D16ds_v5 \
-          --vnet-name "$(cluster_name)-net" \
-          --subnet jumpbox \
-          --public-ip-address "$(cluster_name)-jumpbox-pip" \
-          --admin-username azureuser \
-          --admin-password "$(JUMPBOX_ADMIN_PASSWORD)" \
-          --authentication-type password \
-          --custom-data /tmp/cloud-init.yaml \
-          --subscription "$(subscription_id)"
-
-        az vm open-port \
-          --resource-group "$(RUN_ID)" \
-          --name "$(cluster_name)-jumpbox" \
-          --port 22 \
-          --priority 1001 \
-          --subscription "$(subscription_id)"
-
-        JUMPBOX_PRINCIPAL_ID=$(az vm identity assign \
-          --resource-group "$(RUN_ID)" \
-          --name "$(cluster_name)-jumpbox" \
-          --subscription "$(subscription_id)" \
-          --query systemAssignedIdentity -o tsv)
-
-        RG_ID=$(az group show \
-          --name "$(RUN_ID)" \
-          --subscription "$(subscription_id)" \
-          --query id -o tsv)
-
-        for role in \
-          "Azure Kubernetes Service Cluster Admin Role" \
-          "Azure Kubernetes Service Cluster User Role" \
-          "Azure Kubernetes Service Contributor Role" \
-          "Azure Kubernetes Service RBAC Cluster Admin"; do
-          az role assignment create \
-            --assignee $JUMPBOX_PRINCIPAL_ID \
-            --role "$role" \
-            --scope $RG_ID \
-            --subscription "$(subscription_id)"
-        done
+        az vm create   --resource-group "$(RUN_ID)"   --name "$(cluster_name)-jumpbox"   --image UbuntuLTS   --size Standard_D2s_v3   --subnet "$(JUMPBOX_SUBNET_ID)"   --public-ip-sku Standard   --admin-username azureuser   --generate-ssh-keys   --nsg-rule SSH
     displayName: Create jumpbox
   - task: AzureCLI@2
     inputs:
@@ -404,14 +345,14 @@ jobs:
           --pod-cidr 10.64.0.0/10
           --outbound-type userDefinedRouting
           --enable-private-cluster
-          --enable-apiserver-vnet-integration
-          --apiserver-subnet-id "$(APISERVER_SUBNET_ID)"
           --auto-upgrade-channel none
           --node-os-upgrade-channel None
           --generate-ssh-keys
           --yes
         )
         [[ -n "$(network_dataplane)" ]] && CREATE_ARGS+=(--network-dataplane "$(network_dataplane)")
+        [[ "$(apiserver_vnet_integration)" == "true" ]] && CREATE_ARGS+=(--enable-apiserver-vnet-integration --apiserver-subnet-id "$(APISERVER_SUBNET_ID)")
+
 
         az aks create "${CREATE_ARGS[@]}"
     displayName: Create AKS cluster
@@ -456,7 +397,7 @@ jobs:
           --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool0" \
-          --node-count 20 \
+          --node-count 800 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
           --vnet-subnet-id "$(NODES_SUBNET_ID)" \
@@ -475,7 +416,7 @@ jobs:
           --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool1" \
-          --node-count 20 \
+          --node-count 800 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
           --vnet-subnet-id "$(NODES_SUBNET_ID)" \
@@ -494,7 +435,7 @@ jobs:
           --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool2" \
-          --node-count 20 \
+          --node-count 800 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
           --vnet-subnet-id "$(NODES_SUBNET_ID)" \
@@ -513,7 +454,7 @@ jobs:
           --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool3" \
-          --node-count 20 \
+          --node-count 800 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
           --vnet-subnet-id "$(NODES_SUBNET_ID)" \
@@ -532,9 +473,275 @@ jobs:
           --resource-group "$(RUN_ID)" \
           --subscription "$(subscription_id)" \
           --name "workerpool4" \
-          --node-count 20 \
+          --node-count 800 \
           --node-vm-size "$(user_pool_vm_size)" \
           --mode User \
           --vnet-subnet-id "$(NODES_SUBNET_ID)" \
           --os-sku Ubuntu
     displayName: Create node pool workerpool4
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool5" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool5
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool6" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool6
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool7" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool7
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool8" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool8
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool9" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool9
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool10" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool10
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool11" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool11
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool12" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool12
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool13" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool13
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool14" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool14
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool15" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool15
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool16" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool16
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool17" \
+          --node-count 800 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool17
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks nodepool add \
+          --cluster-name "$(cluster_name)" \
+          --resource-group "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --name "workerpool18" \
+          --node-count 597 \
+          --node-vm-size "$(user_pool_vm_size)" \
+          --mode User \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --os-sku Ubuntu
+    displayName: Create node pool workerpool18

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -369,59 +369,39 @@ jobs:
         set -exo pipefail
 
         NETWORK_DATAPLANE="$(network_dataplane)"
-        NETWORK_DATAPLANE_JSON_FIELD=""
+        NETWORK_DATAPLANE_FLAG=""
         if [ -n "$NETWORK_DATAPLANE" ]; then
-          NETWORK_DATAPLANE_JSON_FIELD='"networkDataplane": "'"$NETWORK_DATAPLANE"'",'
+          NETWORK_DATAPLANE_FLAG="--network-dataplane $NETWORK_DATAPLANE"
         fi
 
-        cat > /tmp/aks-body.json << EOF
-        {
-          "location": "$(location)",
-          "sku": {"name": "Base", "tier": "Standard"},
-          "identity": {
-            "type": "UserAssigned",
-            "userAssignedIdentities": {"$(IDENTITY_ID)": {}}
-          },
-          "tags": {
-            "SkipAKSCluster": "true"
-          },
-          "properties": {
-            "controlPlaneScalingProfile": {"scalingSize": "H8"},
-            "kubernetesVersion": "1.33.0",
-            "dnsPrefix": "$(cluster_name)-dns",
-            "agentPoolProfiles": [
-              {
-                "name": "system",
-                "count": 3,
-                "vmSize": "Standard_D48ds_v5",
-                "maxPods": 60,
-                "osType": "Linux",
-                "osSKU": "Ubuntu",
-                "mode": "System",
-                "vnetSubnetID": "$(NODES_SUBNET_ID)"
-              }
-            ],
-            "networkProfile": {
-              "networkPlugin": "azure",
-              "networkPluginMode": "overlay",
-              "podCidr": "10.64.0.0/10",
-              ${NETWORK_DATAPLANE_JSON_FIELD}
-              "outboundType": "userDefinedRouting"
-            },
-            "apiServerAccessProfile": {
-              "enablePrivateCluster": true,
-              "enableVnetIntegration": true,
-              "subnetId": "$(APISERVER_SUBNET_ID)"
-            }
-          }
-        }
-        EOF
+        az extension add --name aks-preview --allow-preview true --upgrade --yes
 
-        az rest \
-          --method put \
-          --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(RUN_ID)/providers/Microsoft.ContainerService/managedClusters/$(cluster_name)?api-version=2026-01-02-preview" \
-          --headers "Content-Type=application/json" \
-          --body "@/tmp/aks-body.json"
+        az aks create \
+          --subscription "$(subscription_id)" \
+          --resource-group "$(RUN_ID)" \
+          --name "$(cluster_name)" \
+          --location "$(location)" \
+          --kubernetes-version "1.33.0" \
+          --dns-name-prefix "$(cluster_name)-dns" \
+          --tier standard \
+          --assign-identity "$(IDENTITY_ID)" \
+          --tags SkipAKSCluster=true \
+          --control-plane-scaling-size H8 \
+          --nodepool-name system \
+          --node-count 3 \
+          --node-vm-size Standard_D48ds_v5 \
+          --max-pods 60 \
+          --os-sku Ubuntu \
+          --vnet-subnet-id "$(NODES_SUBNET_ID)" \
+          --network-plugin azure \
+          --network-plugin-mode overlay \
+          --pod-cidr 10.64.0.0/10 \
+          --outbound-type userDefinedRouting \
+          --enable-private-cluster \
+          --enable-apiserver-vnet-integration \
+          --apiserver-subnet-id "$(APISERVER_SUBNET_ID)" \
+          --generate-ssh-keys \
+          $NETWORK_DATAPLANE_FLAG
     displayName: Create AKS cluster
   - task: AzureCLI@2
     inputs:

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -311,7 +311,71 @@ jobs:
       inlineScript: |
         set -exo pipefail
 
-        az vm create   --resource-group "$(RUN_ID)"   --name "$(cluster_name)-jumpbox"   --image UbuntuLTS   --size Standard_D2s_v3   --subnet "$(JUMPBOX_SUBNET_ID)"   --public-ip-sku Standard   --admin-username azureuser   --generate-ssh-keys   --nsg-rule SSH
+        cat > /tmp/cloud-init.yaml << 'CLOUDINIT'
+        #cloud-config
+        package_update: true
+        package_upgrade: true
+        packages:
+          - git
+          - ca-certificates
+          - curl
+          - apt-transport-https
+          - lsb-release
+          - gnupg
+        runcmd:
+          - curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+          - wget -q https://go.dev/dl/go1.22.2.linux-amd64.tar.gz -O /tmp/go.tar.gz
+          - tar -C /usr/local -xzf /tmp/go.tar.gz
+          - echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
+          - rm /tmp/go.tar.gz
+          - curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          - install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+          - rm kubectl
+        CLOUDINIT
+
+        az vm create \
+          --resource-group "$(RUN_ID)" \
+          --name "$(cluster_name)-jumpbox" \
+          --image Ubuntu2204 \
+          --size Standard_D16ds_v5 \
+          --vnet-name "$(cluster_name)-net" \
+          --subnet jumpbox \
+          --public-ip-address "$(cluster_name)-jumpbox-pip" \
+          --admin-username azureuser \
+          --admin-password "$(JUMPBOX_ADMIN_PASSWORD)" \
+          --authentication-type password \
+          --custom-data /tmp/cloud-init.yaml \
+          --subscription "$(subscription_id)"
+
+        az vm open-port \
+          --resource-group "$(RUN_ID)" \
+          --name "$(cluster_name)-jumpbox" \
+          --port 22 \
+          --priority 1001 \
+          --subscription "$(subscription_id)"
+
+        JUMPBOX_PRINCIPAL_ID=$(az vm identity assign \
+          --resource-group "$(RUN_ID)" \
+          --name "$(cluster_name)-jumpbox" \
+          --subscription "$(subscription_id)" \
+          --query systemAssignedIdentity -o tsv)
+
+        RG_ID=$(az group show \
+          --name "$(RUN_ID)" \
+          --subscription "$(subscription_id)" \
+          --query id -o tsv)
+
+        for role in \
+          "Azure Kubernetes Service Cluster Admin Role" \
+          "Azure Kubernetes Service Cluster User Role" \
+          "Azure Kubernetes Service Contributor Role" \
+          "Azure Kubernetes Service RBAC Cluster Admin"; do
+          az role assignment create \
+            --assignee $JUMPBOX_PRINCIPAL_ID \
+            --role "$role" \
+            --scope $RG_ID \
+            --subscription "$(subscription_id)"
+        done
     displayName: Create jumpbox
   - task: AzureCLI@2
     inputs:

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -22,6 +22,12 @@ parameters:
   displayName: Network dataplane (leave empty for AKS default)
   type: string
   default: cilium
+variables:
+  subscription_id: ${{ parameters.subscription_id }}
+  location: ${{ parameters.location }}
+  cluster_name: ${{ parameters.cluster_name }}
+  user_pool_vm_size: ${{ parameters.user_pool_vm_size }}
+  network_dataplane: ${{ parameters.network_dataplane }}
 jobs:
 - job: create_cluster
   displayName: Create 15K Nodes Cluster

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -86,7 +86,7 @@ jobs:
           --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-identity" \
           --subscription "$(subscription_id)")
-        echo "##vso[task.setvariable variable=IDENTITY_CLIENT_ID]$(echo "$IDENTITY" | jq -r '.clientId')"
+        echo "##vso[task.setvariable variable=IDENTITY_PRINCIPAL_ID]$(echo "$IDENTITY" | jq -r '.principalId')"
         echo "##vso[task.setvariable variable=IDENTITY_ID]$(echo "$IDENTITY" | jq -r '.id')"
     displayName: Create managed identity $(cluster_name)-identity
   - task: AzureCLI@2
@@ -128,7 +128,8 @@ jobs:
         az role assignment create \
           --scope $SUBNET_ID \
           --role "Network Contributor" \
-          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
+          --assignee-principal-type ServicePrincipal \
           --subscription "$(subscription_id)"
 
         echo "##vso[task.setvariable variable=NODES_SUBNET_ID]$SUBNET_ID"
@@ -158,7 +159,8 @@ jobs:
         az role assignment create \
           --scope $SUBNET_ID \
           --role "Network Contributor" \
-          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
+          --assignee-principal-type ServicePrincipal \
           --subscription "$(subscription_id)"
 
         echo "##vso[task.setvariable variable=APISERVER_SUBNET_ID]$SUBNET_ID"
@@ -188,7 +190,8 @@ jobs:
         az role assignment create \
           --scope $SUBNET_ID \
           --role "Network Contributor" \
-          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
+          --assignee-principal-type ServicePrincipal \
           --subscription "$(subscription_id)"
 
         echo "##vso[task.setvariable variable=AZUREFIREWALLSUBNET_SUBNET_ID]$SUBNET_ID"
@@ -218,7 +221,8 @@ jobs:
         az role assignment create \
           --scope $SUBNET_ID \
           --role "Network Contributor" \
-          --assignee "$(IDENTITY_CLIENT_ID)" \
+          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
+          --assignee-principal-type ServicePrincipal \
           --subscription "$(subscription_id)"
 
         echo "##vso[task.setvariable variable=JUMPBOX_SUBNET_ID]$SUBNET_ID"

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -335,7 +335,7 @@ jobs:
           --resource-group "$(RUN_ID)" \
           --name "$(cluster_name)-jumpbox" \
           --image Ubuntu2204 \
-          --size Standard_D48s_v3 \
+          --size Standard_D16ds_v5 \
           --vnet-name "$(cluster_name)-net" \
           --subnet jumpbox \
           --public-ip-address "$(cluster_name)-jumpbox-pip" \
@@ -408,7 +408,7 @@ jobs:
               {
                 "name": "system",
                 "count": 3,
-                "vmSize": "Standard_D48s_v3",
+                "vmSize": "Standard_D48ds_v5",
                 "maxPods": 60,
                 "osType": "Linux",
                 "osSKU": "Ubuntu",

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -273,17 +273,29 @@ jobs:
           --route-table "$(cluster_name)-firewall-rt" \
           --subscription "$(subscription_id)"
 
-        # Use az rest PUT to apply the full firewall policy in one call — handles large rule sets
-        # and is significantly faster than incremental CLI commands (az network firewall policy rule-collection-group)
+        # Merge rule collections from the policy file into the current firewall and PUT it back in one call.
+        # This handles large rule sets faster than incremental CLI commands (az network firewall policy rule-collection-group)
+        # and avoids overwriting other firewall properties (e.g. location, ipConfigurations).
         if [ -n "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json" ]; then
-          POLICY_TMP=$(mktemp)
-          sed 's|"location": "[^"]*"|"location": "$(location)"|g' "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json" > "$POLICY_TMP"
+          FW_CURRENT=$(mktemp)
+          FW_MERGED=$(mktemp)
+          az rest \
+            --method get \
+            --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(RUN_ID)/providers/Microsoft.Network/azureFirewalls/$(cluster_name)-firewall?api-version=2025-05-01" \
+            > "$FW_CURRENT"
+          jq -s '
+            .[0] as $fw | .[1] as $rules |
+            $fw
+            | .properties.applicationRuleCollections = ($rules.properties.applicationRuleCollections // [])
+            | .properties.networkRuleCollections     = ($rules.properties.networkRuleCollections // [])
+            | .properties.natRuleCollections         = ($rules.properties.natRuleCollections // [])
+          ' "$FW_CURRENT" "$(Pipeline.Workspace)/s/kcl/ccp_team/15K_cluster/firewall-policy.json" > "$FW_MERGED"
           az rest \
             --method put \
             --uri "https://management.azure.com/subscriptions/$(subscription_id)/resourceGroups/$(RUN_ID)/providers/Microsoft.Network/azureFirewalls/$(cluster_name)-firewall?api-version=2025-05-01" \
             --headers "Content-Type=application/json" \
-            --body "@$POLICY_TMP"
-          rm -f "$POLICY_TMP"
+            --body "@$FW_MERGED"
+          rm -f "$FW_CURRENT" "$FW_MERGED"
         fi
     displayName: Setup firewall $(cluster_name)-firewall for subnet nodes
   - task: AzureCLI@2

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -102,6 +102,19 @@ jobs:
           --name "$(cluster_name)-net" \
           --address-prefixes 10.0.0.0/8 \
           --subscription "$(subscription_id)"
+
+        VNET_ID=$(az network vnet show \
+          --resource-group "$(RUN_ID)" \
+          --name "$(cluster_name)-net" \
+          --subscription "$(subscription_id)" \
+          --query id -o tsv)
+
+        az role assignment create \
+          --scope $VNET_ID \
+          --role "Network Contributor" \
+          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
+          --assignee-principal-type ServicePrincipal \
+          --subscription "$(subscription_id)"
     displayName: Create VNet $(cluster_name)-net
   - task: AzureCLI@2
     inputs:
@@ -124,13 +137,6 @@ jobs:
           --name "nodes" \
           --subscription "$(subscription_id)" \
           --query id -o tsv)
-
-        az role assignment create \
-          --scope $SUBNET_ID \
-          --role "Network Contributor" \
-          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
-          --assignee-principal-type ServicePrincipal \
-          --subscription "$(subscription_id)"
 
         echo "##vso[task.setvariable variable=NODES_SUBNET_ID]$SUBNET_ID"
     displayName: Create subnet nodes
@@ -156,13 +162,6 @@ jobs:
           --subscription "$(subscription_id)" \
           --query id -o tsv)
 
-        az role assignment create \
-          --scope $SUBNET_ID \
-          --role "Network Contributor" \
-          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
-          --assignee-principal-type ServicePrincipal \
-          --subscription "$(subscription_id)"
-
         echo "##vso[task.setvariable variable=APISERVER_SUBNET_ID]$SUBNET_ID"
     displayName: Create subnet apiserver
   - task: AzureCLI@2
@@ -187,13 +186,6 @@ jobs:
           --subscription "$(subscription_id)" \
           --query id -o tsv)
 
-        az role assignment create \
-          --scope $SUBNET_ID \
-          --role "Network Contributor" \
-          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
-          --assignee-principal-type ServicePrincipal \
-          --subscription "$(subscription_id)"
-
         echo "##vso[task.setvariable variable=AZUREFIREWALLSUBNET_SUBNET_ID]$SUBNET_ID"
     displayName: Create subnet AzureFirewallSubnet
   - task: AzureCLI@2
@@ -217,13 +209,6 @@ jobs:
           --name "jumpbox" \
           --subscription "$(subscription_id)" \
           --query id -o tsv)
-
-        az role assignment create \
-          --scope $SUBNET_ID \
-          --role "Network Contributor" \
-          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
-          --assignee-principal-type ServicePrincipal \
-          --subscription "$(subscription_id)"
 
         echo "##vso[task.setvariable variable=JUMPBOX_SUBNET_ID]$SUBNET_ID"
     displayName: Create subnet jumpbox

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -2,10 +2,6 @@ name: '15K Nodes Cluster Creation'
 pool: AKS-Telescope-Airlock
 trigger: none
 parameters:
-- name: service_connection
-  displayName: Azure service connection
-  type: string
-  default: $(service_connection)
 - name: subscription_id
   displayName: Subscription ID
   type: string
@@ -27,7 +23,6 @@ parameters:
   type: string
   default: cilium
 variables:
-  service_connection: ${{ parameters.service_connection }}
   subscription_id: ${{ parameters.subscription_id }}
   location: ${{ parameters.location }}
   cluster_name: ${{ parameters.cluster_name }}
@@ -40,7 +35,7 @@ jobs:
   steps:
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -62,7 +57,7 @@ jobs:
     displayName: Set Run ID
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -76,7 +71,7 @@ jobs:
     displayName: Create resource group in $(location) ($(subscription_id))
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -96,7 +91,7 @@ jobs:
     displayName: Create managed identity $(cluster_name)-identity
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -123,7 +118,7 @@ jobs:
     displayName: Create VNet $(cluster_name)-net
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -147,7 +142,7 @@ jobs:
     displayName: Create subnet nodes
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -171,7 +166,7 @@ jobs:
     displayName: Create subnet apiserver
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -195,7 +190,7 @@ jobs:
     displayName: Create subnet AzureFirewallSubnet
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -219,7 +214,7 @@ jobs:
     displayName: Create subnet jumpbox
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -293,7 +288,7 @@ jobs:
     displayName: Setup firewall $(cluster_name)-firewall for subnet nodes
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -367,7 +362,7 @@ jobs:
     displayName: Create jumpbox
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -430,7 +425,7 @@ jobs:
     displayName: Create AKS cluster
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -458,7 +453,7 @@ jobs:
     displayName: Wait for cluster to succeed
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -477,7 +472,7 @@ jobs:
     displayName: Create node pool workerpool0
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -496,7 +491,7 @@ jobs:
     displayName: Create node pool workerpool1
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -515,7 +510,7 @@ jobs:
     displayName: Create node pool workerpool2
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |
@@ -534,7 +529,7 @@ jobs:
     displayName: Create node pool workerpool3
   - task: AzureCLI@2
     inputs:
-      azureSubscription: $(service_connection)
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -26,6 +26,10 @@ parameters:
   displayName: Enable API server vNet integration (leave empty to disable)
   type: string
   default: 'true'
+- name: kms_key_id
+  displayName: Azure Key Vault KMS key ID (versioned key URI; leave empty to disable KMS)
+  type: string
+  default: ''
 variables:
   subscription_id: ${{ parameters.subscription_id }}
   location: ${{ parameters.location }}
@@ -33,6 +37,7 @@ variables:
   user_pool_vm_size: ${{ parameters.user_pool_vm_size }}
   network_dataplane: ${{ parameters.network_dataplane }}
   apiserver_vnet_integration: ${{ parameters.apiserver_vnet_integration }}
+  kms_key_id: ${{ parameters.kms_key_id }}
 jobs:
 - job: create_cluster
   displayName: Create 15K Nodes Cluster
@@ -387,6 +392,30 @@ jobs:
       inlineScript: |
         set -exo pipefail
 
+        KEY_ID="$(kms_key_id)"
+        HOST="${KEY_ID#https://}"
+        VAULT_NAME="${HOST%%.*}"
+
+        KEY_VAULT_RESOURCE_ID=$(az keyvault show \
+          --subscription "$(subscription_id)" \
+          --name "${VAULT_NAME}" \
+          --query id -o tsv)
+
+        az role assignment create \
+          --role "Key Vault Crypto User" \
+          --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
+          --assignee-principal-type ServicePrincipal \
+          --scope "${KEY_VAULT_RESOURCE_ID}"
+    condition: ne(variables['kms_key_id'], '')
+    displayName: Grant KMS access to cluster identity
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(AZURE_SERVICE_CONNECTION)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
         az extension add --name aks-preview --allow-preview true --upgrade --yes
 
         CREATE_ARGS=(
@@ -418,6 +447,7 @@ jobs:
         )
         [[ -n "$(network_dataplane)" ]] && CREATE_ARGS+=(--network-dataplane "$(network_dataplane)")
         [[ "$(apiserver_vnet_integration)" == "true" ]] && CREATE_ARGS+=(--enable-apiserver-vnet-integration --apiserver-subnet-id "$(APISERVER_SUBNET_ID)")
+        [[ -n "$(kms_key_id)" ]] && CREATE_ARGS+=(--enable-azure-keyvault-kms --azure-keyvault-kms-key-id "$(kms_key_id)" --azure-keyvault-kms-key-vault-network-access Public)
 
 
         az aks create "${CREATE_ARGS[@]}"

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -239,6 +239,8 @@ jobs:
           --name "$(cluster_name)-firewall" \
           --location "$(location)" \
           --enable-dns-proxy true \
+          --min-capacity 45 \
+          --max-capacity 45 \
           --subscription "$(subscription_id)"
 
         az network firewall ip-config create \

--- a/kcl/ccp_team/15K_cluster/pipeline.yaml
+++ b/kcl/ccp_team/15K_cluster/pipeline.yaml
@@ -27,9 +27,9 @@ parameters:
   type: string
   default: 'true'
 - name: kms_key_id
-  displayName: Azure Key Vault KMS key ID (versioned key URI; leave empty to disable KMS)
+  displayName: Azure Key Vault KMS key ID (versioned key URI; use 'none' to disable KMS)
   type: string
-  default: ''
+  default: none
 variables:
   subscription_id: ${{ parameters.subscription_id }}
   location: ${{ parameters.location }}
@@ -406,7 +406,7 @@ jobs:
           --assignee-object-id "$(IDENTITY_PRINCIPAL_ID)" \
           --assignee-principal-type ServicePrincipal \
           --scope "${KEY_VAULT_RESOURCE_ID}"
-    condition: ne(variables['kms_key_id'], '')
+    condition: ne(variables['kms_key_id'], 'none')
     displayName: Grant KMS access to cluster identity
   - task: AzureCLI@2
     inputs:
@@ -447,7 +447,7 @@ jobs:
         )
         [[ -n "$(network_dataplane)" ]] && CREATE_ARGS+=(--network-dataplane "$(network_dataplane)")
         [[ "$(apiserver_vnet_integration)" == "true" ]] && CREATE_ARGS+=(--enable-apiserver-vnet-integration --apiserver-subnet-id "$(APISERVER_SUBNET_ID)")
-        [[ -n "$(kms_key_id)" ]] && CREATE_ARGS+=(--enable-azure-keyvault-kms --azure-keyvault-kms-key-id "$(kms_key_id)" --azure-keyvault-kms-key-vault-network-access Public)
+        [[ "$(kms_key_id)" != "none" ]] && CREATE_ARGS+=(--enable-azure-keyvault-kms --azure-keyvault-kms-key-id "$(kms_key_id)" --azure-keyvault-kms-key-vault-network-access Public)
 
 
         az aks create "${CREATE_ARGS[@]}"

--- a/kcl/lib/steps/azure/firewall.k
+++ b/kcl/lib/steps/azure/firewall.k
@@ -55,17 +55,29 @@ az network vnet subnet update \\
   --route-table "${name}-rt" \\
   --subscription "${subscription}"
 
-# Use az rest PUT to apply the full firewall policy in one call — handles large rule sets
-# and is significantly faster than incremental CLI commands (az network firewall policy rule-collection-group)
+# Merge rule collections from the policy file into the current firewall and PUT it back in one call.
+# This handles large rule sets faster than incremental CLI commands (az network firewall policy rule-collection-group)
+# and avoids overwriting other firewall properties (e.g. location, ipConfigurations).
 if [ -n "${policyPath}" ]; then
-  POLICY_TMP=$(mktemp)
-  sed 's|"location": "[^"]*"|"location": "${location}"|g' "${policyPath}" > "$POLICY_TMP"
+  FW_CURRENT=$(mktemp)
+  FW_MERGED=$(mktemp)
+  az rest \\
+    --method get \\
+    --uri "https://management.azure.com/subscriptions/${subscription}/resourceGroups/${resourceGroup}/providers/Microsoft.Network/azureFirewalls/${name}?api-version=2025-05-01" \\
+    > "$FW_CURRENT"
+  jq -s '
+    .[0] as $fw | .[1] as $rules |
+    $fw
+    | .properties.applicationRuleCollections = ($rules.properties.applicationRuleCollections // [])
+    | .properties.networkRuleCollections     = ($rules.properties.networkRuleCollections // [])
+    | .properties.natRuleCollections         = ($rules.properties.natRuleCollections // [])
+  ' "$FW_CURRENT" "${policyPath}" > "$FW_MERGED"
   az rest \\
     --method put \\
     --uri "https://management.azure.com/subscriptions/${subscription}/resourceGroups/${resourceGroup}/providers/Microsoft.Network/azureFirewalls/${name}?api-version=2025-05-01" \\
     --headers "Content-Type=application/json" \\
-    --body "@$POLICY_TMP"
-  rm -f "$POLICY_TMP"
+    --body "@$FW_MERGED"
+  rm -f "$FW_CURRENT" "$FW_MERGED"
 fi
 """
     AzCli(serviceConnection, "Setup firewall ${name} for subnet ${subnetName}", script)

--- a/kcl/lib/steps/azure/firewall.k
+++ b/kcl/lib/steps/azure/firewall.k
@@ -1,6 +1,8 @@
 import azure_pipelines.ap.steps
 
-SetupFirewallForSubnet = lambda serviceConnection: str, subscription: str, resourceGroup: str, location: str, name: str, vnetName: str, subnetName: str, policyPath: str = "" -> steps.Step {
+SetupFirewallForSubnet = lambda serviceConnection: str, subscription: str, resourceGroup: str, location: str, name: str, vnetName: str, subnetName: str, policyPath: str = "", minCapacity: str = "", maxCapacity: str = "" -> steps.Step {
+    minCapacityArg = "  --min-capacity ${minCapacity} \\\n" if minCapacity else ""
+    maxCapacityArg = "  --max-capacity ${maxCapacity} \\\n" if maxCapacity else ""
     script = """
 az extension add --name azure-firewall
 
@@ -16,7 +18,7 @@ az network firewall create \\
   --name "${name}" \\
   --location "${location}" \\
   --enable-dns-proxy true \\
-  --subscription "${subscription}"
+${minCapacityArg}${maxCapacityArg}  --subscription "${subscription}"
 
 az network firewall ip-config create \\
   --resource-group "${resourceGroup}" \\

--- a/kcl/lib/steps/azure/identity.k
+++ b/kcl/lib/steps/azure/identity.k
@@ -11,7 +11,7 @@ IDENTITY=$(az identity show \\
   --resource-group "${resourceGroup}" \\
   --name "${name}" \\
   --subscription "${subscription}")
-echo "##vso[task.setvariable variable=${exportVar}_CLIENT_ID]$(echo "$IDENTITY" | jq -r '.clientId')"
+echo "##vso[task.setvariable variable=${exportVar}_PRINCIPAL_ID]$(echo "$IDENTITY" | jq -r '.principalId')"
 echo "##vso[task.setvariable variable=${exportVar}_ID]$(echo "$IDENTITY" | jq -r '.id')"
 """
     AzCli(serviceConnection, "Create managed identity ${name}", script)

--- a/kcl/lib/steps/azure/vnet.k
+++ b/kcl/lib/steps/azure/vnet.k
@@ -1,17 +1,31 @@
 import azure_pipelines.ap.steps
 
-CreateVNet = lambda serviceConnection: str, resourceGroup: str, name: str, addressPrefixes: str, subscription: str -> steps.Step {
+CreateVNet = lambda serviceConnection: str, resourceGroup: str, name: str, addressPrefixes: str, subscription: str, assignee: str = "" -> steps.Step {
+    roleAssignmentScript = """
+VNET_ID=$(az network vnet show \\
+  --resource-group "${resourceGroup}" \\
+  --name "${name}" \\
+  --subscription "${subscription}" \\
+  --query id -o tsv)
+
+az role assignment create \\
+  --scope $VNET_ID \\
+  --role "Network Contributor" \\
+  --assignee-object-id "${assignee}" \\
+  --assignee-principal-type ServicePrincipal \\
+  --subscription "${subscription}"
+""" if assignee else ""
     script = """
 az network vnet create \\
   --resource-group "${resourceGroup}" \\
   --name "${name}" \\
   --address-prefixes ${addressPrefixes} \\
   --subscription "${subscription}"
-"""
+${roleAssignmentScript}"""
     AzCli(serviceConnection, "Create VNet ${name}", script)
 }
 
-CreateSubnetAndRoleAssignment = lambda serviceConnection: str, resourceGroup: str, vnetName: str, name: str, addressPrefixes: str, subscription: str, assignee: str -> steps.Step {
+CreateSubnet = lambda serviceConnection: str, resourceGroup: str, vnetName: str, name: str, addressPrefixes: str, subscription: str -> steps.Step {
     script = """
 az network vnet subnet create \\
   --resource-group "${resourceGroup}" \\
@@ -26,13 +40,6 @@ SUBNET_ID=$(az network vnet subnet show \\
   --name "${name}" \\
   --subscription "${subscription}" \\
   --query id -o tsv)
-
-az role assignment create \\
-  --scope $SUBNET_ID \\
-  --role "Network Contributor" \\
-  --assignee-object-id "${assignee}" \\
-  --assignee-principal-type ServicePrincipal \\
-  --subscription "${subscription}"
 
 echo "##vso[task.setvariable variable=${name.upper()}_SUBNET_ID]$SUBNET_ID"
 """

--- a/kcl/lib/steps/azure/vnet.k
+++ b/kcl/lib/steps/azure/vnet.k
@@ -30,7 +30,8 @@ SUBNET_ID=$(az network vnet subnet show \\
 az role assignment create \\
   --scope $SUBNET_ID \\
   --role "Network Contributor" \\
-  --assignee "${assignee}" \\
+  --assignee-object-id "${assignee}" \\
+  --assignee-principal-type ServicePrincipal \\
   --subscription "${subscription}"
 
 echo "##vso[task.setvariable variable=${name.upper()}_SUBNET_ID]$SUBNET_ID"


### PR DESCRIPTION
Adds a KCL pipeline for provisioning a large-scale private AKS cluster, intended for 15K-node performance benchmarking.

Full cluster setup: VNet, subnets, firewall, managed identity, jumpbox, AKS cluster, and user node pools
Jumpbox cloud-init installs Azure CLI, Go, and kubectl
Conditional networkDataplane support — set via network_dataplane parameter, omitted if empty (uses AKS default)
Runtime-configurable parameters (subscription_id, location, cluster_name, user_pool_vm_size, network_dataplane) shown in ADO Run dialog