### PR TITLE
feat(gpu-crud): record gpu_mode and MIG strategy on every node-pool op

### DIFF
--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -428,6 +428,21 @@ class AKSClient:
             "gpu_mig_strategy": strategy,
         }
 
+    @staticmethod
+    def _log_gpu_mode(metadata: Dict[str, Any]) -> None:
+        """Echo the normalized GPU-mode metadata to the console for traceability."""
+        if metadata.get("gpu_mode") in (None, "none"):
+            return
+        logger.info(
+            "GPU pool metadata: gpu_mode=%s enable_managed_gpu=%s mig_enabled=%s "
+            "gpu_instance_profile=%s gpu_mig_strategy=%s",
+            metadata.get("gpu_mode"),
+            metadata.get("enable_managed_gpu"),
+            metadata.get("mig_enabled"),
+            metadata.get("gpu_instance_profile"),
+            metadata.get("gpu_mig_strategy"),
+        )
+
     def create_node_pool(
         self,
         node_pool_name: str,
@@ -481,6 +496,7 @@ class AKSClient:
                 gpu_mig_strategy,
             ),
         }
+        self._log_gpu_mode(metadata)
 
         # Create operation context to track the operation
         with self._get_operation_context()(
@@ -633,6 +649,7 @@ class AKSClient:
                 gpu_mig_strategy,
             ),
         }
+        self._log_gpu_mode(metadata)
         node_pool = self.get_node_pool(node_pool_name, cluster_name)
 
         current_count = node_pool.count
@@ -902,6 +919,7 @@ class AKSClient:
                     gpu_mig_strategy,
                 ),
             }
+            self._log_gpu_mode(step_metadata)
 
             # Create operation context for this specific step
             with self._get_operation_context()(

--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -371,39 +371,23 @@ class AKSClient:
         gpu_mig_strategy: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
-        Build normalized GPU-mode metadata that reliably distinguishes
-        managed vs fully-managed GPU and MIG single vs mixed.
+        Build normalized GPU-mode metadata distinguishing managed vs fully-managed
+        GPU and MIG single vs mixed.
 
-        These fields are derived from the operation's INPUT flags rather than the
-        AKS read-back: the stable Python SDK (azure-mgmt-containerservice) does not
-        model gpuProfile.nvidia.managementMode, so a fully-managed pool's mode is
-        silently dropped from nodepool_info. Recording the input flags here keeps
-        the distinction queryable downstream regardless of SDK coverage.
+        Derived from the operation INPUT flags rather than the AKS read-back: the
+        stable SDK does not model gpuProfile.nvidia.managementMode, so a
+        fully-managed pool's mode is dropped from nodepool_info. Flag combinations
+        are normalized for consistency: enable_managed_gpu / MIG only apply to a
+        GPU pool, and MIG only to fully-managed pools (dropped otherwise).
 
-        The flag combination is normalized so records are always internally
-        consistent regardless of how callers combine inputs:
-          - enable_managed_gpu / MIG inputs are only meaningful for a GPU pool
-            (gpu_node_pool=True); they are ignored otherwise.
-          - MIG (gpu_instance_profile / gpu_mig_strategy) only applies to
-            fully-managed GPU pools; it is dropped for managed/non-GPU pools.
-
-        Raises:
-            ValueError: if gpu_mig_strategy is not one of None / "single" / "mixed".
-
-        Returns:
-            Dict with:
-              - gpu_mode: "none" | "managed" | "fully_managed"
-              - enable_managed_gpu: normalized fully-managed flag (False unless it
-                is actually a fully-managed GPU pool)
-              - mig_enabled: whether MIG was requested on a fully-managed pool
-              - gpu_instance_profile: MIG instance profile (e.g. "MIG1g") or None
-              - gpu_mig_strategy: "single" | "mixed" | None
+        Returns a dict with gpu_mode ("none"|"managed"|"fully_managed"),
+        enable_managed_gpu, mig_enabled, gpu_instance_profile, gpu_mig_strategy.
+        Raises ValueError if gpu_mig_strategy is not None / "single" / "mixed".
         """
         strategy = (gpu_mig_strategy or None) and str(gpu_mig_strategy).lower()
         if strategy not in (None, "single", "mixed"):
             raise ValueError(
-                f"invalid gpu_mig_strategy {gpu_mig_strategy!r}; "
-                "expected 'single', 'mixed', or None"
+                f"invalid gpu_mig_strategy {gpu_mig_strategy!r} (want single/mixed/None)"
             )
 
         is_gpu = bool(gpu_node_pool)

--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -268,11 +268,12 @@ class AKSClient:
         retries: int = 10,
         retry_wait: int = 30,
         poll_interval: int = 30,
-        timeout: int = 1200,
+        timeout: int = 1800,
     ) -> None:
         """
         Call begin_create_or_update with retry on OperationNotAllowed/EtagMismatch,
         polling every poll_interval seconds and raising TimeoutError after timeout seconds.
+        timeout defaults to 1800s (30 min) for slow GPU node provisioning (A100 MIG).
         """
         for attempt in range(retries):
             try:

--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -363,6 +363,46 @@ class AKSClient:
                 )
         logger.info(f"az aks nodepool add succeeded for '{node_pool_name}'")
 
+    @staticmethod
+    def _gpu_mode_metadata(
+        gpu_node_pool: bool,
+        enable_managed_gpu: bool,
+        gpu_instance_profile: Optional[str] = None,
+        gpu_mig_strategy: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Build normalized GPU-mode metadata that reliably distinguishes
+        managed vs fully-managed GPU and MIG single vs mixed.
+
+        These fields are derived from the operation's INPUT flags rather than the
+        AKS read-back: the stable Python SDK (azure-mgmt-containerservice) does not
+        model gpuProfile.nvidia.managementMode, so a fully-managed pool's mode is
+        silently dropped from nodepool_info. Recording the input flags here keeps
+        the distinction queryable downstream regardless of SDK coverage.
+
+        Returns:
+            Dict with:
+              - gpu_mode: "none" | "managed" | "fully_managed"
+              - enable_managed_gpu: the raw fully-managed flag
+              - mig_enabled: whether a MIG profile/strategy was requested
+              - gpu_instance_profile: MIG instance profile (e.g. "MIG1g") or None
+              - gpu_mig_strategy: "single" | "mixed" | None
+        """
+        if not gpu_node_pool:
+            gpu_mode = "none"
+        elif enable_managed_gpu:
+            gpu_mode = "fully_managed"
+        else:
+            gpu_mode = "managed"
+
+        return {
+            "gpu_mode": gpu_mode,
+            "enable_managed_gpu": enable_managed_gpu,
+            "mig_enabled": bool(gpu_instance_profile or gpu_mig_strategy),
+            "gpu_instance_profile": gpu_instance_profile,
+            "gpu_mig_strategy": gpu_mig_strategy,
+        }
+
     def create_node_pool(
         self,
         node_pool_name: str,
@@ -409,7 +449,12 @@ class AKSClient:
             "vm_size": vm_size,
             "node_count": node_count,
             "gpu_node_pool": gpu_node_pool,
-            "enable_managed_gpu": enable_managed_gpu,
+            **self._gpu_mode_metadata(
+                gpu_node_pool,
+                enable_managed_gpu,
+                gpu_instance_profile,
+                gpu_mig_strategy,
+            ),
         }
 
         # Create operation context to track the operation
@@ -522,6 +567,7 @@ class AKSClient:
         progressive: bool = False,
         scale_step_size: int = 1,
         gpu_instance_profile: Optional[str] = None,
+        gpu_mig_strategy: Optional[str] = None,
     ) -> Any:
         """
         Scale a node pool to the specified node count.
@@ -555,6 +601,12 @@ class AKSClient:
             "gpu_node_pool": gpu_node_pool,
             "progressive_scaling": progressive,
             "scale_step_size": scale_step_size,
+            **self._gpu_mode_metadata(
+                gpu_node_pool,
+                enable_managed_gpu,
+                gpu_instance_profile,
+                gpu_mig_strategy,
+            ),
         }
         node_pool = self.get_node_pool(node_pool_name, cluster_name)
 
@@ -583,6 +635,7 @@ class AKSClient:
                 enable_managed_gpu=enable_managed_gpu,
                 node_pool=node_pool,
                 gpu_instance_profile=gpu_instance_profile,
+                gpu_mig_strategy=gpu_mig_strategy,
             )
 
         # Create operation context to track the operation
@@ -751,6 +804,7 @@ class AKSClient:
         enable_managed_gpu: bool = False,
         node_pool: Optional[Any] = None,
         gpu_instance_profile: Optional[str] = None,
+        gpu_mig_strategy: Optional[str] = None,
     ) -> Any:
         """
         Scale a node pool progressively with specified step size
