### PR TITLE
fix(pipelines): retry terraform apply/destroy on transient Azure control-plane conflicts

### DIFF
--- a/steps/terraform/run-command.yml
+++ b/steps/terraform/run-command.yml
@@ -16,6 +16,16 @@ parameters:
 - name: skip_resource_deletion
   type: string
   default: "false"
+# Azure control-plane operations on a managed cluster are serialized. When another
+# operation is still running, ARM rejects apply/destroy with a transient conflict
+# (409 EtagMismatch / OperationNotAllowed). These are retried in-script with backoff
+# so they do not depend on retryCountOnTaskFailure, which some pipelines set to 0.
+- name: transient_conflict_retry_count
+  type: number
+  default: 3
+- name: transient_conflict_retry_delay_seconds
+  type: number
+  default: 60
 
 steps:
 - script: |
@@ -41,8 +51,32 @@ steps:
         fi
 
         set +e
-        terraform ${{ parameters.command }} --auto-approve ${{ parameters.arguments }} -var-file $terraform_input_file -var json_input="$terraform_input_variables" 2>&1 | tee terraform_${{ parameters.command }}.log
-        exit_code=${PIPESTATUS[0]}
+        attempt=1
+        max_attempts=$(( ${{ parameters.transient_conflict_retry_count }} + 1 ))
+        while true; do
+          terraform ${{ parameters.command }} --auto-approve ${{ parameters.arguments }} -var-file $terraform_input_file -var json_input="$terraform_input_variables" 2>&1 | tee terraform_${{ parameters.command }}.log
+          exit_code=${PIPESTATUS[0]}
+
+          if [[ $exit_code -eq 0 ]]; then
+            break
+          fi
+
+          if [[ "$CLOUD" != "azure" ]] || (( attempt >= max_attempts )); then
+            break
+          fi
+
+          # Only conflicts caused by a concurrent control-plane operation are retried.
+          # Any other failure falls through to the cleanup logic below immediately.
+          if ! grep -qEi "EtagMismatch|OperationNotAllowed|AnotherOperationInProgress|Another operation is in progress|in-progress .* operation|operation preempted" terraform_${{ parameters.command }}.log; then
+            break
+          fi
+
+          delay=$(( ${{ parameters.transient_conflict_retry_delay_seconds }} * 2 ** (attempt - 1) ))
+          echo "##vso[task.logissue type=warning;] terraform ${{ parameters.command }} hit a transient Azure control-plane conflict in region $region. Retrying in ${delay}s (attempt $attempt of ${{ parameters.transient_conflict_retry_count }})."
+          sleep $delay
+          attempt=$(( attempt + 1 ))
+        done
+
         if [[ $exit_code -ne 0 ]]; then
           if [[ ${{ parameters.command }} == "apply" && "$CLOUD" == "azure" ]]; then
             echo "Delete resources and remove state file before retrying"


### PR DESCRIPTION
## Problem

Azure serializes control-plane operations on a managed cluster. When another operation is still in flight, ARM rejects `terraform apply` / `terraform destroy` with a transient conflict:

```
RESPONSE 409: 409 Conflict
ERROR CODE: EtagMismatch
"message": "Operation is not allowed: Another operation is in progress. ..."
"subcode": "PutManagedClusterAndComponents_FailedPrecondition_HCPServerError"
```

or

```
ERROR: (OperationNotAllowed) Operation is not allowed because there's an
in-progress PutExtensionAddonHandler.PUT operation (operation ID: ...) on the
managed cluster started on UTC ... Please wait for it to finish before starting
a new operation.
```

The only protection today is `retryCountOnTaskFailure`, driven by `retry_attempt_count`. Several pipelines deliberately set that to **0** to avoid re-running expensive provisioning — e.g. [`pipelines/perf-eval/Hyperscale Cluster Benchmark/ccp-provisioning-H2.yml`](https://github.com/Azure/telescope/blob/main/pipelines/perf-eval/Hyperscale%20Cluster%20Benchmark/ccp-provisioning-H2.yml) — so those pipelines fail immediately on a conflict that clears itself within a minute or two.

Observed failures:

| Pipeline | Run | Failure |
|---|---|---|
| Hyperscale H2 | `20260803.1` | `azure_H2` died after **36s** in *Run Terraform destroy Command* — 409 `EtagMismatch` |
| 100 Nodes 10k Pods | `20260802.1` | `azure_uksouth*` — `OperationNotAllowed` (in-progress `PutExtensionAddonHandler.PUT`), cascading into failed destroy + failed Destroy Resource Group |

## Change

Bounded in-script retry with exponential backoff around the terraform apply/destroy invocation in `steps/terraform/run-command.yml`:

- **Narrowly scoped** — only retries when `cloud == azure` **and** the terraform log matches a known concurrent-operation conflict (`EtagMismatch`, `OperationNotAllowed`, `AnotherOperationInProgress`, `Another operation is in progress`, `in-progress … operation`, `operation preempted`). Genuine failures (quota, bad config, missing permissions) still fail fast and fall through to the existing cleanup logic unchanged.
- **Defaults to 3 retries** with 60s / 120s / 240s backoff, tunable via the new `transient_conflict_retry_count` and `transient_conflict_retry_delay_seconds` parameters.
- **Independent of `retry_attempt_count`**, so it also protects pipelines that opt out of task-level retries.
- **Emits an ADO warning** on each retry, so the conflict stays visible in the run summary rather than being silently swallowed.

Behaviour is unchanged for AWS/GCP and for every non-conflict failure path.

## Testing

- `yamllint -c .yamllint steps/terraform/run-command.yml --no-warnings` — clean.
- The generated script body passes `bash -n`.
- Retry loop exercised standalone against four scenarios:

| Scenario | Expected | Result |
|---|---|---|
| Transient conflict, succeeds on 3rd attempt | retry twice, exit 0 | ✅ 3 calls, exit 0 |
| Non-transient error (`quota exceeded`) | no retry, fail fast | ✅ 1 call, exit 1 |
| `cloud == aws` with conflict text | no retry | ✅ 1 call, exit 1 |
| `OperationNotAllowed` / in-progress PUT | retry, recover | ✅ 2 calls, exit 0 |
| Conflict never clears | 1 + 3 attempts, backoff 60/120/240 | ✅ exit 1 after 4 attempts |
