### PR TITLE
Update SKU for azurelinux benchmark pipeline

### DIFF
--- a/scenarios/perf-eval/azurelinux-resource-consume/terraform-inputs/azure-osguard.tfvars
+++ b/scenarios/perf-eval/azurelinux-resource-consume/terraform-inputs/azure-osguard.tfvars
@@ -61,13 +61,13 @@ aks_cli_config_list = [
     default_node_pool = {
       name       = "default"
       node_count = 3
-      vm_size    = "Standard_D16_v4"
+      vm_size    = "Standard_D16_v5"
     }
     extra_node_pool = [
       {
         name       = "prompool"
         node_count = 1
-        vm_size    = "Standard_D16_v4"
+        vm_size    = "Standard_D16_v5"
         optional_parameters = [
           {
             name = "labels"

--- a/scenarios/perf-eval/azurelinux-resource-consume/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/azurelinux-resource-consume/terraform-inputs/azure.tfvars
@@ -19,7 +19,7 @@ aks_config_list = [
     default_node_pool = {
       name                         = "default"
       node_count                   = 3
-      vm_size                      = "Standard_D16_v4"
+      vm_size                      = "Standard_D16_v5"
       os_disk_type                 = "Managed"
       os_sku                       = "AzureLinux"
       only_critical_addons_enabled = true
@@ -30,7 +30,7 @@ aks_config_list = [
         name                 = "prompool"
         node_count           = 1
         auto_scaling_enabled = false
-        vm_size              = "Standard_D16_v4"
+        vm_size              = "Standard_D16_v5"
         os_sku               = "AzureLinux"
         node_labels          = { "prometheus" = "true" }
       },


### PR DESCRIPTION
Update SKU from standard Dv4 to standard Dv5 VM generation in both the azure and azure-osguard tfvars.