### PR TITLE
chore: remove no longer active user from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @alyssa1303 @anson627 @sumanthreddy29 @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma @LeonardCareer
+* @alyssa1303 @sumanthreddy29 @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma @LeonardCareer
 
 # CCP pipelines
 /pipelines/perf-eval/API\ Server\ Benchmark/ @fuweid @xinWeiWei24 @vittoriasalim @wonderyl @liyu-ma @LeonardCareer


### PR DESCRIPTION
Remove a user who is no longer active from CODEOWNERS.