### PR TITLE
Use NAT gateway for Machine API perf test

### DIFF
--- a/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
@@ -12,6 +12,7 @@ schedules:
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-cluster-crud-machine
+  AZURE_SERVICE_CONNECTION: Azure-for-Telescope-Large-Cluster-Sub
   AZURE_SUBSCRIPTION_ID: 854c9ddb-fe9e-4aea-8d58-99ed88282881
 stages:
   - stage: azure_canadacentral_small_scale_10

--- a/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
@@ -41,7 +41,11 @@ aks_cli_config_list = [
     use_aks_preview_cli_extension = true
     use_aks_preview_private_build = false
     use_custom_configurations     = false
-    default_node_pool             = null
+    default_node_pool = {
+      name       = "default"
+      node_count = 2
+      vm_size    = "Standard_D2_v3"
+    }
     optional_parameters = [
       {
         name  = "network-plugin"

--- a/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
@@ -21,7 +21,7 @@ network_config_list = [
       }
     ]
     nat_gateway_associations = [{
-      nat_gateway_name = "crud-c2n5kp5k-nat-gateway"
+      nat_gateway_name = "crud-nat-gateway"
       subnet_names     = ["crud-subnet"]
       public_ip_names  = ["crud-nat-gateway-pip-1", "crud-nat-gateway-pip-2", "crud-nat-gateway-pip-3", "crud-nat-gateway-pip-4", "crud-nat-gateway-pip-5"]
     }]

--- a/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
@@ -2,18 +2,46 @@ scenario_type  = "perf-eval"
 scenario_name  = "k8s-cluster-crud-machine"
 deletion_delay = "4h"
 owner          = "aks"
+
+public_ip_config_list = [
+  {
+    name  = "crud-nat-gateway-pip"
+    count = 5
+  }
+]
+network_config_list = [
+  {
+    role               = "crud"
+    vnet_name          = "crud-vnet"
+    vnet_address_space = "10.192.0.0/10"
+    subnet = [
+      {
+        name           = "crud-subnet"
+        address_prefix = "10.192.0.0/10"
+      }
+    ]
+    nat_gateway_associations = [{
+      nat_gateway_name = "crud-c2n5kp5k-nat-gateway"
+      subnet_names     = ["crud-subnet"]
+      public_ip_names  = ["crud-nat-gateway-pip-1", "crud-nat-gateway-pip-2", "crud-nat-gateway-pip-3", "crud-nat-gateway-pip-4", "crud-nat-gateway-pip-5"]
+    }]
+    network_security_group_name = ""
+    nic_public_ip_associations  = []
+    nsr_rules                   = []
+  }
+]
+
 aks_cli_config_list = [
   {
     role                          = "client"
     aks_name                      = "mchapi"
     sku_tier                      = "standard"
+    subnet_name                   = "crud-subnet"
+    managed_identity_name         = "crud-identity"
     use_aks_preview_cli_extension = true
-    default_node_pool = {
-      name       = "default"
-      node_count = 2
-      vm_size    = "Standard_D2_v3"
-    }
-
+    use_aks_preview_private_build = false
+    use_custom_configurations     = false
+    default_node_pool             = null
     optional_parameters = [
       {
         name  = "network-plugin"
@@ -26,6 +54,10 @@ aks_cli_config_list = [
       {
         name  = "pod-cidr"
         value = "10.128.0.0/11"
+      },
+      {
+        name  = "outbound-type"
+        value = "userAssignedNATGateway"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- route the Machine API perf test through the large-cluster Azure service connection
- add a dedicated NAT gateway with five public IPs for the CRUD subnet
- create the AKS client cluster without the private aks-preview wheel so it uses the public extension path

## Validation
- terraform fmt -check -diff scenarios/perf-eval/k8s-cluster-crud-machine/terraform-inputs/azure.tfvars
- ruby YAML parse for pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
- git diff --cached --check
- terraform -chdir=modules/terraform/azure init -backend=false
- terraform -chdir=modules/terraform/azure validate
- New Pipeline Test build 70837 succeeded: https://dev.azure.com/akstelescope/telescope/_build/results?buildId=70837