@@ -816,6 +870,12 @@ class AKSClient:
                 "scale_step_size": scale_step_size,
                 "cluster_name": cluster_name or self.get_cluster_name(),
                 "gpu_node_pool": gpu_node_pool,
+                **self._gpu_mode_metadata(
+                    gpu_node_pool,
+                    enable_managed_gpu,
+                    gpu_instance_profile,
+                    gpu_mig_strategy,
+                ),
             }
 
             # Create operation context for this specific step

--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -380,27 +380,52 @@ class AKSClient:
         silently dropped from nodepool_info. Recording the input flags here keeps
         the distinction queryable downstream regardless of SDK coverage.
 
+        The flag combination is normalized so records are always internally
+        consistent regardless of how callers combine inputs:
+          - enable_managed_gpu / MIG inputs are only meaningful for a GPU pool
+            (gpu_node_pool=True); they are ignored otherwise.
+          - MIG (gpu_instance_profile / gpu_mig_strategy) only applies to
+            fully-managed GPU pools; it is dropped for managed/non-GPU pools.
+
+        Raises:
+            ValueError: if gpu_mig_strategy is not one of None / "single" / "mixed".
+
         Returns:
             Dict with:
               - gpu_mode: "none" | "managed" | "fully_managed"
-              - enable_managed_gpu: the raw fully-managed flag
-              - mig_enabled: whether a MIG profile/strategy was requested
+              - enable_managed_gpu: normalized fully-managed flag (False unless it
+                is actually a fully-managed GPU pool)
+              - mig_enabled: whether MIG was requested on a fully-managed pool
               - gpu_instance_profile: MIG instance profile (e.g. "MIG1g") or None
               - gpu_mig_strategy: "single" | "mixed" | None
         """
-        if not gpu_node_pool:
+        strategy = (gpu_mig_strategy or None) and str(gpu_mig_strategy).lower()
+        if strategy not in (None, "single", "mixed"):
+            raise ValueError(
+                f"invalid gpu_mig_strategy {gpu_mig_strategy!r}; "
+                "expected 'single', 'mixed', or None"
+            )
+
+        is_gpu = bool(gpu_node_pool)
+        fully_managed = is_gpu and bool(enable_managed_gpu)
+
+        if not is_gpu:
             gpu_mode = "none"
-        elif enable_managed_gpu:
+        elif fully_managed:
             gpu_mode = "fully_managed"
         else:
             gpu_mode = "managed"
 
+        # MIG only applies to fully-managed pools; drop it otherwise.
+        profile = gpu_instance_profile if fully_managed else None
+        strategy = strategy if fully_managed else None
+
         return {
             "gpu_mode": gpu_mode,
-            "enable_managed_gpu": enable_managed_gpu,
-            "mig_enabled": bool(gpu_instance_profile or gpu_mig_strategy),
-            "gpu_instance_profile": gpu_instance_profile,
-            "gpu_mig_strategy": gpu_mig_strategy,
+            "enable_managed_gpu": fully_managed,
+            "mig_enabled": bool(profile or strategy),
+            "gpu_instance_profile": profile,
+            "gpu_mig_strategy": strategy,
         }
 
     def create_node_pool(

--- a/modules/python/clients/kubernetes_client.py
+++ b/modules/python/clients/kubernetes_client.py
@@ -683,18 +683,29 @@ class KubernetesClient:
                 logger.info(f"Verifying NVIDIA drivers on node {node_name}")
                 node = self.describe_node(node_name)
 
-                # Check if the node has GPUs allocated values (whole GPU or MIG slices)
+                # Wait for the node to advertise a POSITIVE GPU/MIG count. The device
+                # plugin can register nvidia.com/gpu with value "0" before MIG instances
+                # are published, so a MIG-single node briefly looks GPU-less. Waiting on
+                # key presence (rather than a positive count) would race in during that
+                # window and skip the node; wait on the count instead.
                 start_time = time.time()
+                gpu_count = 0
                 while time.time() < start_time + 600:
                     allocatable = node.status.allocatable or {}
-                    if "nvidia.com/gpu" in allocatable or any(k.startswith("nvidia.com/mig-") for k in allocatable):
+                    gpu_count = int(allocatable.get("nvidia.com/gpu", "0"))
+                    mig_count = sum(
+                        int(v) for k, v in allocatable.items()
+                        if k.startswith("nvidia.com/mig-")
+                    )
+                    if gpu_count > 0 or mig_count > 0:
                         break
-                    node = self.describe_node(node_name)
-                    logger.info(f"Node allocatable resources: {node.status.allocatable}")
-                    logger.info(f"Waiting for GPUs to be allocated on node {node_name}...")
+                    logger.info(
+                        f"Waiting for GPUs to be allocated on node {node_name}... "
+                        f"(allocatable: {allocatable})"
+                    )
                     time.sleep(1)
-                gpu_count = int(node.status.allocatable.get("nvidia.com/gpu", "0"))
-                has_mig = any(k.startswith("nvidia.com/mig-") for k in node.status.allocatable)
+                    node = self.describe_node(node_name)
+                has_mig = any(k.startswith("nvidia.com/mig-") for k in (node.status.allocatable or {}))
 
                 logger.info(f"Node {node_name} has {gpu_count} GPUs, requesting all for validation")
 

--- a/modules/python/crud/azure/node_pool_crud.py
+++ b/modules/python/crud/azure/node_pool_crud.py
@@ -118,6 +118,7 @@ class NodePoolCRUD:
         gpu_node_pool=False,
         enable_managed_gpu=False,
         gpu_instance_profile=None,
+        gpu_mig_strategy=None,
     ):
         """
         Scale a node pool to specified count
