### PR TITLE
test: verify /run-tf-integration trigger (DO NOT MERGE)

### DIFF
--- a/scenarios/perf-eval/apiserver-cm100/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/apiserver-cm100/terraform-inputs/azure.tfvars
@@ -1,3 +1,4 @@
+# test: verify /run-tf-integration end-to-end (delete this line)
 scenario_type  = "perf-eval"
 scenario_name  = "apiserver-cm100"
 deletion_delay = "10h"


### PR DESCRIPTION
Test PR for verifying end-to-end behavior of the terraform integration slash-command trigger deployed via #1272. Modifies one Azure tfvars to make setup-matrix produce a non-empty matrix. Do not merge.