### PR TITLE
Replace Dv5 with Dsv6 for cri-resource-consume pipeline

### DIFF
--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure-ubuntu2404.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure-ubuntu2404.tfvars
@@ -12,13 +12,13 @@ aks_cli_config_list = [
     default_node_pool = {
       name       = "default"
       node_count = 3
-      vm_size    = "Standard_D16_v5"
+      vm_size    = "Standard_D16s_v6"
     }
     extra_node_pool = [
       {
         name       = "prompool",
         node_count = 1,
-        vm_size    = "Standard_D16_v5",
+        vm_size    = "Standard_D16s_v6",
         optional_parameters = [
           {
             name  = "labels"

--- a/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars
@@ -38,7 +38,7 @@ aks_config_list = [
     default_node_pool = {
       name                         = "default"
       node_count                   = 3
-      vm_size                      = "Standard_D16_v5"
+      vm_size                      = "Standard_D16s_v6"
       os_disk_type                 = "Managed"
       only_critical_addons_enabled = true
       temporary_name_for_rotation  = "defaulttmp"
@@ -48,7 +48,7 @@ aks_config_list = [
         name                 = "prompool"
         node_count           = 1
         auto_scaling_enabled = false
-        vm_size              = "Standard_D16_v5"
+        vm_size              = "Standard_D16s_v6"
         os_disk_type         = "Managed"
         node_labels          = { "prometheus" = "true" }
       },


### PR DESCRIPTION
## Summary
- Replace `Standard_D16_v5` (Dv5) with `Standard_D16s_v6` (Dsv6) for the `default` and `prompool` node pools in the **cri-resource-consume** scenario.
- Applies to both input files:
  - `scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure.tfvars`
  - `scenarios/perf-eval/cri-resource-consume/terraform-inputs/azure-ubuntu2404.tfvars`
- The `userpool0` pool (`Standard_D16ds_v6`) is unchanged.

## Quota impact (Sweden Central)
This shifts the `default` + `prompool` VMs (4 per job × 16 cores) from the **Dv5** family to the **Dsv6** family. Ensure sufficient **Standard Dsv6 Family vCPU** quota is available in Sweden Central before merge.

## Test plan
- [ ] Pipeline provisions clusters successfully with the new SKU
- [ ] Sweden Central Dsv6 quota confirmed sufficient