### PR TITLE
fix(ci): eliminate zero-click fork-PR RCE in terraform workflows

### DIFF
--- a/.github/workflows/terraform-integration.yml
+++ b/.github/workflows/terraform-integration.yml
@@ -1,0 +1,180 @@
+name: Terraform Integration
+
+# Privileged terraform test/plan gated by the `terraform-privileged` environment
+# (required reviewers configured in repo Settings). See MSRC #127928.
+
+on:
+  pull_request_target:
+    paths:
+      - '**.tf'
+      - '**.json'
+      - '**.tfvars'
+      - 'modules/terraform/**'
+
+permissions:
+  contents: read
+
+env:
+  TERRAFORM_AZURE_MODULES_DIR: modules/terraform/azure
+  TERRAFORM_AWS_MODULES_DIR: modules/terraform/aws
+
+jobs:
+  authorize:
+    environment: terraform-privileged
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authorized
+        run: echo "Authorized PR #${{ github.event.pull_request.number }} head=${{ github.event.pull_request.head.sha }}"
+
+  terraform-test:
+    needs: authorize
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          # Only checked out AFTER `authorize` completes.
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.10.0
+
+      - name: Terraform AWS Test
+        working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
+        run: terraform test
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_MI }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Azure Test
+        working-directory: ${{ env.TERRAFORM_AZURE_MODULES_DIR }}
+        run: terraform test
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  setup-matrix:
+    needs: authorize
+    runs-on: ubuntu-latest
+    name: Setup terraform plan matrix for test scenarios
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup test matrix scenarios
+        id: setup-matrix-scenarios
+        run: |
+          set -eux
+          matrix=$(find $GITHUB_WORKSPACE/scenarios/ -name "*.tfvars" | grep 'azure' | awk -F'/' '{split($11, file_name, "."); split(file_name[1], cloud_region, "-");region= (length(cloud_region) > 1) ? substr($11, index($11, "-") + 1) : ""; cloud=cloud_region[1]; gsub(".json", "", region); print "{\"cloud\": \"" cloud "\", \"file_name\": \"" file_name[1] "\", " (region != "" ? "\"region\": \"" region "\", " : "") "\"scenario_type\": \"" $8 "\", \"scenario_name\": \"" $9 "\"},"}' | sort | uniq | sed 's/,$/,/')
+          matrix_array="[${matrix%,}]"
+
+          file_changes=$(git diff --name-only -r origin/main HEAD)
+          echo "PR file changes: $file_changes"
+
+          if [ -z "$file_changes" ]; then
+            matrix_combinations=null
+            echo "matrix_combinations=$matrix_combinations" >> "$GITHUB_OUTPUT"
+          else
+            cloud_changes=$(echo "$file_changes" | grep -E '\.tf$' | awk -F'/' '{print $3}' | uniq)
+            echo "File changes related to cloud: $cloud_changes"
+
+            run_all_tests=false
+            module_matrix='[]'
+            scenario_matrix='[]'
+            if [ $(echo "$cloud_changes" | wc -w) -eq 1 ]; then
+              cloud=$(echo "$cloud_changes" | cut -d' ' -f1)
+              module_matrix=$(echo "$matrix_array" | jq --arg cloud_value "$cloud" '. | map(select(.cloud == $cloud_value))')
+            elif [ $(echo "$cloud_changes" | wc -w) -eq 0 ]; then
+              run_all_tests=false
+            else
+              run_all_tests=true
+              module_matrix=$(echo "$matrix_array")
+            fi
+            echo "module_matrix: $module_matrix"
+            if [ "$run_all_tests" = false ]; then
+              changed_scenario_names=$(echo "$file_changes" | grep -E '^scenarios/' | awk -F'/' '{print $3}' | tr ' ' '\n' | sort -u)
+              echo "Test scenarios changed: $changed_scenario_names"
+              for scenario_name in $changed_scenario_names; do
+                filtered_objects=$(echo "$matrix_array" | jq --arg scenario_value "$scenario_name" '. | map(select(.scenario_name == $scenario_value))')
+                scenario_matrix=$(echo "$scenario_matrix $filtered_objects" | jq -s 'flatten | unique')
+              done
+            fi
+            updated_matrix=$(echo "$module_matrix $scenario_matrix" | jq -s 'flatten | unique')
+            echo "Test scenarios to run: $updated_matrix"
+            updated_matrix="${updated_matrix//$'\n'/''}"
+            matrix_combinations="{\"include\": ${updated_matrix%?}}"
+            echo "matrix_combinations={\"include\": ${updated_matrix} }" >> "$GITHUB_OUTPUT"
+          fi
+          echo "matrix_combinations: $matrix_combinations"
+    outputs:
+      matrix-combinations: ${{ steps.setup-matrix-scenarios.outputs.matrix_combinations }}
+
+  terraform-plan:
+    needs: [authorize, setup-matrix]
+    permissions:
+      id-token: write
+      contents: read
+    if: ${{ needs.setup-matrix.result == 'success' && needs.setup-matrix.outputs.matrix-combinations != '' && needs.setup-matrix.outputs.matrix-combinations != 'null' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix-combinations) }}
+    runs-on: ubuntu-latest
+    name: ${{ matrix.cloud }}-${{ matrix.scenario_type }}-${{ matrix.scenario_name }} ${{ matrix.region }}
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.10.0
+
+      - name: Get job id and set env
+        run: |
+          echo "TERRAFORM_INPUT_FILE=$GITHUB_WORKSPACE/scenarios/${{ matrix.scenario_type }}/${{ matrix.scenario_name }}/terraform-inputs/${{ matrix.file_name }}.tfvars" >> "$GITHUB_ENV"
+          echo "TERRAFORM_TEST_INPUT_FILE=$GITHUB_WORKSPACE/scenarios/${{ matrix.scenario_type }}/${{ matrix.scenario_name }}/terraform-test-inputs/${{ matrix.file_name }}.json" >> "$GITHUB_ENV"
+          echo "TERRAFORM_MODULES_DIR=modules/terraform/${{ matrix.cloud }}" >> "$GITHUB_ENV"
+
+      - name: Create JSON Input
+        run: |
+          INPUT_JSON_OBJECT=$(jq . ${{ env.TERRAFORM_TEST_INPUT_FILE }})
+          INPUT_JSON_STRING=$(echo $INPUT_JSON_OBJECT | jq -c '. + {creation_time: (now |  todateiso8601)}')
+          echo "INPUT_JSON=$INPUT_JSON_STRING" >> "$GITHUB_ENV"
+
+      - name: Azure login
+        if: ${{ matrix.cloud == 'azure' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_MI }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform Init
+        working-directory: ${{ env.TERRAFORM_MODULES_DIR }}
+        run: terraform init
+
+      - name: Terraform Plan
+        working-directory: ${{ env.TERRAFORM_MODULES_DIR }}
+        run: |
+          terraform plan -var-file "$TERRAFORM_INPUT_FILE" -var="json_input=$INPUT_JSON"
+        env:
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          CLOUD: ${{ matrix.cloud }}

--- a/.github/workflows/terraform-integration.yml
+++ b/.github/workflows/terraform-integration.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Only checked out AFTER `authorize` completes.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
@@ -70,6 +71,7 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
@@ -115,8 +117,8 @@ jobs:
             updated_matrix=$(echo "$module_matrix $scenario_matrix" | jq -s 'flatten | unique')
             echo "Test scenarios to run: $updated_matrix"
             updated_matrix="${updated_matrix//$'\n'/''}"
-            matrix_combinations="{\"include\": ${updated_matrix%?}}"
-            echo "matrix_combinations={\"include\": ${updated_matrix} }" >> "$GITHUB_OUTPUT"
+            matrix_combinations="{\"include\": ${updated_matrix}}"
+            echo "matrix_combinations=$matrix_combinations" >> "$GITHUB_OUTPUT"
           fi
           echo "matrix_combinations: $matrix_combinations"
     outputs:
@@ -139,6 +141,7 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
@@ -155,8 +158,7 @@ jobs:
 
       - name: Create JSON Input
         run: |
-          INPUT_JSON_OBJECT=$(jq . ${{ env.TERRAFORM_TEST_INPUT_FILE }})
-          INPUT_JSON_STRING=$(echo $INPUT_JSON_OBJECT | jq -c '. + {creation_time: (now |  todateiso8601)}')
+          INPUT_JSON_STRING=$(jq -c '. + {creation_time: (now | todateiso8601)}' "${{ env.TERRAFORM_TEST_INPUT_FILE }}")
           echo "INPUT_JSON=$INPUT_JSON_STRING" >> "$GITHUB_ENV"
 
       - name: Azure login

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -1,5 +1,8 @@
 name: Terraform Validation
 
+# Static checks only. Privileged steps (terraform test / azure/login) live in
+# terraform-integration.yml. See MSRC #127928 / IcM 31000000665395.
+
 on:
   pull_request:
     paths:
@@ -8,16 +11,16 @@ on:
       - '**.tfvars'
       - 'modules/terraform/**'
 
+permissions:
+  contents: read
+
 env:
   TERRAFORM_AZURE_MODULES_DIR: modules/terraform/azure
   TERRAFORM_AWS_MODULES_DIR: modules/terraform/aws
+
 jobs:
   terraform-validation:
-    permissions:
-      id-token: write
-      contents: read
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -35,17 +38,19 @@ jobs:
             echo "Please run 'terraform fmt -recursive' from root directory to format the code."
             exit 1
           fi
+
       - name: Terraform Azure Validation Check
         if: always()
         working-directory: ${{ env.TERRAFORM_AZURE_MODULES_DIR }}
         run: |
-          terraform init
+          terraform init -backend=false
           terraform validate
+
       - name: Terraform AWS Validation Check
         if: always()
         working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
         run: |
-          terraform init
+          terraform init -backend=false
           terraform validate
 
       - uses: terraform-linters/setup-tflint@v4
@@ -65,129 +70,3 @@ jobs:
       - name: Terraform Lint Check
         if: always()
         run: tflint --recursive --config "$GITHUB_WORKSPACE/.tflint.hcl" --minimum-failure-severity=warning
-
-      - name: Terraform AWS Test
-        working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
-        run: terraform test
-
-      - name: Azure login
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.AZURE_MI }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: Terraform Azure Test
-        working-directory: ${{ env.TERRAFORM_AZURE_MODULES_DIR }}
-        run: terraform test
-        env:
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-  setup-matrix:
-    runs-on: ubuntu-latest
-    name: Setup terraform plan matrix for test scenarios
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup test matrix scenarios
-        id: setup-matrix-scenarios
-        run: |
-          set -eux
-          matrix=$(find $GITHUB_WORKSPACE/scenarios/ -name "*.tfvars" | grep 'azure' | awk -F'/' '{split($11, file_name, "."); split(file_name[1], cloud_region, "-");region= (length(cloud_region) > 1) ? substr($11, index($11, "-") + 1) : ""; cloud=cloud_region[1]; gsub(".json", "", region); print "{\"cloud\": \"" cloud "\", \"file_name\": \"" file_name[1] "\", " (region != "" ? "\"region\": \"" region "\", " : "") "\"scenario_type\": \"" $8 "\", \"scenario_name\": \"" $9 "\"},"}' | sort | uniq | sed 's/,$/,/')
-          matrix_array="[${matrix%,}]"
-
-          file_changes=$(git diff --name-only -r origin/main HEAD)
-          echo "PR file changes: $file_changes"
-
-          if [ -z "$file_changes" ]; then
-            matrix_combinations=null
-            echo "matrix_combinations=$matrix_combinations" >> "$GITHUB_OUTPUT"
-          else
-            cloud_changes=$(echo "$file_changes" | grep -E '\.tf$' | awk -F'/' '{print $3}' | uniq)
-            echo "File changes related to cloud: $cloud_changes"
-
-            run_all_tests=false
-            module_matrix='[]'
-            scenario_matrix='[]'
-            if [ $(echo "$cloud_changes" | wc -w) -eq 1 ]; then
-              cloud=$(echo "$cloud_changes" | cut -d' ' -f1)
-              module_matrix=$(echo "$matrix_array" | jq --arg cloud_value "$cloud" '. | map(select(.cloud == $cloud_value))')
-            elif [ $(echo "$cloud_changes" | wc -w) -eq 0 ]; then
-              run_all_tests=false
-            else
-              run_all_tests=true
-              module_matrix=$(echo "$matrix_array")
-            fi
-            echo "module_matrix: $module_matrix"
-            if [ "$run_all_tests" = false ]; then
-              changed_scenario_names=$(echo "$file_changes" | grep -E '^scenarios/' | awk -F'/' '{print $3}' | tr ' ' '\n' | sort -u)
-              echo "Test scenarios changed: $changed_scenario_names"
-              for scenario_name in $changed_scenario_names; do
-                filtered_objects=$(echo "$matrix_array" | jq --arg scenario_value "$scenario_name" '. | map(select(.scenario_name == $scenario_value))')
-                scenario_matrix=$(echo "$scenario_matrix $filtered_objects" | jq -s 'flatten | unique')
-              done
-            fi
-            updated_matrix=$(echo "$module_matrix $scenario_matrix" | jq -s 'flatten | unique')
-            echo "Test scenarios to run: $updated_matrix"
-            updated_matrix="${updated_matrix//$'\n'/''}"
-            matrix_combinations="{\"include\": ${updated_matrix%?}}"
-            echo "matrix_combinations={\"include\": ${updated_matrix} }" >> "$GITHUB_OUTPUT"
-          fi
-          echo "matrix_combinations: $matrix_combinations"
-    outputs:
-      matrix-combinations: ${{ steps.setup-matrix-scenarios.outputs.matrix_combinations }}
-  terraform-plan:
-    permissions:
-      id-token: write
-      contents: read
-    needs: setup-matrix
-    if: ${{ needs.setup-matrix.result == 'success' && needs.setup-matrix.outputs.matrix-combinations != 'null' && needs.setup-matrix.outputs.matrix-combinations['inlcude'] != '[]' }}
-    strategy:
-      fail-fast: false
-      max-parallel: 3
-      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix-combinations) }}
-    runs-on: ubuntu-latest
-    name: ${{ matrix.cloud }}-${{ matrix.scenario_type }}-${{ matrix.scenario_name }} ${{ matrix.region }}
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.10.0
-
-      - name: Get job id and set env
-        run: |
-          echo "TERRAFORM_INPUT_FILE=$GITHUB_WORKSPACE/scenarios/${{ matrix.scenario_type }}/${{ matrix.scenario_name }}/terraform-inputs/${{ matrix.file_name }}.tfvars" >> "$GITHUB_ENV"
-          echo "TERRAFORM_TEST_INPUT_FILE=$GITHUB_WORKSPACE/scenarios/${{ matrix.scenario_type }}/${{ matrix.scenario_name }}/terraform-test-inputs/${{ matrix.file_name }}.json" >> "$GITHUB_ENV"
-          echo "TERRAFORM_MODULES_DIR=modules/terraform/${{ matrix.cloud }}" >> "$GITHUB_ENV"
-
-      - name: Create JSON Input
-        run: |
-          INPUT_JSON_OBJECT=$(jq . ${{ env.TERRAFORM_TEST_INPUT_FILE }})
-          INPUT_JSON_STRING=$(echo $INPUT_JSON_OBJECT | jq -c '. + {creation_time: (now |  todateiso8601)}')
-          echo "INPUT_JSON=$INPUT_JSON_STRING" >> "$GITHUB_ENV"
-
-      - name: Azure login
-        if: ${{ matrix.cloud == 'azure' }}
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.AZURE_MI }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Terraform Init
-        working-directory: ${{ env.TERRAFORM_MODULES_DIR }}
-        run: terraform init
-
-      - name: Terraform Plan
-        working-directory: ${{ env.TERRAFORM_MODULES_DIR }}
-        run: |
-          terraform plan -var-file "$TERRAFORM_INPUT_FILE" -var="json_input=$INPUT_JSON"
-        env:
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          CLOUD: ${{ matrix.cloud }}


