### PR TITLE
Use 16-core VM for cl2pool in hyperscale pod scheduling pipeline

### DIFF
--- a/kcl/ccp_team/hyperscale_pod_scheduling/pipeline.k
+++ b/kcl/ccp_team/hyperscale_pod_scheduling/pipeline.k
@@ -22,7 +22,7 @@ CL2_IMAGE = "ghcr.io/azure/clusterloader2:v20260220"
 CL2_NAMESPACE = "clusterloader2"
 CL2_POOL = azure.NodePool {
     name = "cl2pool"
-    sku = "Standard_D8S_v4"
+    sku = "Standard_D16S_v4"
     count = 1
     taintPrefix = "cl2pool"
 }

--- a/kcl/ccp_team/hyperscale_pod_scheduling/pipeline.yaml
+++ b/kcl/ccp_team/hyperscale_pod_scheduling/pipeline.yaml
@@ -156,7 +156,7 @@ stages:
               --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
               --name "cl2pool" \
               --node-count 1 \
-              --node-vm-size "Standard_D8S_v4" \
+              --node-vm-size "Standard_D16S_v4" \
               --mode User \
               --node-taints cl2pool=true:NoSchedule 2>&1)
             rc=$?
@@ -483,7 +483,7 @@ stages:
               --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
               --name "cl2pool" \
               --node-count 1 \
-              --node-vm-size "Standard_D8S_v4" \
+              --node-vm-size "Standard_D16S_v4" \
               --mode User \
               --node-taints cl2pool=true:NoSchedule 2>&1)
             rc=$?
@@ -810,7 +810,7 @@ stages:
               --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
               --name "cl2pool" \
               --node-count 1 \
-              --node-vm-size "Standard_D8S_v4" \
+              --node-vm-size "Standard_D16S_v4" \
               --mode User \
               --node-taints cl2pool=true:NoSchedule 2>&1)
             rc=$?


### PR DESCRIPTION
Updates the cl2pool node SKU from Standard_D8S_v4 to Standard_D16S_v4 (16 cores) in the hyperscale pod scheduling pipeline, targeting the v2 branch. Regenerated pipeline.yaml with `kcl run`.