### PR TITLE
fix(kperf): support both runkperf and kperf rg run result formats

### DIFF
--- a/kcl/apiserver_benchmark/configmaps100/pipeline.yaml
+++ b/kcl/apiserver_benchmark/configmaps100/pipeline.yaml
@@ -183,18 +183,36 @@ stages:
               cluster_id: $cluster_id
             }')
 
+          # runkperf bench output: { description, loadSpec, result: {...}, info }  → extract .result
+          # kperf rg run  output: { total, duration, errors, ... }                 → pass-through
+          jq 'if has("result") then .result else . end' "$(Pipeline.Workspace)/tmp_results.json" > "$(Pipeline.Workspace)/tmp_results.json.norm"
+          mv "$(Pipeline.Workspace)/tmp_results.json.norm" "$(Pipeline.Workspace)/tmp_results.json"
+
           # Check for errors and print error details if error rate exceeds threshold
-          errors_number=$(jq -r '.result.errors | length' $(Pipeline.Workspace)/tmp_results.json)
-          error_rate_too_high=$(jq -r '(1 - .result.total / (.loadSpec.count * .loadSpec.loadProfile.spec.total)) > 0.1' $(Pipeline.Workspace)/tmp_results.json)
-          if [[ "$errors_number" != "0" && "$error_rate_too_high" == "true" ]]; then
-            echo "Error rate exceeds 0.1, printing error details:"
-            jq -r ".result.errors | map(. + {run_id: \"$(RUN_ID)\", cloud: \"azure\"}) | .[]" $(Pipeline.Workspace)/tmp_results.json
+          # Error rate = failures / (successes + failures)
+          #   .total       = successful requests (does NOT include errors)
+          #   .errorStats  = per-type failure counts (omitempty; // {} fallback when absent)
+          error_rate_too_high=$(jq -r --argjson t "0.1" '
+            ([.errorStats // {} | .[]] | add // 0) as $errs
+            | (.total // 0) as $ok
+            | ($ok + $errs) as $done
+            | if $done > 0 then ($errs / $done) > $t else false end
+          ' "$(Pipeline.Workspace)/tmp_results.json")
+
+          if [[ "$error_rate_too_high" == "true" ]]; then
+            echo "Error rate exceeds 0.1, errorStats summary:"
+            jq -c '.errorStats // {}' "$(Pipeline.Workspace)/tmp_results.json"
+            echo "Error details (first 100):"
+            # errorStats only has counts; pull actual URL/message from .errors
+            jq -r --arg rid "$(RUN_ID)" \
+              '.errors // [] | .[0:100] | map(. + {run_id: $rid, cloud: "azure"}) | .[]' \
+              "$(Pipeline.Workspace)/tmp_results.json"
           fi
 
           # Collect final result
           cat $(Pipeline.Workspace)/tmp_results.json \
-            | jq 'del(.result.errors)' \
-            | jq -c --argjson ci "$cloud_info" '{ cloud: $ci.cloud, region: $ci.region, fqdn: $ci.fqdn, k8s_version: $ci.k8s_version, sku_tier: $ci.sku_tier, subscription: $ci.subscription, cluster_id: $ci.cluster_id, flowcontrol: "workload-low:1000", benchmarkSubcmdArgs: "--total 10000 --size=1024 --group-size=10 --configmap-amount=100" } + .result | { result: . }' \
+            | jq 'del(.errors)' \
+            | jq -c --argjson ci "$cloud_info" '{ cloud: $ci.cloud, region: $ci.region, fqdn: $ci.fqdn, k8s_version: $ci.k8s_version, sku_tier: $ci.sku_tier, subscription: $ci.subscription, cluster_id: $ci.cluster_id, flowcontrol: "workload-low:1000", benchmarkSubcmdArgs: "--total 10000 --size=1024 --group-size=10 --configmap-amount=100" } + . | { result: . }' \
             | jq -c '. + { timestamp: "'"$TIMESTAMP"'", run_id: "$(RUN_ID)", run_url: "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)", pipeline: "$(Build.DefinitionName)" }' \
             > /tmp/run-result.json
 
@@ -397,18 +415,36 @@ stages:
               cluster_id: $cluster_id
             }')
 
+          # runkperf bench output: { description, loadSpec, result: {...}, info }  → extract .result
+          # kperf rg run  output: { total, duration, errors, ... }                 → pass-through
+          jq 'if has("result") then .result else . end' "$(Pipeline.Workspace)/tmp_results.json" > "$(Pipeline.Workspace)/tmp_results.json.norm"
+          mv "$(Pipeline.Workspace)/tmp_results.json.norm" "$(Pipeline.Workspace)/tmp_results.json"
+
           # Check for errors and print error details if error rate exceeds threshold
-          errors_number=$(jq -r '.result.errors | length' $(Pipeline.Workspace)/tmp_results.json)
-          error_rate_too_high=$(jq -r '(1 - .result.total / (.loadSpec.count * .loadSpec.loadProfile.spec.total)) > 0.1' $(Pipeline.Workspace)/tmp_results.json)
-          if [[ "$errors_number" != "0" && "$error_rate_too_high" == "true" ]]; then
-            echo "Error rate exceeds 0.1, printing error details:"
-            jq -r ".result.errors | map(. + {run_id: \"$(RUN_ID)\", cloud: \"azure\"}) | .[]" $(Pipeline.Workspace)/tmp_results.json
+          # Error rate = failures / (successes + failures)
+          #   .total       = successful requests (does NOT include errors)
+          #   .errorStats  = per-type failure counts (omitempty; // {} fallback when absent)
+          error_rate_too_high=$(jq -r --argjson t "0.1" '
+            ([.errorStats // {} | .[]] | add // 0) as $errs
+            | (.total // 0) as $ok
+            | ($ok + $errs) as $done
+            | if $done > 0 then ($errs / $done) > $t else false end
+          ' "$(Pipeline.Workspace)/tmp_results.json")
+
+          if [[ "$error_rate_too_high" == "true" ]]; then
+            echo "Error rate exceeds 0.1, errorStats summary:"
+            jq -c '.errorStats // {}' "$(Pipeline.Workspace)/tmp_results.json"
+            echo "Error details (first 100):"
+            # errorStats only has counts; pull actual URL/message from .errors
+            jq -r --arg rid "$(RUN_ID)" \
+              '.errors // [] | .[0:100] | map(. + {run_id: $rid, cloud: "azure"}) | .[]' \
+              "$(Pipeline.Workspace)/tmp_results.json"
           fi
 
           # Collect final result
           cat $(Pipeline.Workspace)/tmp_results.json \
-            | jq 'del(.result.errors)' \
-            | jq -c --argjson ci "$cloud_info" '{ cloud: $ci.cloud, region: $ci.region, fqdn: $ci.fqdn, k8s_version: $ci.k8s_version, sku_tier: $ci.sku_tier, subscription: $ci.subscription, cluster_id: $ci.cluster_id, flowcontrol: "exempt:5", benchmarkSubcmdArgs: "--total 10000 --size=1024 --group-size=10 --configmap-amount=100" } + .result | { result: . }' \
+            | jq 'del(.errors)' \
+            | jq -c --argjson ci "$cloud_info" '{ cloud: $ci.cloud, region: $ci.region, fqdn: $ci.fqdn, k8s_version: $ci.k8s_version, sku_tier: $ci.sku_tier, subscription: $ci.subscription, cluster_id: $ci.cluster_id, flowcontrol: "exempt:5", benchmarkSubcmdArgs: "--total 10000 --size=1024 --group-size=10 --configmap-amount=100" } + . | { result: . }' \
             | jq -c '. + { timestamp: "'"$TIMESTAMP"'", run_id: "$(RUN_ID)", run_url: "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)", pipeline: "$(Build.DefinitionName)" }' \
             > /tmp/run-result.json
 

--- a/kcl/lib/steps/kperf/collect_result.k
+++ b/kcl/lib/steps/kperf/collect_result.k
@@ -27,18 +27,36 @@ cloud_info=$(jq -n \\
     cluster_id: $cluster_id
   }')
 
+# runkperf bench output: { description, loadSpec, result: {...}, info }  → extract .result
+# kperf rg run  output: { total, duration, errors, ... }                 → pass-through
+jq 'if has("result") then .result else . end' "${inputPath}" > "${inputPath}.norm"
+mv "${inputPath}.norm" "${inputPath}"
+
 # Check for errors and print error details if error rate exceeds threshold
-errors_number=$(jq -r '.result.errors | length' ${inputPath})
-error_rate_too_high=$(jq -r '(1 - .result.total / (.loadSpec.count * .loadSpec.loadProfile.spec.total)) > ${errorRateThreshold}' ${inputPath})
-if [[ "$errors_number" != "0" && "$error_rate_too_high" == "true" ]]; then
-  echo "Error rate exceeds ${errorRateThreshold}, printing error details:"
-  jq -r ".result.errors | map(. + {run_id: \\"$(RUN_ID)\\", cloud: \\"azure\\"}) | .[]" ${inputPath}
+# Error rate = failures / (successes + failures)
+#   .total       = successful requests (does NOT include errors)
+#   .errorStats  = per-type failure counts (omitempty; // {} fallback when absent)
+error_rate_too_high=$(jq -r --argjson t "${errorRateThreshold}" '
+  ([.errorStats // {} | .[]] | add // 0) as $errs
+  | (.total // 0) as $ok
+  | ($ok + $errs) as $done
+  | if $done > 0 then ($errs / $done) > $t else false end
+' "${inputPath}")
+
+if [[ "$error_rate_too_high" == "true" ]]; then
+  echo "Error rate exceeds ${errorRateThreshold}, errorStats summary:"
+  jq -c '.errorStats // {}' "${inputPath}"
+  echo "Error details (first 100):"
+  # errorStats only has counts; pull actual URL/message from .errors
+  jq -r --arg rid "$(RUN_ID)" \\
+    '.errors // [] | .[0:100] | map(. + {run_id: $rid, cloud: "azure"}) | .[]' \\
+    "${inputPath}"
 fi
 
 # Collect final result
 cat ${inputPath} \\
-  | jq 'del(.result.errors)' \\
-  | jq -c --argjson ci "$cloud_info" '{ cloud: $ci.cloud, region: $ci.region, fqdn: $ci.fqdn, k8s_version: $ci.k8s_version, sku_tier: $ci.sku_tier, subscription: $ci.subscription, cluster_id: $ci.cluster_id, flowcontrol: "${flowcontrol}", benchmarkSubcmdArgs: "${benchmarkSubcmdArgs}" } + .result | { result: . }' \\
+  | jq 'del(.errors)' \\
+  | jq -c --argjson ci "$cloud_info" '{ cloud: $ci.cloud, region: $ci.region, fqdn: $ci.fqdn, k8s_version: $ci.k8s_version, sku_tier: $ci.sku_tier, subscription: $ci.subscription, cluster_id: $ci.cluster_id, flowcontrol: "${flowcontrol}", benchmarkSubcmdArgs: "${benchmarkSubcmdArgs}" } + . | { result: . }' \\
   | jq -c '. + { timestamp: "'"$TIMESTAMP"'", run_id: "$(RUN_ID)", run_url: "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)", pipeline: "$(Build.DefinitionName)" }' \\
   > ${outputPath}
 


### PR DESCRIPTION
- Normalize by unwrapping `.result` when present (runkperf), pass through otherwise (kperf rg run).