@@ -145,6 +146,7 @@ class NodePoolCRUD:
                 progressive=progressive,
                 scale_step_size=scale_step_size,
                 gpu_instance_profile=gpu_instance_profile,
+                gpu_mig_strategy=gpu_mig_strategy,
             )
 
             if result is not None:
@@ -253,6 +255,7 @@ class NodePoolCRUD:
                 gpu_node_pool=gpu_node_pool,
                 enable_managed_gpu=enable_managed_gpu,
                 gpu_instance_profile=gpu_instance_profile,
+                gpu_mig_strategy=gpu_mig_strategy,
             )
             results["scale_up"] = scale_up_result
 
@@ -276,6 +279,8 @@ class NodePoolCRUD:
                 scale_step_size=scale_step_size,
                 gpu_node_pool=gpu_node_pool,
                 enable_managed_gpu=enable_managed_gpu,
+                gpu_instance_profile=gpu_instance_profile,
+                gpu_mig_strategy=gpu_mig_strategy,
             )
             results["scale_down"] = scale_down_result
 

--- a/modules/python/crud/main.py
+++ b/modules/python/crud/main.py
@@ -107,6 +107,16 @@ def handle_node_pool_operation(node_pool_crud, args):
     command = args.command
     result = None
 
+    # gpu_instance_profile / gpu_mig_strategy are Azure-only MIG inputs. The AWS
+    # CRUD does not accept these kwargs (and has no **kwargs), so passing them for
+    # --cloud aws would raise TypeError. Only forward them on Azure.
+    azure_gpu_kwargs = {}
+    if args.cloud == "azure":
+        azure_gpu_kwargs = {
+            "gpu_instance_profile": args.gpu_instance_profile,
+            "gpu_mig_strategy": args.gpu_mig_strategy,
+        }
+
     try:
         if command == "create":
             # Prepare create arguments
@@ -116,8 +126,7 @@ def handle_node_pool_operation(node_pool_crud, args):
                 "node_count": args.node_count,
                 "gpu_node_pool": args.gpu_node_pool,
                 "enable_managed_gpu": args.enable_managed_gpu,
-                "gpu_instance_profile": args.gpu_instance_profile,
-                "gpu_mig_strategy": args.gpu_mig_strategy,
+                **azure_gpu_kwargs,
             }
 
             result = node_pool_crud.create_node_pool(**create_kwargs)
@@ -131,8 +140,7 @@ def handle_node_pool_operation(node_pool_crud, args):
                 "scale_step_size": args.scale_step_size,
                 "gpu_node_pool": args.gpu_node_pool,
                 "enable_managed_gpu": args.enable_managed_gpu,
-                "gpu_instance_profile": args.gpu_instance_profile,
-                "gpu_mig_strategy": args.gpu_mig_strategy,
+                **azure_gpu_kwargs,
             }
 
             result = node_pool_crud.scale_node_pool(**scale_kwargs)
@@ -152,8 +160,7 @@ def handle_node_pool_operation(node_pool_crud, args):
                 "gpu_node_pool": args.gpu_node_pool,
                 "enable_managed_gpu": args.enable_managed_gpu,
                 "step_wait_time": args.step_wait_time,
-                "gpu_instance_profile": args.gpu_instance_profile,
-                "gpu_mig_strategy": args.gpu_mig_strategy,
+                **azure_gpu_kwargs,
             }
 
             result = node_pool_crud.all(**all_kwargs)

