### PR TITLE
feat: declare agent pool explicitly in the sourcecode

### DIFF
--- a/pipelines/perf-eval/ACR Benchmark/image-pull-n10.yml
+++ b/pipelines/perf-eval/ACR Benchmark/image-pull-n10.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 */6 * * *"
     displayName: "Every 6 Hours"

--- a/pipelines/perf-eval/ACR Benchmark/image-pull-n1000.yml
+++ b/pipelines/perf-eval/ACR Benchmark/image-pull-n1000.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: image-pull-n1000

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-configmaps100.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-configmaps100.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 3 * * *"
     displayName: "Every Day at 3 AM"

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 12 * * *"
     displayName: "Every Day at Noon"

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods3k.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 0 * * *"
     displayName: "Daily midnight build"

--- a/pipelines/perf-eval/Automatic Benchmark/cluster-automatic-single-cluster.yml
+++ b/pipelines/perf-eval/Automatic Benchmark/cluster-automatic-single-cluster.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # AKS Automatic On-Demand Schedule
   - cron: "0 15/6 * * *"

--- a/pipelines/perf-eval/Automatic Benchmark/hobo-automatic.yml
+++ b/pipelines/perf-eval/Automatic Benchmark/hobo-automatic.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   - cron: "0 15 * * *"
     displayName: "Daily HOBO Automatic"

--- a/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark .yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark .yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # Azure Small Scale(10) Schedule
   - cron: "0 1 * * *"

--- a/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes200-ab-testing.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-nodes200-ab-testing.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 8,20 * * *"
     displayName: "Every day at 8:00 AM and 8:00 PM"

--- a/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-vms.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/cluster-autoscaler-benchmark-vms.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # Azure Small Scale(10) VMs Schedule
   - cron: "0 2 * * *"

--- a/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/k8s-cluster-crud-machine.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   # Azure Machine API scale schedule
   - cron: "0 3 * * *"

--- a/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-5k-nodes.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-5k-nodes.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 # schedules:
 #   # Azure Large Scale(5000) On-Demand Schedule
 #   - cron: "0 15 * * *"

--- a/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-complex.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark-complex.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # canadacentral - daily
   - cron: "0 21 * * *"

--- a/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark.yml
+++ b/pipelines/perf-eval/Autoscale Benchmark/node-auto-provisioning-benchmark.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # Azure Small Scale(10) Schedule
   - cron: "0 3 * * *"

--- a/pipelines/perf-eval/CNI Benchmark/cni-ab-testing.yml
+++ b/pipelines/perf-eval/CNI Benchmark/cni-ab-testing.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 1-23/4 * * *"
     displayName: "Every 4 Hour (1AM start)"

--- a/pipelines/perf-eval/CRI Benchmark/azurelinux-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/azurelinux-resource-consume.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 */4 * * *"
     displayName: "Every 4 Hour"

--- a/pipelines/perf-eval/CRI Benchmark/cri-kbench-cp-bottlerocket.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-kbench-cp-bottlerocket.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: cri-kbench-cp-bottlerocket

--- a/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/cri-resource-consume.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 2-23/4 * * *"
     displayName: "Every 4 Hour"

--- a/pipelines/perf-eval/CRI Benchmark/flatcar-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/flatcar-resource-consume.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "30 3-23/4 * * *"
     displayName: "Every 4 Hour"

--- a/pipelines/perf-eval/CRI Benchmark/k8s-resource-pressure.yml
+++ b/pipelines/perf-eval/CRI Benchmark/k8s-resource-pressure.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-node-stress

--- a/pipelines/perf-eval/CRI Benchmark/konnectivity-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/konnectivity-resource-consume.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 #schedules:
 #- cron: "0 2-23/4 * * *"
 # displayName: "Every 4 Hour"

--- a/pipelines/perf-eval/CRI Benchmark/windows-resource-consume.yml
+++ b/pipelines/perf-eval/CRI Benchmark/windows-resource-consume.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "45 1-23/4 * * *"
     displayName: "Every 4 Hour"

--- a/pipelines/perf-eval/CSI Benchmark/csi-attach-detach-1000.yml
+++ b/pipelines/perf-eval/CSI Benchmark/csi-attach-detach-1000.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 20 * * *"
     displayName: "8:00 PM Every Day"

--- a/pipelines/perf-eval/CSI Benchmark/csi-attach-detach-300.yml
+++ b/pipelines/perf-eval/CSI Benchmark/csi-attach-detach-300.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 16 * * *"
     displayName: "4:00 PM Every Day"

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # Two region chains run independently (different clusters via run_id, no conflict):
   #   australiaeast: H100-managed → A10-managed → H100-fully → A10-fully (sequential, up to 12h)

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-scheduling.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-scheduling.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
 - cron: "0 8 * * *"
   displayName: "8:00 AM daily (small scale)"

