### PR TITLE
fix(ci): fix shell syntax in authorize job

### DIFF
--- a/.github/workflows/terraform-integration.yml
+++ b/.github/workflows/terraform-integration.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Authorized
-        run: echo "Authorized PR #${{ github.event.pull_request.number }} head=${{ github.event.pull_request.head.sha }}"
+        run: 'echo "Authorized PR ${{ github.event.pull_request.number }} head=${{ github.event.pull_request.head.sha }}"'
 
   terraform-test:
     needs: authorize


### PR DESCRIPTION
Follow-up to #1266 / MSRC #127928.

## Bug

The `authorize` job's `run:` line:
```yaml
run: echo "Authorized PR #${{ github.event.pull_request.number }} head=${{ github.event.pull_request.head.sha }}"
```

The `#` is interpreted as a **YAML comment**, so the shell only sees `echo "Authorized PR ` — an unterminated double-quoted string — and fails:
```
/home/runner/work/_temp/...sh: line 1: unexpected EOF while looking for matching `"'
##[error]Process completed with exit code 2.
```

That fails `authorize`, which skips `terraform-test` / `setup-matrix` / `terraform-plan`.

## Fix

Wrap the whole `run:` value in single quotes and drop `#`:
```yaml
run: 'echo "Authorized PR ${{ github.event.pull_request.number }} head=${{ github.event.pull_request.head.sha }}"'
```

Scanned all workflows for the same pattern — no other occurrences.

## Verification

Reproduced in retest PR #1267 (authorize job [30315458954](https://github.com/Azure/telescope/actions/runs/30315458954)):
- ✅ `Terraform Validation` on `pull_request` — success (static checks).
- ✅ `Terraform Integration` — paused waiting for `terraform-privileged` approval, confirming the gate works.
- ❌ After approval, `authorize` failed with the shell-syntax error above; downstream jobs skipped.

Once this merges I'll re-run the retest to confirm `authorize` → `terraform-test` → `azure/login` succeeds end-to-end with the new federated credential.

/cc @wonderyl @liyu-ma