--- a/modules/python/crud/main.py
+++ b/modules/python/crud/main.py
@@ -132,6 +132,7 @@ def handle_node_pool_operation(node_pool_crud, args):
                 "gpu_node_pool": args.gpu_node_pool,
                 "enable_managed_gpu": args.enable_managed_gpu,
                 "gpu_instance_profile": args.gpu_instance_profile,
+                "gpu_mig_strategy": args.gpu_mig_strategy,
             }
 
             result = node_pool_crud.scale_node_pool(**scale_kwargs)
@@ -151,6 +152,8 @@ def handle_node_pool_operation(node_pool_crud, args):
                 "gpu_node_pool": args.gpu_node_pool,
                 "enable_managed_gpu": args.enable_managed_gpu,
                 "step_wait_time": args.step_wait_time,
+                "gpu_instance_profile": args.gpu_instance_profile,
+                "gpu_mig_strategy": args.gpu_mig_strategy,
             }
 
             result = node_pool_crud.all(**all_kwargs)

--- a/modules/python/tests/clients/test_aks_client.py
+++ b/modules/python/tests/clients/test_aks_client.py
@@ -662,6 +662,19 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         single = gpu_meta(True, True, "MIG1g", "single")
         self.assertEqual(single["gpu_mig_strategy"], "single")
         self.assertTrue(single["mig_enabled"])
+        # Normalization: MIG inputs are dropped for non-fully-managed pools
+        managed_with_mig = gpu_meta(True, False, "MIG1g", "single")
+        self.assertEqual(managed_with_mig["gpu_mode"], "managed")
+        self.assertFalse(managed_with_mig["mig_enabled"])
+        self.assertIsNone(managed_with_mig["gpu_instance_profile"])
+        self.assertIsNone(managed_with_mig["gpu_mig_strategy"])
+        # Normalization: managed flag is meaningless without a GPU pool
+        not_gpu = gpu_meta(False, True)
+        self.assertEqual(not_gpu["gpu_mode"], "none")
+        self.assertFalse(not_gpu["enable_managed_gpu"])
+        # Invalid MIG strategy is rejected
+        with self.assertRaises(ValueError):
+            gpu_meta(True, True, "MIG1g", "bogus")
 
     @mock.patch("clients.aks_client.time")
     def test_scale_node_pool_records_gpu_mode_metadata(self, mock_time):

--- a/modules/python/tests/clients/test_aks_client.py
+++ b/modules/python/tests/clients/test_aks_client.py
@@ -629,11 +629,12 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         # Check that NVIDIA verification was NOT performed for scale-down
         self.mock_k8s.verify_nvidia_smi_on_node.assert_not_called()
 
-    def test_gpu_mode_metadata_variants(self):  # pylint: disable=protected-access
+    def test_gpu_mode_metadata_variants(self):
         """_gpu_mode_metadata normalizes managed/fully-managed and MIG single/mixed."""
+        gpu_meta = AKSClient._gpu_mode_metadata  # pylint: disable=protected-access
         # Non-GPU pool
         self.assertEqual(
-            AKSClient._gpu_mode_metadata(False, False),
+            gpu_meta(False, False),
             {
                 "gpu_mode": "none",
                 "enable_managed_gpu": False,
@@ -643,22 +644,22 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
             },
         )
         # Managed (driver bootstrap only)
-        managed = AKSClient._gpu_mode_metadata(True, False)
+        managed = gpu_meta(True, False)
         self.assertEqual(managed["gpu_mode"], "managed")
         self.assertFalse(managed["enable_managed_gpu"])
         self.assertFalse(managed["mig_enabled"])
         # Fully managed
-        fully = AKSClient._gpu_mode_metadata(True, True)
+        fully = gpu_meta(True, True)
         self.assertEqual(fully["gpu_mode"], "fully_managed")
         self.assertTrue(fully["enable_managed_gpu"])
         # Fully managed + MIG mixed
-        mixed = AKSClient._gpu_mode_metadata(True, True, "MIG1g", "mixed")
+        mixed = gpu_meta(True, True, "MIG1g", "mixed")
         self.assertEqual(mixed["gpu_mode"], "fully_managed")
         self.assertTrue(mixed["mig_enabled"])
         self.assertEqual(mixed["gpu_instance_profile"], "MIG1g")
         self.assertEqual(mixed["gpu_mig_strategy"], "mixed")
         # Fully managed + MIG single
-        single = AKSClient._gpu_mode_metadata(True, True, "MIG1g", "single")
+        single = gpu_meta(True, True, "MIG1g", "single")
         self.assertEqual(single["gpu_mig_strategy"], "single")
         self.assertTrue(single["mig_enabled"])
 

--- a/modules/python/tests/clients/test_aks_client.py
+++ b/modules/python/tests/clients/test_aks_client.py
@@ -676,6 +676,25 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         with self.assertRaises(ValueError):
             gpu_meta(True, True, "MIG1g", "bogus")
 
+    def test_log_gpu_mode_console_echo(self):
+        """_log_gpu_mode echoes GPU metadata to the console for GPU pools only."""
+        log_gpu_mode = AKSClient._log_gpu_mode  # pylint: disable=protected-access
+        with self.assertLogs("clients.aks_client", level="INFO") as cm:
+            log_gpu_mode(
+                {
+                    "gpu_mode": "fully_managed",
+                    "enable_managed_gpu": True,
+                    "mig_enabled": True,
+                    "gpu_instance_profile": "MIG1g",
+                    "gpu_mig_strategy": "mixed",
+                }
+            )
+        self.assertTrue(any("gpu_mode=fully_managed" in m for m in cm.output))
+        self.assertTrue(any("gpu_mig_strategy=mixed" in m for m in cm.output))
+        # Non-GPU operations must not emit the GPU metadata line.
+        with self.assertNoLogs("clients.aks_client", level="INFO"):
+            log_gpu_mode({"gpu_mode": "none"})
+
     @mock.patch("clients.aks_client.time")
     def test_scale_node_pool_records_gpu_mode_metadata(self, mock_time):
         """Scale ops persist gpu_mode + MIG fields even though the SDK read-back drops them."""

