### PR TITLE
fix(ci): terraform init before test + gate downstream jobs on terraform-privileged environment

### DIFF
--- a/.github/workflows/terraform-integration.yml
+++ b/.github/workflows/terraform-integration.yml
@@ -28,6 +28,7 @@ jobs:
 
   terraform-test:
     needs: authorize
+    environment: terraform-privileged
     permissions:
       contents: read
       id-token: write
@@ -48,7 +49,9 @@ jobs:
 
       - name: Terraform AWS Test
         working-directory: ${{ env.TERRAFORM_AWS_MODULES_DIR }}
-        run: terraform test
+        run: |
+          terraform init
+          terraform test
 
       - name: Azure login
         uses: azure/login@v2
@@ -59,7 +62,9 @@ jobs:
 
       - name: Terraform Azure Test
         working-directory: ${{ env.TERRAFORM_AZURE_MODULES_DIR }}
-        run: terraform test
+        run: |
+          terraform init
+          terraform test
         env:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
@@ -126,6 +131,7 @@ jobs:
 
   terraform-plan:
     needs: [authorize, setup-matrix]
+    environment: terraform-privileged
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Follow-up to #1266 / MSRC #127928.

## Two fixes

### 1. `terraform test` needs `terraform init` first

Before the split, `terraform-validation.yml` ran `terraform init && terraform validate` as one step, and the downstream `terraform test` reused the resulting `.terraform/` directory as a side effect. After moving `terraform test` into `terraform-integration.yml` (#1266), that side effect is gone and `terraform test` fails with:

```
Error: Module not installed
Run "terraform init" to install all modules required by this configuration.
```

Fix: prepend `terraform init` to both AWS and Azure test steps.

### 2. Downstream jobs need `environment: terraform-privileged` to change the OIDC subject

Currently only `authorize` has `environment: terraform-privileged`. The other jobs (`terraform-test`, `terraform-plan`) present a JWT with `subject=repo:Azure/telescope:pull_request` because that's the default when a job has no environment. This only works today because the legacy federated credential `gh-telescope-pr` is still on `telescope-github-oidc` (retest run [30317570861](https://github.com/Azure/telescope/actions/runs/30317570861/job/90146643975) confirms the JWT subject).

**Once the two old FICs are removed to actually close MSRC #127928, `azure/login` in these jobs would start failing.** Add `environment: terraform-privileged` to both jobs so their JWT subject is `environment:terraform-privileged`, matching the new FIC `gh-telescope-env-terraform-privileged`.

## Approval prompts do NOT multiply

GitHub deduplicates environment approvals per `(workflow_run, environment_name)`. `authorize`'s single approval covers all three jobs. Verified in retest #1267 — after approving `authorize`, both `terraform-test` and `terraform-plan` started immediately without a second prompt (they just failed the login step due to the JWT subject mismatch, which this PR fixes).

## Verification plan

1. Merge this PR.
2. Trigger a no-op retest PR (same shape as #1267).
3. Observe:
   - `authorize` waits for approval ✅ (same as before)
   - After approve, `terraform-test` runs — its `azure/login` step's JWT subject should now read `subject claim - repo:Azure/telescope:environment:terraform-privileged` (or the numeric equivalent), matching the new FIC.
   - `terraform-plan` matrix jobs the same.
4. Delete the two legacy FICs (`gh-telescope-pr`, `gh-telescope-pr-numeric`).
5. Re-run one job — must still succeed. Confirms new FICs alone are sufficient.
6. Close MSRC via retest.

/cc @wonderyl @liyu-ma