### PR TITLE
remove unneeded header

### DIFF
--- a/scenarios/perf-eval/nap-complex/terraform-inputs/azure-machineapi.tfvars
+++ b/scenarios/perf-eval/nap-complex/terraform-inputs/azure-machineapi.tfvars
@@ -352,7 +352,7 @@ aks_cli_config_list = [
       },
       {
         name  = "aks-custom-headers"
-        value = "AKSHTTPCustomFeatures=Microsoft.ContainerService/AKSHTTPCustomFeatures,AKSHTTPCustomFeatures=DisableSelfContainedVHD,BootstrappingMethodTestOnly=aksmachineapiheaderbatch"
+        value = "AKSHTTPCustomFeatures=Microsoft.ContainerService/AKSHTTPCustomFeatures,BootstrappingMethodTestOnly=aksmachineapiheaderbatch"
       }
     ]
   }


### PR DESCRIPTION
Removes header that disables scriptless, as this is no longer required.