### PR DESCRIPTION
Fixes MSRC #127928 / IcM 31000000665395.

## Root cause

`terraform-validation.yml` was reachable from fork PRs and combined three capabilities that together enabled zero-click RCE and Azure-token minting under `AZURE_MI`:

1. `permissions: id-token: write` on a `pull_request`-triggered job (added in #327) — fork PRs are not stripped of OIDC minting.
2. `terraform test` step (added in #530) — defaults to `command = apply` and executes attacker-controlled HCL from the PR (`null_resource` + `provisioner "local-exec"`).
3. AWS creds gate removed in #1135 — `terraform test` now runs on any fork PR without needing any secrets.

Plus an Entra federated identity credential on `AZURE_MI` (= `telescope-github-oidc`, sub `AKS Airlock`, rg `telescope`) trusting `sub=repo:Azure/telescope:pull_request`, which GitHub emits identically for same-repo and fork PRs — closing the chain.

## Changes

**`.github/workflows/terraform-validation.yml`** (`pull_request`):
- Remove `permissions: id-token: write` (both jobs).
- Remove `terraform test` steps (AWS + Azure).
- Remove `azure/login` step.
- Remove the `setup-matrix` and `terraform-plan` jobs (moved).
- Add top-level `permissions: contents: read`.
- Use `terraform init -backend=false` to prevent backend-driven egress.
- Keeps only fmt / validate / tflint — safe for any fork PR.

**`.github/workflows/terraform-integration.yml`** (new, `pull_request_target`):
- Every PR (same-repo AND fork) is gated by an `authorize` job that uses the `terraform-privileged` environment. Required reviewers = the `@Azure/telescope-oncall` team. A compromised `telescope-write` account is part of the threat model, so same-repo PRs are not auto-approved.
- `terraform-test`, `setup-matrix`, `terraform-plan` all `needs: authorize` and check out `github.event.pull_request.head.sha` from the PR's head repo only after human approval.
- `azure/login@v1` → `@v2` (v1 is deprecated).
- Fix pre-existing `matrix_combinations` double-assignment bug; simplify `Create JSON Input` to read the file directly via `jq -c … "$FILE"`.

## Out-of-band actions

### 1. Org admin — create team `@Azure/telescope-oncall`
Members: @wonderyl, @liyu-ma, @LeonardCareer, @xinWeiWei24, @vittoriasalim. Grant the team **Write** access on `Azure/telescope`.

### 2. Repo admin — create `terraform-privileged` environment
- URL: https://github.com/Azure/telescope/settings/environments
- Name: `terraform-privileged`
- Required reviewers: `@Azure/telescope-oncall`

### 3. Tenant admin — update federated credentials on `telescope-github-oidc`
Managed Identity: `telescope-github-oidc` (client-id `faa8d4b3-7b17-4588-bef2-95f0fb74abc5`), subscription `AKS Airlock` (`137f0351-8235-42a6-ac7a-6b46be2d21c7`), resource group `telescope`.

**Two new FICs already created** (zero-downtime rollout):

| Name | Subject | Status |
|---|---|---|
| `gh-telescope-env-terraform-privileged` | `repo:Azure/telescope:environment:terraform-privileged` | ✅ created |
| `gh-telescope-env-terraform-privileged-numeric` | `repository_owner_id:6844498:repository_id:718354598:environment:terraform-privileged` | ✅ created |

**Old FICs to be deleted after merge + validation**:

| Name | Subject | Action |
|---|---|---|
| `gh-telescope-pr` | `repo:Azure/telescope:pull_request` | 🗑 delete |
| `gh-telescope-pr-numeric` | `repository_owner_id:6844498:repository_id:718354598:pull_request` | 🗑 delete |

```bash
az identity federated-credential delete -g telescope --identity-name telescope-github-oidc --name gh-telescope-pr --yes
az identity federated-credential delete -g telescope --identity-name telescope-github-oidc --name gh-telescope-pr-numeric --yes
```

**Keep**: `gh-telescope-main` and `gh-telescope-main-numeric` (needed for post-merge Actions on `main`).

## Rollout order

1. ✅ Add the two new FICs (done).
2. Configure the team (§1) and the environment (§2).
3. Merge this PR.
4. Validate on the next Terraform-touching PR: `terraform-validation` runs green; `terraform-integration / authorize` pauses waiting for approval; after approve, `azure/login` succeeds.
5. Delete the two old `gh-telescope-pr*` FICs. **MSRC vulnerability is not considered closed until this step is done.**
6. Notify MSRC to re-test.