--- a/modules/python/tests/clients/test_aks_client.py
+++ b/modules/python/tests/clients/test_aks_client.py
@@ -629,6 +629,76 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         # Check that NVIDIA verification was NOT performed for scale-down
         self.mock_k8s.verify_nvidia_smi_on_node.assert_not_called()
 
+    def test_gpu_mode_metadata_variants(self):
+        """_gpu_mode_metadata normalizes managed/fully-managed and MIG single/mixed."""
+        # Non-GPU pool
+        self.assertEqual(
+            AKSClient._gpu_mode_metadata(False, False),
+            {
+                "gpu_mode": "none",
+                "enable_managed_gpu": False,
+                "mig_enabled": False,
+                "gpu_instance_profile": None,
+                "gpu_mig_strategy": None,
+            },
+        )
+        # Managed (driver bootstrap only)
+        managed = AKSClient._gpu_mode_metadata(True, False)
+        self.assertEqual(managed["gpu_mode"], "managed")
+        self.assertFalse(managed["enable_managed_gpu"])
+        self.assertFalse(managed["mig_enabled"])
+        # Fully managed
+        fully = AKSClient._gpu_mode_metadata(True, True)
+        self.assertEqual(fully["gpu_mode"], "fully_managed")
+        self.assertTrue(fully["enable_managed_gpu"])
+        # Fully managed + MIG mixed
+        mixed = AKSClient._gpu_mode_metadata(True, True, "MIG1g", "mixed")
+        self.assertEqual(mixed["gpu_mode"], "fully_managed")
+        self.assertTrue(mixed["mig_enabled"])
+        self.assertEqual(mixed["gpu_instance_profile"], "MIG1g")
+        self.assertEqual(mixed["gpu_mig_strategy"], "mixed")
+        # Fully managed + MIG single
+        single = AKSClient._gpu_mode_metadata(True, True, "MIG1g", "single")
+        self.assertEqual(single["gpu_mig_strategy"], "single")
+        self.assertTrue(single["mig_enabled"])
+
+    @mock.patch("clients.aks_client.time")
+    def test_scale_node_pool_records_gpu_mode_metadata(self, mock_time):
+        """Scale ops persist gpu_mode + MIG fields even though the SDK read-back drops them."""
+        node_pool_name = "h100fullmgd"
+        node_count = 3
+
+        mock_time.time.side_effect = [100, 150]
+
+        mock_node_pool = mock.MagicMock()
+        mock_node_pool.count = 1
+        mock_node_pool.vm_size = "Standard_NC40ads_H100_v5"
+        mock_node_pool.as_dict.return_value = {"count": 1}
+        self.mock_agent_pools.get.return_value = mock_node_pool
+        self.aks_client.get_node_pool = mock.MagicMock(return_value=mock_node_pool)
+        self.mock_k8s.wait_for_nodes_ready.return_value = [mock.MagicMock()] * node_count
+        self.mock_k8s.verify_managed_gpu_systemd_services = mock.MagicMock(return_value={})
+        self.mock_k8s.verify_nvidia_smi_on_node = mock.MagicMock()
+        self.mock_k8s.verify_mig_allocatable = mock.MagicMock(return_value={})
+
+        result = self.aks_client.scale_node_pool(
+            node_pool_name=node_pool_name,
+            node_count=node_count,
+            gpu_node_pool=True,
+            enable_managed_gpu=True,
+            gpu_instance_profile="MIG1g",
+            gpu_mig_strategy="mixed",
+        )
+
+        self.assertTrue(result)
+        # The metadata dict is the 3rd positional arg to OperationContext(...)
+        metadata = self.mock_operation_context.call_args[0][2]
+        self.assertEqual(metadata["gpu_mode"], "fully_managed")
+        self.assertTrue(metadata["enable_managed_gpu"])
+        self.assertTrue(metadata["mig_enabled"])
+        self.assertEqual(metadata["gpu_instance_profile"], "MIG1g")
+        self.assertEqual(metadata["gpu_mig_strategy"], "mixed")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/modules/python/tests/clients/test_aks_client.py
+++ b/modules/python/tests/clients/test_aks_client.py
@@ -629,7 +629,7 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
         # Check that NVIDIA verification was NOT performed for scale-down
         self.mock_k8s.verify_nvidia_smi_on_node.assert_not_called()
 