--- a/pipelines/perf-eval/GPU Benchmark/k8s-ray-scheduling.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-ray-scheduling.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
 - cron: "0 0 * * *"
   displayName: "12:00 AM daily (small scale)"

--- a/pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-H2.yml
+++ b/pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-H2.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   - cron: "0 */6 * * *"
     displayName: "Run every 6 hours"

--- a/pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-H4.yml
+++ b/pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-H4.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   - cron: "0 */6 * * *"
     displayName: "Run every 6 hours"

--- a/pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-H8.yml
+++ b/pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-H8.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   - cron: "0 */6 * * *"
     displayName: "Run every 6 hours"

--- a/pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-baseline.yml
+++ b/pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-baseline.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   - cron: "0 */6 * * *"
     displayName: "Run every 6 hours"

--- a/pipelines/perf-eval/Large Cluster Benchmark/cluster-churn.yml
+++ b/pipelines/perf-eval/Large Cluster Benchmark/cluster-churn.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 */12 * * *"
     displayName: "12:00 AM & PM Daily"

--- a/pipelines/perf-eval/Large Cluster Benchmark/service-churn.yml
+++ b/pipelines/perf-eval/Large Cluster Benchmark/service-churn.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 6,18 * * *"
     displayName: "6:00 AM & PM Daily"

--- a/pipelines/perf-eval/Network Benchmark/pod-to-pod-diff-node-same-zone-same-cluster.yml
+++ b/pipelines/perf-eval/Network Benchmark/pod-to-pod-diff-node-same-zone-same-cluster.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   - cron: "0 11 * * *"
     displayName: "11:00 AM Daily"

--- a/pipelines/perf-eval/Scheduler Benchmark/job-scheduling.yml
+++ b/pipelines/perf-eval/Scheduler Benchmark/job-scheduling.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
 - cron: "0 4 * * *"
   displayName: "4:00 AM daily (small scale)"

--- a/pipelines/perf-eval/Scheduler Benchmark/pod-churn-50k-sched.yml
+++ b/pipelines/perf-eval/Scheduler Benchmark/pod-churn-50k-sched.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "30 1/12 * * *"
     displayName: "1:30 AM and PM every day"

--- a/pipelines/perf-eval/Secure TLS Bootstrap Benchmark/cluster-autoscaler.yml
+++ b/pipelines/perf-eval/Secure TLS Bootstrap Benchmark/cluster-autoscaler.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # Linux Large Scale Schedule
   - cron: "0 7 * * *"

--- a/pipelines/perf-eval/Secure TLS Bootstrap Benchmark/cri-resource-consume.yml
+++ b/pipelines/perf-eval/Secure TLS Bootstrap Benchmark/cri-resource-consume.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # Linux CRI Resource Consume Schedule
   - cron: "0 9,21 * * *"

--- a/pipelines/perf-eval/Secure TLS Bootstrap Benchmark/node-auto-provisioning.yml
+++ b/pipelines/perf-eval/Secure TLS Bootstrap Benchmark/node-auto-provisioning.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   # Azure Large Scale Schedule
   - cron: "0 3 * * *"

--- a/pipelines/perf-eval/Storage Benchmark/k8s-nvme-disk-fio.yml
+++ b/pipelines/perf-eval/Storage Benchmark/k8s-nvme-disk-fio.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   - cron: "15 3 * * *"
     displayName: "Daily at 3:15 AM"

--- a/pipelines/perf-eval/Storage Benchmark/k8s-os-disk-fio.yml
+++ b/pipelines/perf-eval/Storage Benchmark/k8s-os-disk-fio.yml
@@ -1,4 +1,7 @@
 trigger: none
+
+pool:
+  name: 'AKS-Telescope-Airlock'
 schedules:
   - cron: "0 10 */2 * *"
     displayName: "Every Even Day at 10 AM"

--- a/pipelines/system/aws-capacity-reservation.yml
+++ b/pipelines/system/aws-capacity-reservation.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 stages:
   - stage: aws_capacity_reservation
     displayName: "AWS Capacity Reservation"

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 variables:
   SCENARIO_TYPE: <scenario-type>
   SCENARIO_NAME: <scenario-name>

--- a/pipelines/system/pipeline-validator.yml
+++ b/pipelines/system/pipeline-validator.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+pool:
+  name: 'AKS-Telescope-Airlock'
+
 schedules:
   - cron: "0 */6 * * *"
     displayName: "Every 6 hours"


### PR DESCRIPTION
The agent pool is declared in ADO pipeline, which is not ideal and easy to have mistake. To avoid pipeline using the wrong agent pool. This PR is to fix it in the source code.