### PR TITLE
feat(kperf): add optional flowcontrol parameter to RunKperfRunnerGroup

### DIFF
--- a/kcl/lib/steps/kperf/run_benchmark.k
+++ b/kcl/lib/steps/kperf/run_benchmark.k
@@ -23,8 +23,9 @@ runkperf -v 3 bench \\
 }
 
 # RunKperfRunnerGroup runs `kperf rg run` with the specified runner image, runner
-# group manifest, and optional affinity selector.
-RunKperfRunnerGroup = lambda runnerImage: str, runnerGroup: str, affinity: str = "", target: str = None -> steps.Step {
+# group manifest, optional flow control setting, and optional affinity selector.
+RunKperfRunnerGroup = lambda runnerImage: str, runnerGroup: str, flowcontrol: str = "", affinity: str = "", target: str = None -> steps.Step {
+    flowcontrolFlag = "--runner-flowcontrol ${flowcontrol} \\\n  " if flowcontrol else ""
     affinityFlag = "--affinity=\"${affinity}\" \\\n  " if affinity else ""
     steps.Script {
         script = """
@@ -36,7 +37,7 @@ kperf rg delete
 kperf rg run \\
   --runner-image=${runnerImage} \\
   --runnergroup="${runnerGroup}" \\
-  ${affinityFlag}
+  ${flowcontrolFlag}${affinityFlag}
 """
         displayName = "Run kperf runner group"
         target = target

--- a/kcl/lib/steps/kperf/run_benchmark.k
+++ b/kcl/lib/steps/kperf/run_benchmark.k
@@ -25,7 +25,7 @@ runkperf -v 3 bench \\
 # RunKperfRunnerGroup runs `kperf rg run` with the specified runner image, runner
 # group manifest, optional flow control setting, and optional affinity selector.
 RunKperfRunnerGroup = lambda runnerImage: str, runnerGroup: str, flowcontrol: str = "", affinity: str = "", target: str = None -> steps.Step {
-    flowcontrolFlag = "--runner-flowcontrol ${flowcontrol} \\\n  " if flowcontrol else ""
+    flowcontrolFlag = "--runner-flowcontrol=\"${flowcontrol}\" \\\n  " if flowcontrol else ""
     affinityFlag = "--affinity=\"${affinity}\" \\\n  " if affinity else ""
     steps.Script {
         script = """


### PR DESCRIPTION
## Summary

Add an optional `flowcontrol` parameter to `RunKperfRunnerGroup` so callers can pass `--runner-flowcontrol` to `kperf rg run`.

This is needed for scenarios like audit log missing repro where APF throttling must be bypassed via `--runner-flowcontrol exempt:2` to push maximum mutation throughput.

**Before:** No way to set flow control — callers had to write custom bash steps.

**After:**
```kcl
kperf.RunKperfRunnerGroup(KPERF_IMAGE, "file:///config.yaml", flowcontrol="exempt:2")