-    def test_gpu_mode_metadata_variants(self):
+    def test_gpu_mode_metadata_variants(self):  # pylint: disable=protected-access
         """_gpu_mode_metadata normalizes managed/fully-managed and MIG single/mixed."""
         # Non-GPU pool
         self.assertEqual(

--- a/modules/python/tests/clients/test_kubernetes_client.py
+++ b/modules/python/tests/clients/test_kubernetes_client.py
@@ -2,6 +2,7 @@
 """
 Unit tests for KubernetesClient class
 """
+import itertools
 import unittest
 from unittest import mock
 from unittest.mock import patch, mock_open, MagicMock
@@ -2113,18 +2114,63 @@ class TestKubernetesClient(unittest.TestCase):
         result = self.client.verify_nvidia_smi_on_node([node])
         self.assertFalse(result)
 
+    @patch("time.time", side_effect=itertools.count(0, 1000))
+    @patch("time.sleep", return_value=None)
     @patch("clients.kubernetes_client.KubernetesClient.describe_node")
-    def test_verify_nvidia_smi_no_gpu_nodes(self, mock_describe_node):
-        """Test nvidia-smi verification skips nodes with no GPUs."""
+    def test_verify_nvidia_smi_no_gpu_nodes(self, mock_describe_node, _mock_sleep, _mock_time):
+        """Nodes that never advertise a positive GPU/MIG count are skipped (after the wait)."""
         node = MagicMock()
         node.metadata.name = "cpu-only-node"
         node.status.allocatable = {"nvidia.com/gpu": "0"}
 
-        # Mock describe_node to return the node with no GPUs
+        # describe_node keeps reporting 0 GPUs; the wait times out and the node is skipped.
         mock_describe_node.return_value = node
 
         result = self.client.verify_nvidia_smi_on_node([node])
         self.assertEqual(result, {})  # Should return empty dict as no nodes processed
+
+    @patch("time.time", side_effect=itertools.count(0, 1))
+    @patch("time.sleep", return_value=None)
+    @patch("clients.kubernetes_client.KubernetesClient.get_pod_logs")
+    @patch("kubernetes.client.CoreV1Api.delete_namespaced_pod")
+    @patch("kubernetes.client.CoreV1Api.read_namespaced_pod")
+    @patch("kubernetes.client.CoreV1Api.create_namespaced_pod")
+    @patch("clients.kubernetes_client.KubernetesClient.describe_node")
+    def test_verify_nvidia_smi_waits_for_mig_registration(
+        self,
+        mock_describe_node,
+        mock_create_pod,
+        mock_read_pod,
+        _mock_delete_pod,
+        mock_get_logs,
+        _mock_sleep,
+        _mock_time,
+    ):
+        """A node reporting 0 GPUs mid-registration is NOT skipped — wait for a positive count."""
+        node_name = "mig-single-node"
+        zero_node = MagicMock()
+        zero_node.metadata.name = node_name
+        zero_node.status.allocatable = {"nvidia.com/gpu": "0"}  # device plugin registered, not yet populated
+        ready_node = MagicMock()
+        ready_node.metadata.name = node_name
+        ready_node.status.allocatable = {"nvidia.com/gpu": "56"}  # MIG-single instances published
+
+        # First describe (pre-loop) sees 0; after one wait iteration it sees 56.
+        mock_describe_node.side_effect = [zero_node, ready_node]
+        mock_read_pod.side_effect = [
+            MagicMock(status=MagicMock(phase="Pending")),
+            MagicMock(status=MagicMock(phase="Succeeded")),
+        ]
+        mock_get_logs.return_value = "NVIDIA-SMI GPU driver info"
+
+        result = self.client.verify_nvidia_smi_on_node([zero_node])
+
+        # The node was verified, not skipped, and a whole GPU (MIG-single) was requested.
+        self.assertIn(node_name, result)
+        self.assertTrue(result[node_name]["device_status"])
+        self.assertGreaterEqual(mock_describe_node.call_count, 2)
+        pod_spec = mock_create_pod.call_args[1]["body"]
+        self.assertEqual(pod_spec.spec.containers[0].resources.limits["nvidia.com/gpu"], "1")
 
     @patch("kubernetes.client.AppsV1Api.create_namespaced_daemon_set")
     @patch("requests.get")

--- a/modules/python/tests/crud/test_azure_node_pool_crud.py
+++ b/modules/python/tests/crud/test_azure_node_pool_crud.py
@@ -114,6 +114,7 @@ class TestAzureNodePoolCRUD(unittest.TestCase):
             progressive=False,
             scale_step_size=1,
             gpu_instance_profile=None,
+            gpu_mig_strategy=None,
         )
 
     def test_scale_node_pool_down(self):
@@ -143,6 +144,7 @@ class TestAzureNodePoolCRUD(unittest.TestCase):
             progressive=False,
             scale_step_size=1,
             gpu_instance_profile=None,
+            gpu_mig_strategy=None,
         )
 
     def test_delete_node_pool(self):

--- a/modules/python/tests/crud/test_main.py
+++ b/modules/python/tests/crud/test_main.py
@@ -68,6 +68,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
         # Setup
         mock_args = mock.MagicMock()
         mock_args.command = "create"
+        mock_args.cloud = "azure"
         mock_args.node_pool_name = "test-np"
         mock_args.vm_size = "Standard_D2s_v3"
         mock_args.node_count = 3
@@ -98,6 +99,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
         # Setup
         mock_args = mock.MagicMock()
         mock_args.command = "scale"
+        mock_args.cloud = "azure"
         mock_args.node_pool_name = "test-np"
         mock_args.target_count = 5
         mock_args.scale_step_size = (
@@ -131,6 +133,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
         # Setup - when scale_step_size equals target_count, progressive should be False
         mock_args = mock.MagicMock()
         mock_args.command = "scale"
+        mock_args.cloud = "azure"
         mock_args.node_pool_name = "test-np"
         mock_args.target_count = 3
         mock_args.scale_step_size = (
@@ -172,6 +175,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
         # Setup - progressive scaling where operation fails
         mock_args = mock.MagicMock()
         mock_args.command = "scale"
+        mock_args.cloud = "azure"
         mock_args.node_pool_name = "test-np"
         mock_args.target_count = 10
         mock_args.scale_step_size = 2  # Progressive scaling
@@ -260,6 +264,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
         # Setup
         mock_args = mock.MagicMock()
         mock_args.command = "all"
+        mock_args.cloud = "azure"
         mock_args.node_pool_name = "test-np"
         mock_args.vm_size = "Standard_D2s_v3"
         mock_args.node_count = 1
@@ -291,12 +296,34 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
             gpu_mig_strategy=mock_args.gpu_mig_strategy,
         )
 
+    def test_handle_node_pool_operation_scale_aws_omits_mig_kwargs(self):
+        """AWS scale must not receive Azure-only MIG kwargs (the AWS CRUD rejects them)."""
+        mock_args = mock.MagicMock()
+        mock_args.command = "scale"
+        mock_args.cloud = "aws"
+        mock_args.node_pool_name = "test-np"
+        mock_args.target_count = 5
+        mock_args.scale_step_size = 1
+        mock_args.gpu_node_pool = False
+        mock_args.enable_managed_gpu = False
+
+        mock_crud = mock.MagicMock()
+        mock_crud.scale_node_pool.return_value = True
+
+        result = handle_node_pool_operation(mock_crud, mock_args)
+
+        self.assertEqual(result, 0)
+        call_kwargs = mock_crud.scale_node_pool.call_args.kwargs
+        self.assertNotIn("gpu_instance_profile", call_kwargs)
+        self.assertNotIn("gpu_mig_strategy", call_kwargs)
+
     @mock.patch("crud.main.AzureNodePoolCRUD")
     def test_handle_node_pool_operation_failure(self, mock_azure_crud):
         """Test handle_node_pool_operation when operation fails"""
         # Setup
         mock_args = mock.MagicMock()
         mock_args.command = "create"
+        mock_args.cloud = "azure"
         mock_args.node_pool_name = "test-np"
         mock_args.vm_size = "Standard_D2s_v3"
         mock_args.node_count = 1
@@ -358,6 +385,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
         # Setup
         mock_args = mock.MagicMock()
         mock_args.command = "create"
+        mock_args.cloud = "azure"
         mock_args.node_pool_name = "test-np"
         mock_args.vm_size = "Standard_D2s_v3"
         mock_args.node_count = 1

--- a/modules/python/tests/crud/test_main.py
+++ b/modules/python/tests/crud/test_main.py
@@ -122,6 +122,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
             gpu_node_pool=False,
             enable_managed_gpu=False,
             gpu_instance_profile=mock_args.gpu_instance_profile,
+            gpu_mig_strategy=mock_args.gpu_mig_strategy,
         )
 
     @mock.patch("crud.main.AzureNodePoolCRUD")
