### PR TITLE
Add InstallPrometheus and InstallHelm lib steps

### DIFF
--- a/kcl/lib/steps/k8s/install_helm.k
+++ b/kcl/lib/steps/k8s/install_helm.k
@@ -1,0 +1,14 @@
+import azure_pipelines.ap.steps
+
+# Install Helm v3 on the pipeline agent.
+InstallHelm = lambda -> steps.Step {
+    steps.Bash {
+        bash = """\
+set -euo pipefail
+if ! command -v helm >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+fi
+helm version --short"""
+        displayName = "Install Helm"
+    }
+}

--- a/kcl/lib/steps/k8s/install_prometheus.k
+++ b/kcl/lib/steps/k8s/install_prometheus.k
@@ -1,19 +1,11 @@
 import azure_pipelines.ap.steps
 import lib.steps.azure
 
-# Install kube-prometheus-stack via Helm. Caller must run azure.GetCredentials first and check in a values.yaml.
-InstallKubePrometheusStack = lambda serviceConnection: str, valuesFile: str, namespace: str = "monitoring", releaseName: str = "prometheus", chartVersion: str = "", waitTimeout: str = "10m" -> steps.Step {
+# Install kube-prometheus-stack via Helm. Caller must run InstallHelm and azure.GetCredentials first, and check in a values.yaml.
+InstallPrometheus = lambda serviceConnection: str, valuesFile: str, namespace: str = "monitoring", releaseName: str = "prometheus", chartVersion: str = "", waitTimeout: str = "10m" -> steps.Step {
     script = """
 set -euo pipefail
 
-# Install Helm v3 if missing
-if ! command -v helm >/dev/null 2>&1; then
-  echo "==> helm not found; installing"
-  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-fi
-helm version --short
-
-# Add / refresh prometheus-community repo (idempotent)
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
 helm repo update prometheus-community
 
@@ -28,9 +20,7 @@ helm upgrade --install "${releaseName}" prometheus-community/kube-prometheus-sta
   --wait --atomic --timeout "${waitTimeout}" \\
   \${VERSION_FLAG}
 
-echo "==> kube-prometheus-stack release '${releaseName}' is ready in namespace '${namespace}'"
-# Prometheus web service is svc/<releaseName>-kube-prometheus-prometheus on port 9090.
-echo "==> Prometheus web service: svc/${releaseName}-kube-prometheus-prometheus in ${namespace} (port 9090)"
+echo "==> Prometheus release '${releaseName}' is ready in namespace '${namespace}'"
 """
-    azure.AzCli(serviceConnection, "Install kube-prometheus-stack", script)
+    azure.AzCli(serviceConnection, "Install Prometheus", script)
 }

--- a/kcl/lib/steps/k8s/install_prometheus.k
+++ b/kcl/lib/steps/k8s/install_prometheus.k
@@ -1,0 +1,36 @@
+import azure_pipelines.ap.steps
+import lib.steps.azure
+
+# Install kube-prometheus-stack via Helm. Caller must run azure.GetCredentials first and check in a values.yaml.
+InstallKubePrometheusStack = lambda serviceConnection: str, valuesFile: str, namespace: str = "monitoring", releaseName: str = "prometheus", chartVersion: str = "", waitTimeout: str = "10m" -> steps.Step {
+    script = """
+set -euo pipefail
+
+# Install Helm v3 if missing
+if ! command -v helm >/dev/null 2>&1; then
+  echo "==> helm not found; installing"
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+fi
+helm version --short
+
+# Add / refresh prometheus-community repo (idempotent)
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
+helm repo update prometheus-community
+
+VERSION_FLAG=""
+if [ -n "${chartVersion}" ]; then
+  VERSION_FLAG="--version ${chartVersion}"
+fi
+
+helm upgrade --install "${releaseName}" prometheus-community/kube-prometheus-stack \\
+  --namespace "${namespace}" --create-namespace \\
+  --values "$(Pipeline.Workspace)/s/${valuesFile}" \\
+  --wait --atomic --timeout "${waitTimeout}" \\
+  \${VERSION_FLAG}
+
+echo "==> kube-prometheus-stack release '${releaseName}' is ready in namespace '${namespace}'"
+# Prometheus web service is svc/<releaseName>-kube-prometheus-prometheus on port 9090.
+echo "==> Prometheus web service: svc/${releaseName}-kube-prometheus-prometheus in ${namespace} (port 9090)"
+"""
+    azure.AzCli(serviceConnection, "Install kube-prometheus-stack", script)
+}


### PR DESCRIPTION
## Summary

Adds two new lib steps under `kcl/lib/steps/k8s/`:

- `install_helm.k` — `InstallHelm`: installs Helm v3 on the pipeline agent.
- `install_prometheus.k` — `InstallPrometheus`: installs the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm chart (Operator + Prometheus + kube-state-metrics + Grafana + Alertmanager) into the current kubectl context.

```kcl
import lib.steps.k8s.install_helm as helm
import lib.steps.k8s.install_prometheus as prom

helm.InstallHelm()
prom.InstallPrometheus(
    serviceConnection = SERVICE_CONNECTION,
    valuesFile        = "kcl/<scenario>/prometheus-values.yaml",
)
```

`InstallHelm` is its own step so other helm-based steps can reuse it.

## Why

Multiple benchmark scenarios need to provision an in-cluster Prometheus on a freshly created AKS cluster — currently each scenario hand-rolls its own helm/kubectl-apply step. This step covers both cases discussed so far:

- **Xinwei**'s 15K-node bench (kube-prometheus-stack with cilium PodMonitor / PrometheusRule and KSM)
- **Leonard**'s S5 lease bench (lightweight: Operator + Prometheus only, all other components disabled in values.yaml)

## What the caller must prepare

1. **Helm on PATH** — call `InstallHelm()` in a prior step.
2. **Working kubeconfig** — call `azure.GetCredentials(...)` in a prior step so kubectl works against the target cluster.
3. **`values.yaml`** checked in to the caller's pipeline repo, e.g. `kcl/<scenario>/prometheus-values.yaml`. The path passed to `valuesFile` is **repo-relative under `$(Pipeline.Workspace)/s/`**. All workload-specific tuning (retention, storage, resource requests, scrape rules, PodMonitor/ServiceMonitor selectors, node selectors, tolerations, enabling/disabling Grafana/Alertmanager/KSM) lives in this file — see the chart's [`values.yaml`](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) for the full surface.
4. **Firewall egress** to the chart registries (`ghcr.io`, `quay.io`, `pkg-containers.githubusercontent.com`, `production.cloudflare.docker.com` and `*.` of each) — caller handles this in their cluster-create step.
5. Any **PodMonitor / ServiceMonitor / PrometheusRule** CRs the workload needs — caller `kubectl apply -f ...` after this step. Not lib's concern.

## What InstallPrometheus does

1. Adds / refreshes the `prometheus-community` helm repo.
2. `helm upgrade --install <releaseName> prometheus-community/kube-prometheus-stack` with the caller's values file, `--create-namespace`, `--wait`, `--atomic` (rolls back cleanly on failure), and configurable timeout.

## Parameters

| Parameter | Default | Required |
|---|---|---|
| `serviceConnection` | — | yes |
| `valuesFile` | — | yes |
| `namespace` | `"monitoring"` | no |
| `releaseName` | `"prometheus"` | no |
| `chartVersion` | `""` (latest) | no |
| `waitTimeout` | `"10m"` | no |

## Validation

End-to-end-tested in the Telescope S5 lease benchmark pipeline (internal repo) against an AKS H8 hyperscale cluster in southeastasia:
- helm install completes in ~2.5 min
- the installed `svc/prometheus-kube-prometheus-prometheus` is port-forwardable and serves `/-/ready`, `/api/v1/query`, `/api/v1/query_range`
- caller's `additionalScrapeConfigs` scrape config picks up the workload pods correctly
