### PR TITLE
fix(gpu): unpin AKS kubernetes_version so AKS selects a supported default

### DIFF
--- a/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/azure.tfvars
@@ -8,7 +8,6 @@ aks_cli_config_list = [
     role                          = "gpu"
     aks_name                      = "gpu-cluster"
     sku_tier                      = "standard"
-    kubernetes_version            = "1.33"
     use_aks_preview_cli_extension = true
     default_node_pool = {
       name       = "default"

--- a/scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars
@@ -8,7 +8,6 @@ aks_cli_config_list = [
     role                          = "client"
     aks_name                      = "gpu-scheduling"
     sku_tier                      = "Standard"
-    kubernetes_version            = "1.33"
     use_aks_preview_private_build = false
     use_custom_configurations     = false
     default_node_pool = {

--- a/scenarios/perf-eval/k8s-ray-scheduling/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/k8s-ray-scheduling/terraform-inputs/azure.tfvars
@@ -8,7 +8,6 @@ aks_cli_config_list = [
     role                          = "client"
     aks_name                      = "ray-scheduling"
     sku_tier                      = "Standard"
-    kubernetes_version            = "1.33"
     use_aks_preview_private_build = false
     use_custom_configurations     = false
     default_node_pool = {


### PR DESCRIPTION
## Problem

All scheduled runs of the **GPU Cluster CRUD** pipeline (ADO `akstelescope/telescope` def 61) — and the sibling GPU scheduling / Ray scheduling pipelines — have been failing on `az aks create`:

```
ERROR: (K8sVersionNotSupported) Managed cluster gpu-cluster is on version 1.33.13,
which is only available for Long-Term Support (LTS).
```

## Root cause

The GPU scenarios pinned `kubernetes_version = "1.33"`. AKS has since aged the entire 1.33 minor into **LTS-only** support. On a `Standard`-tier cluster without LTS enabled, `--kubernetes-version 1.33` resolves to `1.33.13` and is rejected. Community-supported versions are now 1.34 / 1.35 / 1.36.

## Fix

Remove the version pin from the **Azure** inputs of all three GPU scenarios. The `aks-cli` module already treats `kubernetes_version = null` as "omit `--kubernetes-version`", so AKS selects its current default supported version. This also prevents recurrence as versions age out.

- `scenarios/perf-eval/k8s-gpu-cluster-crud/terraform-inputs/azure.tfvars`
- `scenarios/perf-eval/k8s-gpu-scheduling/terraform-inputs/azure.tfvars`
- `scenarios/perf-eval/k8s-ray-scheduling/terraform-inputs/azure.tfvars`

The EKS `aws.tfvars` (`k8s-gpu-cluster-crud`) is left on 1.33 — EKS still supports it and no GPU pipeline runs on AWS.

## Note

The same stale `1.33` pin exists in ~12 other **Azure** perf-eval scenarios and will fail identically; scoped this PR to the GPU pipelines per the request. Happy to follow up with a sweep for the rest.