@@ -154,6 +155,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
             gpu_node_pool=False,
             enable_managed_gpu=False,
             gpu_instance_profile=mock_args.gpu_instance_profile,
+            gpu_mig_strategy=mock_args.gpu_mig_strategy,
         )
 
     @mock.patch("crud.main.logger")
@@ -192,6 +194,7 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
             gpu_node_pool=False,
             enable_managed_gpu=False,
             gpu_instance_profile=mock_args.gpu_instance_profile,
+            gpu_mig_strategy=mock_args.gpu_mig_strategy,
         )
         mock_logger.error.assert_called_with("Operation 'scale' failed")
 
@@ -284,6 +287,8 @@ class TestNodePoolCRUDFunctions(unittest.TestCase):
             gpu_node_pool=True,
             enable_managed_gpu=False,
             step_wait_time=30,
+            gpu_instance_profile=mock_args.gpu_instance_profile,
+            gpu_mig_strategy=mock_args.gpu_mig_strategy,
         )
 
     @mock.patch("crud.main.AzureNodePoolCRUD")

--- a/steps/engine/crud/k8s/execute.yml
+++ b/steps/engine/crud/k8s/execute.yml
@@ -16,8 +16,8 @@ steps:
       --step-timeout "$STEP_TIME_OUT" \
       ${GPU_NODE_POOL:+--gpu-node-pool} \
       $([[ "${ENABLE_MANAGED_GPU,,}" == "true" ]] && echo "--enable-managed-gpu" || true) \
