### PR TITLE
ci: remove max-parallel: 3 so one approval covers the whole matrix

### DIFF
--- a/.github/workflows/terraform-integration.yml
+++ b/.github/workflows/terraform-integration.yml
@@ -19,15 +19,7 @@ env:
   TERRAFORM_AWS_MODULES_DIR: modules/terraform/aws
 
 jobs:
-  authorize:
-    environment: terraform-privileged
-    runs-on: ubuntu-latest
-    steps:
-      - name: Authorized
-        run: 'echo "Authorized PR ${{ github.event.pull_request.number }} head=${{ github.event.pull_request.head.sha }}"'
-
   terraform-test:
-    needs: authorize
     environment: terraform-privileged
     permissions:
       contents: read
@@ -37,7 +29,6 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          # Only checked out AFTER `authorize` completes.
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -69,7 +60,6 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   setup-matrix:
-    needs: authorize
     runs-on: ubuntu-latest
     name: Setup terraform plan matrix for test scenarios
     steps:
@@ -130,7 +120,7 @@ jobs:
       matrix-combinations: ${{ steps.setup-matrix-scenarios.outputs.matrix_combinations }}
 
   terraform-plan:
-    needs: [authorize, setup-matrix]
+    needs: setup-matrix
     environment: terraform-privileged
     permissions:
       id-token: write
@@ -138,7 +128,6 @@ jobs:
     if: ${{ needs.setup-matrix.result == 'success' && needs.setup-matrix.outputs.matrix-combinations != '' && needs.setup-matrix.outputs.matrix-combinations != 'null' }}
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix-combinations) }}
     runs-on: ubuntu-latest
     name: ${{ matrix.cloud }}-${{ matrix.scenario_type }}-${{ matrix.scenario_name }} ${{ matrix.region }}


### PR DESCRIPTION
Follow-up to #1266 / #1269 / MSRC #127928 — approval-fatigue fix.

## Problem

With `max-parallel: 3` on `terraform-plan`, GitHub creates matrix jobs in waves of 3. Each wave is a separate `terraform-privileged` deployment request, so approving the environment covers only the current wave. For ~20 tfvars this means 7-8 approval clicks per push (see retest #1267 run #4).

Additionally, the `authorize` job was a no-op placeholder that only existed to attach `environment: terraform-privileged`. After #1269 both `terraform-test` and `terraform-plan` carry that environment themselves, so `authorize` no longer serves a purpose.

## Fix

Two changes:

1. **Delete `max-parallel: 3`.** All matrix jobs now pend simultaneously as one batch. GitHub deduplicates approval per batch, so a single click covers the entire matrix.

2. **Delete the `authorize` job** and the `needs: authorize` references on `terraform-test`, `setup-matrix`, and `terraform-plan`. The approval gate now lives directly on the jobs that actually use the OIDC token (`terraform-test`, `terraform-plan`). Same security guarantee — an environment approval is still required before any privileged step can run — just one fewer job in the DAG.

## Runner concurrency

telescope has no self-hosted runners; workflows run on the Azure org's shared GitHub-hosted Ubuntu pool. Azure is on GitHub Enterprise Cloud, which caps Ubuntu concurrency at ~500 per org. With ~20 matrix jobs this is well within budget; if org-wide contention ever exhausts the pool, extra jobs simply queue behind the currently-approved batch — they don't fail.

## Verification plan

After merge, trigger a Terraform-touching PR and confirm:
- All jobs (`terraform-test`, `setup-matrix`, `terraform-plan` matrix) pend simultaneously
- One click on `terraform-privileged` approves the whole batch
- No further approval prompts appear as jobs finish

/cc @wonderyl @liyu-ma
