### PR TITLE
Add AKS Machine API CRUD scale pipeline

### DIFF
--- a/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
@@ -1,0 +1,120 @@
+trigger: none
+
+schedules:
+  # Azure Small Scale(10) Machine API Schedule
+  - cron: "0 2 * * *"
+    displayName: "Machine API small scale 10 daily"
+    branches:
+      include:
+        - main
+    always: true
+  # Azure Medium Scale(500) Machine API Schedule
+  - cron: "0 11 * * *"
+    displayName: "Machine API medium scale 500 daily"
+    branches:
+      include:
+        - main
+    always: true
+  # Azure Large Scale(1000) Machine API Schedule
+  - cron: "0 13 * * *"
+    displayName: "Machine API large scale 1000 daily"
+    branches:
+      include:
+        - main
+    always: true
+
+variables:
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: k8s-cluster-crud-machine
+  USE_LATEST_GA_K8S_VERSION: true
+
+stages:
+  - stage: azure_canadacentral_small_scale_10
+    condition: |
+        or(
+          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API small scale 10 daily'),
+          eq(variables['Build.Reason'], 'Manual')
+        )
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - canadacentral
+          topology: k8s-cluster-crud-machine
+          engine: machine
+          matrix:
+            canadacentral-small-scale-10:
+              vm_size: Standard_D2_v3
+              pool_name: smallpool1
+              scale_machine_count: 10
+              machine_workers: 5
+              use_batch_api: "false"
+              step_time_out: 900
+          max_parallel: 1
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false
+
+  - stage: azure_canadacentral_medium_scale_500
+    condition: |
+        or(
+          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API medium scale 500 daily'),
+          eq(variables['Build.Reason'], 'Manual')
+        )
+    dependsOn: []
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - canadacentral
+          topology: k8s-cluster-crud-machine
+          engine: machine
+          matrix:
+            canadacentral-medium-scale-500:
+              vm_size: Standard_D2_v3
+              pool_name: mediumpool1
+              scale_machine_count: 500
+              machine_workers: 10
+              use_batch_api: "true"
+              step_time_out: 2400
+          max_parallel: 1
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false
+
+  - stage: azure_canadacentral_large_scale_1000
+    condition: |
+        and(
+          or(
+            eq(variables['Build.CronSchedule.DisplayName'], 'Machine API large scale 1000 daily'),
+            eq(variables['Build.Reason'], 'Manual')
+          ),
+          in(dependencies.azure_canadacentral_small_scale_10.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
+          in(dependencies.azure_canadacentral_medium_scale_500.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+        )
+    dependsOn:
+      - azure_canadacentral_small_scale_10
+      - azure_canadacentral_medium_scale_500
+    jobs:
+      - template: /jobs/competitive-test.yml
+        parameters:
+          cloud: azure
+          regions:
+            - canadacentral
+          topology: k8s-cluster-crud-machine
+          engine: machine
+          matrix:
+            canadacentral-large-scale-1000:
+              vm_size: Standard_D2_v3
+              pool_name: largepool1
+              scale_machine_count: 1000
+              machine_workers: 20
+              use_batch_api: "true"
+              step_time_out: 3600
+          max_parallel: 1
+          timeout_in_minutes: 360
+          credential_type: service_connection
+          ssh_key_enabled: false

--- a/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
@@ -12,6 +12,7 @@ schedules:
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-cluster-crud-machine
+  AZURE_SUBSCRIPTION_ID: 854c9ddb-fe9e-4aea-8d58-99ed88282881
 stages:
   - stage: azure_canadacentral_small_scale_10
     condition: |

--- a/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
@@ -1,22 +1,15 @@
 trigger: none
 
 schedules:
-  # Azure Small Scale(10) Machine API Schedule
-  - cron: "0 2 * * *"
-    displayName: "Machine API small scale 10 daily"
-    branches:
-      include:
-        - main
-    always: true
-  # Azure Medium Scale(500) Machine API Schedule
-  - cron: "0 11 * * *"
-    displayName: "Machine API medium scale 500 daily"
+  # Azure Small Scale(10) and Medium Scale(500) Machine API Schedule
+  - cron: "0 3 * * *"
+    displayName: "Machine API small and medium scale daily"
     branches:
       include:
         - main
     always: true
   # Azure Large Scale(1000) Machine API Schedule
-  - cron: "0 13 * * *"
+  - cron: "0 4 * * *"
     displayName: "Machine API large scale 1000 daily"
     branches:
       include:
@@ -30,7 +23,7 @@ stages:
   - stage: azure_canadacentral_small_scale_10
     condition: |
         or(
-          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API small scale 10 daily'),
+          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API small and medium scale daily'),
           eq(variables['Build.Reason'], 'Manual')
         )
     dependsOn: []
@@ -58,7 +51,7 @@ stages:
   - stage: azure_canadacentral_medium_scale_500
     condition: |
         or(
-          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API medium scale 500 daily'),
+          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API small and medium scale daily'),
           eq(variables['Build.Reason'], 'Manual')
         )
     dependsOn: []

--- a/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
@@ -1,16 +1,9 @@
 trigger: none
 
 schedules:
-  # Azure Small Scale(10) and Medium Scale(500) Machine API Schedule
+  # Azure Machine API scale schedule
   - cron: "0 3 * * *"
-    displayName: "Machine API small and medium scale daily"
-    branches:
-      include:
-        - main
-    always: true
-  # Azure Large Scale(1000) Machine API Schedule
-  - cron: "0 4 * * *"
-    displayName: "Machine API large scale 1000 daily"
+    displayName: "Machine API scale daily"
     branches:
       include:
         - main
@@ -23,7 +16,7 @@ stages:
   - stage: azure_canadacentral_small_scale_10
     condition: |
         or(
-          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API small and medium scale daily'),
+          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API scale daily'),
           eq(variables['Build.Reason'], 'Manual')
         )
     dependsOn: []
@@ -51,7 +44,7 @@ stages:
   - stage: azure_canadacentral_medium_scale_500
     condition: |
         or(
-          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API small and medium scale daily'),
+          eq(variables['Build.CronSchedule.DisplayName'], 'Machine API scale daily'),
           eq(variables['Build.Reason'], 'Manual')
         )
     dependsOn: []
@@ -80,7 +73,7 @@ stages:
     condition: |
         and(
           or(
-            eq(variables['Build.CronSchedule.DisplayName'], 'Machine API large scale 1000 daily'),
+            eq(variables['Build.CronSchedule.DisplayName'], 'Machine API scale daily'),
             eq(variables['Build.Reason'], 'Manual')
           ),
           in(dependencies.azure_canadacentral_small_scale_10.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),

--- a/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
@@ -26,8 +26,6 @@ schedules:
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-cluster-crud-machine
-  USE_LATEST_GA_K8S_VERSION: true
-
 stages:
   - stage: azure_canadacentral_small_scale_10
     condition: |

--- a/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
@@ -1,0 +1,32 @@
+scenario_type  = "perf-eval"
+scenario_name  = "k8s-cluster-crud-machine"
+deletion_delay = "4h"
+owner          = "aks"
+aks_cli_config_list = [
+  {
+    role                          = "client"
+    aks_name                      = "mchapi"
+    sku_tier                      = "standard"
+    use_aks_preview_cli_extension = true
+    default_node_pool = {
+      name       = "default"
+      node_count = 2
+      vm_size    = "Standard_D2_v3"
+    }
+
+    optional_parameters = [
+      {
+        name  = "network-plugin"
+        value = "azure"
+      },
+      {
+        name  = "network-plugin-mode"
+        value = "overlay"
+      },
+      {
+        name  = "pod-cidr"
+        value = "10.128.0.0/11"
+      }
+    ]
+  }
+]

--- a/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-test-inputs/azure.json
+++ b/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-test-inputs/azure.json
@@ -1,0 +1,22 @@
+{
+    "run_id"                           : "123456789",
+    "region"                           : "canadacentral",
+    "aks_cli_system_node_pool" : {
+      "name"        : "default",
+      "node_count"  : 1,
+      "vm_size"     : "Standard_D2s_v3",
+      "vm_set_type" : "VirtualMachineScaleSets"
+    },
+    "aks_cli_user_node_pool" : [{
+        "name"        : "pool1",
+        "node_count"  : 1,
+        "vm_size"     : "Standard_D2s_v3",
+        "vm_set_type" : "VirtualMachineScaleSets"
+      },
+      {
+        "name"        : "pool2",
+        "node_count"  : 1,
+        "vm_size"     : "Standard_D2s_v3",
+        "vm_set_type" : "VirtualMachineScaleSets"
+      }]
+}

--- a/steps/engine/machine/k8s/collect.yml
+++ b/steps/engine/machine/k8s/collect.yml
@@ -5,6 +5,9 @@ parameters:
     type: string
 
 steps:
+  - template: /steps/cloud/${{ parameters.cloud }}/collect-cloud-info.yml
+    parameters:
+      region: ${{ parameters.region }}
   - bash: |
       set -euo pipefail
       python3 -m crud.main collect

--- a/steps/engine/machine/k8s/collect.yml
+++ b/steps/engine/machine/k8s/collect.yml
@@ -1,0 +1,19 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: region
+    type: string
+
+steps:
+  - bash: |
+      set -euo pipefail
+      python3 -m crud.main collect
+    workingDirectory: modules/python
+    displayName: "Collect Machine API results"
+    condition: always()
+    env:
+      PYTHONPATH: $(Pipeline.Workspace)/s/modules/python
+      RUN_ID: $(RUN_ID)
+      REGION: ${{ parameters.region }}
+      RESULT_DIR: $(System.DefaultWorkingDirectory)/$(RUN_ID)
+      RUN_URL: $(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs&j=$(System.JobId)

--- a/steps/engine/machine/k8s/collect.yml
+++ b/steps/engine/machine/k8s/collect.yml
@@ -8,14 +8,14 @@ steps:
   - template: /steps/cloud/${{ parameters.cloud }}/collect-cloud-info.yml
     parameters:
       region: ${{ parameters.region }}
-  - bash: |
-      set -euo pipefail
-      python3 -m crud.main collect
+  - script: |
+      set -eo pipefail
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" collect
     workingDirectory: modules/python
     displayName: "Collect Machine API results"
     condition: always()
     env:
-      PYTHONPATH: $(Pipeline.Workspace)/s/modules/python
+      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
       RUN_ID: $(RUN_ID)
       REGION: ${{ parameters.region }}
       RESULT_DIR: $(System.DefaultWorkingDirectory)/$(RUN_ID)

--- a/steps/engine/machine/k8s/execute.yml
+++ b/steps/engine/machine/k8s/execute.yml
@@ -24,7 +24,7 @@ steps:
         --arg deletion_due_time "$DELETION_DUE_TIME" \
         --arg creation_time "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
         --arg scenario "$SCENARIO_TYPE-$SCENARIO_NAME" \
-        --arg owner aks \
+        --arg owner "$OWNER" \
         '{run_id:$run_id, deletion_due_time:$deletion_due_time, creation_time:$creation_time, scenario:$scenario, owner:$owner}')
       python3 -m crud.main create-machine \
         --cloud "${{ parameters.cloud }}" \

--- a/steps/engine/machine/k8s/execute.yml
+++ b/steps/engine/machine/k8s/execute.yml
@@ -18,15 +18,15 @@ parameters:
     default: "600"
 
 steps:
-  - bash: |
-      set -euo pipefail
+  - script: |
+      set -eo pipefail
       tags=$(jq -nc --arg run_id "$RUN_ID" \
         --arg deletion_due_time "$DELETION_DUE_TIME" \
         --arg creation_time "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
         --arg scenario "$SCENARIO_TYPE-$SCENARIO_NAME" \
         --arg owner "$OWNER" \
         '{run_id:$run_id, deletion_due_time:$deletion_due_time, creation_time:$creation_time, scenario:$scenario, owner:$owner}')
-      python3 -m crud.main create-machine \
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" create-machine \
         --cloud "${{ parameters.cloud }}" \
         --run-id "$RUN_ID" \
         --node-pool-name "${{ parameters.pool_name }}" \
@@ -38,7 +38,7 @@ steps:
         USE_BATCH_FLAG="--use-batch-api"
       fi
       # shellcheck disable=SC2086
-      python3 -m crud.main scale-machine \
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" scale-machine \
         --cloud "${{ parameters.cloud }}" \
         --run-id "$RUN_ID" \
         --node-pool-name "${{ parameters.pool_name }}" \
@@ -53,8 +53,9 @@ steps:
     workingDirectory: modules/python
     displayName: "Execute Machine API CRUD"
     env:
-      PYTHONPATH: $(Pipeline.Workspace)/s/modules/python
+      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
       RUN_ID: $(RUN_ID)
       DELETION_DUE_TIME: $(DELETION_DUE_TIME)
       SCENARIO_TYPE: $(SCENARIO_TYPE)
       SCENARIO_NAME: $(SCENARIO_NAME)
+      OWNER: aks

--- a/steps/engine/machine/k8s/execute.yml
+++ b/steps/engine/machine/k8s/execute.yml
@@ -1,50 +1,44 @@
 parameters:
   - name: cloud
     type: string
-  - name: result_dir
-    type: string
-  - name: vm_size
-    type: string
-  - name: pool_name
-    type: string
-  - name: scale_machine_count
-    type: string  # numeric matrix values resolve at runtime via $(VAR)
-  - name: machine_workers
-    type: string
-  - name: use_batch_api
-    type: string  # 'true'|'false' as ADO doesn't have boolean type for matrix
-  - name: step_time_out
-    type: string
-    default: "600"
 
 steps:
   - script: |
       set -eo pipefail
+
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" create-machine \
-        --cloud "${{ parameters.cloud }}" \
+        --cloud "$CLOUD" \
         --run-id "$RUN_ID" \
-        --node-pool-name "${{ parameters.pool_name }}" \
-        --vm-size "${{ parameters.vm_size }}" \
-        --step-timeout "${{ parameters.step_time_out }}" \
-        --result-dir "${{ parameters.result_dir }}"
-      USE_BATCH_FLAG=""
-      if [[ "${{ parameters.use_batch_api }}" == "true" ]]; then
-        USE_BATCH_FLAG="--use-batch-api"
+        --node-pool-name "$POOL_NAME" \
+        --vm-size "$VM_SIZE" \
+        --step-timeout "$STEP_TIME_OUT" \
+        --result-dir "$RESULT_DIR"
+
+      use_batch_args=()
+      if [[ "${USE_BATCH_API,,}" == "true" ]]; then
+        use_batch_args+=(--use-batch-api)
       fi
-      # shellcheck disable=SC2086
+
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" scale-machine \
-        --cloud "${{ parameters.cloud }}" \
+        --cloud "$CLOUD" \
         --run-id "$RUN_ID" \
-        --node-pool-name "${{ parameters.pool_name }}" \
-        --vm-size "${{ parameters.vm_size }}" \
-        --scale-machine-count "${{ parameters.scale_machine_count }}" \
-        --machine-workers "${{ parameters.machine_workers }}" \
-        $USE_BATCH_FLAG \
-        --step-timeout "${{ parameters.step_time_out }}" \
-        --readiness-wait-timeout "${{ parameters.step_time_out }}" \
-        --result-dir "${{ parameters.result_dir }}"
+        --node-pool-name "$POOL_NAME" \
+        --vm-size "$VM_SIZE" \
+        --scale-machine-count "$SCALE_MACHINE_COUNT" \
+        --machine-workers "$MACHINE_WORKERS" \
+        "${use_batch_args[@]}" \
+        --step-timeout "$STEP_TIME_OUT" \
+        --readiness-wait-timeout "$STEP_TIME_OUT" \
+        --result-dir "$RESULT_DIR"
     workingDirectory: modules/python
     displayName: "Execute Machine API CRUD"
     env:
       PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
-      RUN_ID: $(RUN_ID)
+      CLOUD: ${{ parameters.cloud }}
+      VM_SIZE: $(VM_SIZE)
+      POOL_NAME: $(POOL_NAME)
+      SCALE_MACHINE_COUNT: $(SCALE_MACHINE_COUNT)
+      MACHINE_WORKERS: $(MACHINE_WORKERS)
+      USE_BATCH_API: $(USE_BATCH_API)
+      STEP_TIME_OUT: $(STEP_TIME_OUT)
+      RESULT_DIR: $(System.DefaultWorkingDirectory)/$(RUN_ID)

--- a/steps/engine/machine/k8s/execute.yml
+++ b/steps/engine/machine/k8s/execute.yml
@@ -20,12 +20,6 @@ parameters:
 steps:
   - script: |
       set -eo pipefail
-      tags=$(jq -nc --arg run_id "$RUN_ID" \
-        --arg deletion_due_time "$DELETION_DUE_TIME" \
-        --arg creation_time "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-        --arg scenario "$SCENARIO_TYPE-$SCENARIO_NAME" \
-        --arg owner "$OWNER" \
-        '{run_id:$run_id, deletion_due_time:$deletion_due_time, creation_time:$creation_time, scenario:$scenario, owner:$owner}')
       PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" create-machine \
         --cloud "${{ parameters.cloud }}" \
         --run-id "$RUN_ID" \
@@ -48,14 +42,9 @@ steps:
         $USE_BATCH_FLAG \
         --step-timeout "${{ parameters.step_time_out }}" \
         --readiness-wait-timeout "${{ parameters.step_time_out }}" \
-        --result-dir "${{ parameters.result_dir }}" \
-        --tags "$tags"
+        --result-dir "${{ parameters.result_dir }}"
     workingDirectory: modules/python
     displayName: "Execute Machine API CRUD"
     env:
       PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
       RUN_ID: $(RUN_ID)
-      DELETION_DUE_TIME: $(DELETION_DUE_TIME)
-      SCENARIO_TYPE: $(SCENARIO_TYPE)
-      SCENARIO_NAME: $(SCENARIO_NAME)
-      OWNER: aks

--- a/steps/engine/machine/k8s/execute.yml
+++ b/steps/engine/machine/k8s/execute.yml
@@ -1,0 +1,60 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: result_dir
+    type: string
+  - name: vm_size
+    type: string
+  - name: pool_name
+    type: string
+  - name: scale_machine_count
+    type: string  # numeric matrix values resolve at runtime via $(VAR)
+  - name: machine_workers
+    type: string
+  - name: use_batch_api
+    type: string  # 'true'|'false' as ADO doesn't have boolean type for matrix
+  - name: step_time_out
+    type: string
+    default: "600"
+
+steps:
+  - bash: |
+      set -euo pipefail
+      tags=$(jq -nc --arg run_id "$RUN_ID" \
+        --arg deletion_due_time "$DELETION_DUE_TIME" \
+        --arg creation_time "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+        --arg scenario "$SCENARIO_TYPE-$SCENARIO_NAME" \
+        --arg owner aks \
+        '{run_id:$run_id, deletion_due_time:$deletion_due_time, creation_time:$creation_time, scenario:$scenario, owner:$owner}')
+      python3 -m crud.main create-machine \
+        --cloud "${{ parameters.cloud }}" \
+        --run-id "$RUN_ID" \
+        --node-pool-name "${{ parameters.pool_name }}" \
+        --vm-size "${{ parameters.vm_size }}" \
+        --step-timeout "${{ parameters.step_time_out }}" \
+        --result-dir "${{ parameters.result_dir }}"
+      USE_BATCH_FLAG=""
+      if [[ "${{ parameters.use_batch_api }}" == "true" ]]; then
+        USE_BATCH_FLAG="--use-batch-api"
+      fi
+      # shellcheck disable=SC2086
+      python3 -m crud.main scale-machine \
+        --cloud "${{ parameters.cloud }}" \
+        --run-id "$RUN_ID" \
+        --node-pool-name "${{ parameters.pool_name }}" \
+        --vm-size "${{ parameters.vm_size }}" \
+        --scale-machine-count "${{ parameters.scale_machine_count }}" \
+        --machine-workers "${{ parameters.machine_workers }}" \
+        $USE_BATCH_FLAG \
+        --step-timeout "${{ parameters.step_time_out }}" \
+        --readiness-wait-timeout "${{ parameters.step_time_out }}" \
+        --result-dir "${{ parameters.result_dir }}" \
+        --tags "$tags"
+    workingDirectory: modules/python
+    displayName: "Execute Machine API CRUD"
+    env:
+      PYTHONPATH: $(Pipeline.Workspace)/s/modules/python
+      RUN_ID: $(RUN_ID)
+      DELETION_DUE_TIME: $(DELETION_DUE_TIME)
+      SCENARIO_TYPE: $(SCENARIO_TYPE)
+      SCENARIO_NAME: $(SCENARIO_NAME)

--- a/steps/topology/k8s-cluster-crud-machine/collect-machine.yml
+++ b/steps/topology/k8s-cluster-crud-machine/collect-machine.yml
@@ -1,0 +1,14 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: regions
+    type: object
+  - name: engine_input
+    type: object
+    default: {}
+
+steps:
+  - template: /steps/engine/machine/k8s/collect.yml
+    parameters:
+      cloud: ${{ parameters.cloud }}
+      region: ${{ parameters.regions[0] }}

--- a/steps/topology/k8s-cluster-crud-machine/execute-machine.yml
+++ b/steps/topology/k8s-cluster-crud-machine/execute-machine.yml
@@ -11,10 +11,3 @@ steps:
   - template: /steps/engine/machine/k8s/execute.yml
     parameters:
       cloud: ${{ parameters.cloud }}
-      result_dir: $(System.DefaultWorkingDirectory)/$(RUN_ID)
-      vm_size: $(VM_SIZE)
-      pool_name: $(POOL_NAME)
-      scale_machine_count: $(SCALE_MACHINE_COUNT)
-      machine_workers: $(MACHINE_WORKERS)
-      use_batch_api: $(USE_BATCH_API)
-      step_time_out: $(STEP_TIME_OUT)

--- a/steps/topology/k8s-cluster-crud-machine/execute-machine.yml
+++ b/steps/topology/k8s-cluster-crud-machine/execute-machine.yml
@@ -1,0 +1,20 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: regions
+    type: object
+  - name: engine_input
+    type: object
+    default: {}
+
+steps:
+  - template: /steps/engine/machine/k8s/execute.yml
+    parameters:
+      cloud: ${{ parameters.cloud }}
+      result_dir: $(System.DefaultWorkingDirectory)/$(RUN_ID)
+      vm_size: $(VM_SIZE)
+      pool_name: $(POOL_NAME)
+      scale_machine_count: $(SCALE_MACHINE_COUNT)
+      machine_workers: $(MACHINE_WORKERS)
+      use_batch_api: $(USE_BATCH_API)
+      step_time_out: $(STEP_TIME_OUT)

--- a/steps/topology/k8s-cluster-crud-machine/validate-resources.yml
+++ b/steps/topology/k8s-cluster-crud-machine/validate-resources.yml
@@ -1,0 +1,13 @@
+parameters:
+  - name: cloud
+    type: string
+  - name: regions
+    type: object
+  - name: engine
+    type: string
+
+steps:
+  - template: /steps/cloud/${{ parameters.cloud }}/update-kubeconfig.yml
+    parameters:
+      role: client
+      region: ${{ parameters.regions[0] }}


### PR DESCRIPTION
## Summary
- add the Machine API CRUD perf-eval pipeline with canadacentral small/medium/large scale buckets for 10, 500, and 1000 machines
- add the k8s-cluster-crud-machine scenario Terraform inputs and test inputs
- add machine topology and engine collect/execute templates used by competitive-test
- keep the PR scoped to production perf pipeline files only; this intentionally excludes `pipelines/system/new-pipeline-test.yml`

## Validation
- YAML/JSON parse smoke for changed pipeline, scenario, and step files
- `terraform fmt -check -diff scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars`
- stage/dependency/matrix validation for `pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml`
- `git diff --check origin/main...HEAD`
- confirmed no Python files differ from `origin/main`