-      $([[ "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true) \
-      $([[ "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true) \
+      $([[ "${ENABLE_MANAGED_GPU,,}" == "true" && "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true) \
+      $([[ "${ENABLE_MANAGED_GPU,,}" == "true" && "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true) \
       --capacity-type "${CAPACITY_TYPE:-ON_DEMAND}"
 
     # Scale Up Node Pool
@@ -32,8 +32,8 @@ steps:
       --step-timeout "$STEP_TIME_OUT" \
       ${GPU_NODE_POOL:+--gpu-node-pool} \
       $([[ "${ENABLE_MANAGED_GPU,,}" == "true" ]] && echo "--enable-managed-gpu" || true) \
-      $([[ "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true) \
-      $([[ "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true)
+      $([[ "${ENABLE_MANAGED_GPU,,}" == "true" && "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true) \
+      $([[ "${ENABLE_MANAGED_GPU,,}" == "true" && "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true)
 
   displayName: 'Execute K8s Create & Scale Up Operations for ${{ parameters.cloud }}'
   workingDirectory: modules/python
@@ -158,8 +158,8 @@ steps:
       --step-timeout "$STEP_TIME_OUT" \
       ${GPU_NODE_POOL:+--gpu-node-pool} \
       $([[ "${ENABLE_MANAGED_GPU,,}" == "true" ]] && echo "--enable-managed-gpu" || true) \
-      $([[ "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true) \
-      $([[ "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true)
+      $([[ "${ENABLE_MANAGED_GPU,,}" == "true" && "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true) \
+      $([[ "${ENABLE_MANAGED_GPU,,}" == "true" && "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true)
 
     # Delete Node Pool
     PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" delete \

--- a/steps/engine/crud/k8s/execute.yml
+++ b/steps/engine/crud/k8s/execute.yml
@@ -32,7 +32,8 @@ steps:
       --step-timeout "$STEP_TIME_OUT" \
       ${GPU_NODE_POOL:+--gpu-node-pool} \
       $([[ "${ENABLE_MANAGED_GPU,,}" == "true" ]] && echo "--enable-managed-gpu" || true) \
-      $([[ "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true)
+      $([[ "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true) \
+      $([[ "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true)
 
   displayName: 'Execute K8s Create & Scale Up Operations for ${{ parameters.cloud }}'
   workingDirectory: modules/python
@@ -155,7 +156,10 @@ steps:
       --scale-step-size "$SCALE_STEP_SIZE" \
       --step-wait-time "$STEP_WAIT_TIME" \
       --step-timeout "$STEP_TIME_OUT" \
-      ${GPU_NODE_POOL:+--gpu-node-pool}
+      ${GPU_NODE_POOL:+--gpu-node-pool} \
+      $([[ "${ENABLE_MANAGED_GPU,,}" == "true" ]] && echo "--enable-managed-gpu" || true) \
+      $([[ "${GPU_INSTANCE_PROFILE}" =~ ^MIG ]] && echo "--gpu-instance-profile ${GPU_INSTANCE_PROFILE}" || true) \
+      $([[ "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true)
 
     # Delete Node Pool
     PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" delete \
@@ -178,6 +182,9 @@ steps:
     STEP_TIME_OUT: $(STEP_TIME_OUT)
     RESULT_DIR: $(System.DefaultWorkingDirectory)/$(RUN_ID)
     GPU_NODE_POOL: $(GPU_NODE_POOL)
+    ENABLE_MANAGED_GPU: $(ENABLE_MANAGED_GPU)
+    GPU_INSTANCE_PROFILE: $(GPU_INSTANCE_PROFILE)
+    GPU_MIG_STRATEGY: $(GPU_MIG_STRATEGY)
     STEP_WAIT_TIME: $(STEP_WAIT_TIME)
     ${{ if eq(parameters.cloud, 'aws') }}:
       CAPACITY_TYPE: $(CAPACITY_TYPE)


### PR DESCRIPTION
## Problem

GPU CRUD benchmark records could not reliably distinguish **managed** vs **fully-managed** GPU pools. The stable `azure-mgmt-containerservice` SDK does not model `gpuProfile.nvidia.managementMode`, so a fully-managed pool's mode is silently dropped from the `nodepool_info` read-back — leaving only the pool name (a brittle string) to tell them apart. On top of that:

- **MIG `single` vs `mixed`** was dropped on scale operations.
- `scale_node_pool` never recorded the managed flag at all.

## What this does

Derive a normalized set of GPU metadata from the operation **input flags** (not the lossy AKS read-back) and attach it to **create, scale, and progressive-scale** operations:

| field | values |
|---|---|
| `gpu_mode` | `none` \| `managed` \| `fully_managed` |
| `enable_managed_gpu` | normalized fully-managed flag |
| `mig_enabled` | bool |
| `gpu_instance_profile` | e.g. `MIG1g` \| `null` |
| `gpu_mig_strategy` | `single` \| `mixed` \| `null` |

- Thread `gpu_mig_strategy` through the scale path (`main.py` → `NodePoolCRUD` → `AKSClient` → `_progressive_scale`) and through `execute.yml` so scale-up/scale-down records are accurate.
- Echo the metadata to the console on each op (`GPU pool metadata: gpu_mode=… mig_enabled=… …`) so it is visible in pipeline logs, not only in the uploaded `results.json`.

## Robustness / review hardening

- `gpu_instance_profile` / `gpu_mig_strategy` are **Azure-only** MIG inputs; the AWS CRUD does not accept them (no `**kwargs`). They are now only forwarded when `--cloud azure`, avoiding a `TypeError` on AWS runs.
- `_gpu_mode_metadata` normalizes flag combinations so records are always internally consistent: managed/MIG only apply to a GPU pool; MIG only applies to fully-managed pools (dropped otherwise); invalid `gpu_mig_strategy` is rejected.
- `execute.yml` gates `--gpu-instance-profile` / `--gpu-mig-strategy` on `ENABLE_MANAGED_GPU==true` (create, scale-up, scale-down) so MIG flags are only emitted for fully-managed pools.

## Incidental fixes (folded in)

- **Scale poller timeout 20m → 30m** (`_begin_update_with_retry`): A100 MIG node provisioning could exceed the old 1200s timeout, causing spurious scale failures.
- **`verify_nvidia_smi_on_node` MIG-single race**: the readiness wait broke as soon as the `nvidia.com/gpu` key appeared, even with value `0`. A freshly-scaled MIG-single node registers `nvidia.com/gpu=0` before publishing its MIG instances, so the check raced in, read `0`, and skipped the node with a misleading "has no GPUs" warning. Now waits for a **positive** GPU/MIG count.

## Verification

Validated end-to-end on the GPU Cluster CRUD pipeline — latest run **build 71637** (commit `e07404fa`, **succeeded**), A100 chain `managed → fully_managed → MIG-mixed → MIG-single`.

Recorded `metadata` in the published `results.json` is correct on **every** create/scale_up/scale_down op (confirmed across builds 71550/71623/71637):

| stage | gpu_mode | enable_managed_gpu | mig_enabled | gpu_instance_profile | gpu_mig_strategy |
|---|---|---|---|---|---|
| managed | `managed` | `False` | `False` | `None` | `None` |
| fully_managed | `fully_managed` | `True` | `False` | `None` | `None` |
| MIG mixed | `fully_managed` | `True` | `True` | `MIG1g` | `mixed` |
| MIG single | `fully_managed` | `True` | `True` | `MIG1g` | `single` |

Also confirmed in build 71637 logs:
- Console echo prints per op, e.g. `GPU pool metadata: gpu_mode=managed enable_managed_gpu=False mig_enabled=False gpu_instance_profile=None gpu_mig_strategy=None`.
- The MIG-single `nvidia.com/gpu=0` race is fixed — `a100migsin` is no longer skipped.
- No scale-poller timeout (30-min bump applied).

`managed` vs `fully_managed` are now distinguishable, and MIG `mixed` vs `single` is recorded on scale ops as well as create.

## Known / out-of-scope (not introduced by this PR)

Observed in build 71637 but unrelated to these changes:
- **A100 vCPU quota exhaustion** in `southcentralus` (`ErrCode_InsufficientVCPUQuota`, requested 192 / remaining 0) during an `a100migmixed` scale-up — environmental capacity, not a code issue.
- **Managed-pool GPU advertisement**: `a100managed` (driver-install) nodes did not advertise `nvidia.com/gpu` within the wait window, so nvidia-smi verification skipped them. This is pre-existing behavior (the prior code also waited and skipped, since the key never appears) — a device-plugin scheduling/timing issue on the managed A100 path, worth a separate follow-up.

## Testing

- Unit tests for the metadata helper variants, normalization (MIG dropped for non-fully-managed, managed flag normalized without a GPU pool, invalid strategy rejected), scale-op metadata persistence, console echo, an AWS regression test asserting MIG kwargs are omitted for `--cloud aws`, and a `verify_nvidia_smi_on_node` regression test (node reports `0` then a positive count → verified, not skipped).
- End-to-end validated via build 71637 (tables above).