### PR TITLE
Migrate perf-eval/cni-benchmark/cni-ab-testing pipeline to v2 KCL

### DIFF
--- a/kcl/lib/steps/azure/az_cli.k
+++ b/kcl/lib/steps/azure/az_cli.k
@@ -1,10 +1,18 @@
 import azure_pipelines.ap.steps
 
-AzCli = lambda serviceConnection: str, displayName: str, script: str, condition: str = Undefined, continueOnError: bool = Undefined, stepName: str = Undefined -> steps.Step {
+AzCli = lambda {
+    serviceConnection: str,
+    displayName: str,
+    script: str,
+    condition: str = Undefined,
+    continueOnError: bool = Undefined,
+    stepName: str = Undefined,
+    env: {str:str} = Undefined,
+} -> steps.Step {
     steps.Task {
         task = "AzureCLI@2"
         inputs = {
-            azureSubscription = serviceConnection,
+            azureSubscription = serviceConnection
             scriptType = "bash"
             scriptLocation = "inlineScript"
             inlineScript = "set -exo pipefail\n" + script
@@ -13,5 +21,6 @@ AzCli = lambda serviceConnection: str, displayName: str, script: str, condition:
         condition = condition
         continueOnError = continueOnError
         name = stepName
+        env = env
     }
 }

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/UPSTREAM
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/UPSTREAM
@@ -1,0 +1,6 @@
+Source: https://github.com/Azure/telescope
+Commit: ec8aecd5bcdc472b76c65087ddd4fafb0f43b696
+Paths:
+- modules/python/clusterloader2/cri/cri.py
+- modules/python/clusterloader2/cri/config/
+- modules/python/clusterloader2/utils.py

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config/config.yaml
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config/config.yaml
@@ -1,0 +1,193 @@
+name: resource-consumer
+
+{{$deploymentSize := DefaultParam .CL2_DEPLOYMENT_SIZE 10}}
+{{$memory := DefaultParam .CL2_RESOURCE_CONSUME_MEMORY "100"}}
+{{$memoryKi := DefaultParam .CL2_RESOURCE_CONSUME_MEMORY_KI "100"}}
+{{$cpu := DefaultParam .CL2_RESOURCE_CONSUME_CPU 100}}
+{{$repeats := DefaultParam .CL2_REPEATS 1}}
+
+{{$steps := DefaultParam .CL2_STEPS 1}}
+{{$nodePerStep := DefaultParam .CL2_NODE_PER_STEP 1}}
+{{$totalNodes := MultiplyInt $nodePerStep $steps}}
+{{$replicas := MultiplyInt $deploymentSize $totalNodes}}
+{{$scaleReplicas := MultiplyInt $deploymentSize $nodePerStep}}
+{{$scaleEnabled := DefaultParam .CL2_SCALE_ENABLED false}}
+
+{{$operationTimeout := DefaultParam .CL2_OPERATION_TIMEOUT "5m"}}
+{{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "15s"}}
+{{$loadType := DefaultParam .CL2_LOAD_TYPE "memory"}}
+
+{{$provider := DefaultParam .CL2_PROVIDER "aks"}}
+{{$registryEndpoint := DefaultParam .CL2_REGISTRY_ENDPOINT "akscritelescope.azurecr.io" }}
+{{$testImage := DefaultParam .CL2_TEST_IMAGE "e2e-test-images/resource-consumer:1.13" }}
+{{$osType := DefaultParam .CL2_OS_TYPE "linux"}}
+{{$scrapeKubelets := DefaultParam .CL2_SCRAPE_KUBELETS false}}
+{{$scrapeContainerd := DefaultParam .CL2_SCRAPE_CONTAINERD false}}
+{{$hostNetwork := DefaultParam .CL2_HOST_NETWORK "true"}}
+
+namespace:
+  number: 1
+  prefix: resource-consumer
+  deleteStaleNamespaces: true
+  deleteAutomanagedNamespaces: true
+  enableExistingNamespaces: false
+
+tuningSets:
+- name: Uniform1qps
+  qpsLoad:
+    qps: 1
+
+steps:
+  - name: Start measurements
+    measurements:
+      - Identifier: PodStartupLatency
+        Method: PodStartupLatency
+        Params:
+          action: start
+          labelSelector: group = resource-consumer
+          threshold: {{$podStartupLatencyThreshold}}
+      - Identifier: ResourceUsageSummary
+        Method: ResourceUsageSummary
+        Params:
+          action: start
+          labelSelector: group = resource-consumer
+      - Identifier: WaitForRunningLatencyDeployments
+        Method: WaitForControlledPodsRunning
+        Params:
+          action: start
+          checkIfPodsAreUpdated: true
+          apiVersion: apps/v1
+          kind: Deployment
+          labelSelector: group = resource-consumer
+          operationTimeout: {{$operationTimeout}}
+
+{{range $i := Loop $repeats}}
+
+  {{if $scrapeKubelets}}
+  - module:
+      path: /kubelet-measurement.yaml
+      params:
+        action: start
+  {{end}}
+
+  {{if $scrapeContainerd}}
+  - module:
+      path: /containerd-measurements.yaml
+      params:
+        action: start
+  {{end}}
+
+  {{range $j := Loop $steps}}
+  - name: Create deployment {{$j}}
+    phases:
+    - namespaceRange:
+          min: 1
+          max: 1
+      replicasPerNamespace: 1
+      tuningSet: Uniform1qps
+      objectBundle:
+      - basename: resource-consumer-{{$j}}
+        objectTemplatePath: deployment_template.yaml
+        templateFillMap:
+      {{if $scaleEnabled}}
+        {{if eq $j 0}}
+          Replicas: {{AddInt $scaleReplicas $deploymentSize}}
+        {{else}}
+          Replicas: {{$scaleReplicas}}
+        {{end}}
+      {{else}}
+          Replicas: {{$replicas}}
+      {{end}}
+          Group: resource-consumer
+          {{if eq $osType "windows"}}
+          Memory: {{$memory}}
+          {{else}}
+          Memory: {{$memoryKi}}K
+          {{end}}
+          CPU: --millicores={{$cpu}}
+          MemoryRequest: {{$memoryKi}}
+          CPURequest: {{$cpu}}m
+          LoadType: {{$loadType}}
+          Provider: {{$provider}}
+          RegistryEndpoint: {{$registryEndpoint}}
+          TestImage: {{$testImage}}
+          OSType: {{$osType}}
+          HostNetwork: {{$hostNetwork}}
+
+  - name: Waiting for latency pods to be running
+    measurements:
+      - Identifier: WaitForRunningLatencyDeployments
+        Method: WaitForControlledPodsRunning
+        Params:
+          action: gather
+
+  - name: Wait for resource consumption
+    measurements:
+      - Identifier: Sleep
+        Method: Sleep
+        Params:
+          duration: 1m
+
+  - name: Wait for nodes to be ready
+    measurements:
+      - Identifier: ConfirmNodeCount
+        Method: WaitForNodes
+        Params:
+          action: start
+        {{if $scaleEnabled}}
+          minDesiredNodeCount: {{MultiplyInt (AddInt (MultiplyInt $nodePerStep (AddInt $j 1)) 1) 0.8}}
+          maxDesiredNodeCount: {{AddInt $totalNodes 1}}
+        {{else}}
+          minDesiredNodeCount: {{MultiplyInt $totalNodes 0.8}}
+          maxDesiredNodeCount: {{$totalNodes}}
+        {{end}}
+          labelSelector: cri-resource-consume = true
+          timeout: 1m
+          refreshInterval: 5s
+  {{end}}
+
+  {{if $scrapeKubelets}}
+  - module:
+      path: /kubelet-measurement.yaml
+      params:
+        action: gather
+  {{end}}
+
+  {{if $scrapeContainerd}}
+  - module:
+      path: /containerd-measurements.yaml
+      params:
+        action: gather
+  {{end}}
+
+  {{range $j := Loop $steps}}
+  - name: Deleting deployments {{$j}}
+    phases:
+      - namespaceRange:
+          min: 1
+          max: 1
+        replicasPerNamespace: 0
+        tuningSet: Uniform1qps
+        objectBundle:
+          - basename: resource-consumer-{{$j}}
+            objectTemplatePath: deployment_template.yaml
+
+  - name: Waiting for latency pods to be deleted
+    measurements:
+      - Identifier: WaitForRunningLatencyDeployments
+        Method: WaitForControlledPodsRunning
+        Params:
+          action: gather
+  {{end}}
+{{end}}
+
+  - name: Collect measurements
+    measurements:
+      - Identifier: ResourceUsageSummary
+        Method: ResourceUsageSummary
+        Params:
+          action: gather
+      - Identifier: PodStartupLatency
+        Method: PodStartupLatency
+        Params:
+          action: gather

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config/containerd-measurements.yaml
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config/containerd-measurements.yaml
@@ -1,0 +1,29 @@
+{{$action := .action}} # start, gather
+
+steps:
+  - name: {{$action}} Containerd Measurements
+    measurements:
+    - Identifier: ContainerdCriImagePullingThroughput
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: ContainerdCriImagePullingThroughput
+        metricVersion: v1
+        unit: MB/s
+        queries:
+        # Weighted average throughput per image pull (nodes with more pulls have more weight)
+        - name: Avg
+          query: sum(rate(containerd_cri_image_pulling_throughput_sum{nodepool=~"userpool.*"}[%v])) / sum(rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v]))
+        # Unweighted average - each node contributes equally regardless of pull count (filtered for active nodes)
+        - name: AvgPerNode
+          query: avg((sum by (instance) (rate(containerd_cri_image_pulling_throughput_sum{nodepool=~"userpool.*"}[%v])) / sum by (instance) (rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v]))) and (sum by (instance) (rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v])) > 0))
+        # Number of successful image pull observations
+        - name: Count
+          query: sum(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"})
+        # Cluster level percentiles - throughput distribution across nodes (filtered to exclude nodes with no pulls)
+        - name: Perc50
+          query: quantile(0.5, (sum by (instance) (rate(containerd_cri_image_pulling_throughput_sum{nodepool=~"userpool.*"}[%v])) / sum by (instance) (rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v]))) and (sum by (instance) (rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v])) > 0))
+        - name: Perc90
+          query: quantile(0.9, (sum by (instance) (rate(containerd_cri_image_pulling_throughput_sum{nodepool=~"userpool.*"}[%v])) / sum by (instance) (rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v]))) and (sum by (instance) (rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v])) > 0))
+        - name: Perc99
+          query: quantile(0.99, (sum by (instance) (rate(containerd_cri_image_pulling_throughput_sum{nodepool=~"userpool.*"}[%v])) / sum by (instance) (rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v]))) and (sum by (instance) (rate(containerd_cri_image_pulling_throughput_count{nodepool=~"userpool.*"}[%v])) > 0))

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config/deployment_template.yaml
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config/deployment_template.yaml
@@ -1,0 +1,112 @@
+{{$Memory := DefaultParam .Memory "1000M"}}
+{{$CPU := DefaultParam .CPU "--millicores=100"}}
+{{$MemoryRequest := DefaultParam .MemoryRequest "1000Ki"}}
+{{$CPURequest := DefaultParam .CPURequest "100m"}}
+{{$LoadType := DefaultParam .LoadType "memory"}}
+{{$Provider := DefaultParam .Provider "aks"}}
+{{$RegistryEndpoint := DefaultParam .RegistryEndpoint "akscritelescope.azurecr.io"}}
+{{$TestImage := DefaultParam .TestImage "e2e-test-images/resource-consumer:1.13"}}
+{{$OSType := DefaultParam .OSType "linux"}}
+{{$HostNetwork := DefaultParam .HostNetwork "true"}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        group: {{.Group}}
+    spec:
+      hostNetwork: {{$HostNetwork}}
+      nodeSelector:
+        cri-resource-consume: "true"
+      containers:
+      {{if eq $LoadType "memory"}}
+      - name: resource-consumer-memory
+        imagePullPolicy: IfNotPresent
+        {{if eq $OSType "windows"}}
+        image: {{$RegistryEndpoint}}/e2e-test-images/resource-consumer:1.13-windows-amd64-ltsc2022
+        command:
+          - testlimit.exe
+        args:
+          - -accepteula
+          - -d
+          - "{{$Memory}}"
+          - -e
+          - "0"
+          - "3600"
+          - -c
+          - "1"
+        {{else}}
+          {{if eq $Provider "aks"}}
+        image: {{$RegistryEndpoint}}/{{$TestImage}}
+          {{else}}
+        image: registry.k8s.io/e2e-test-images/resource-consumer:1.13
+          {{end}}
+          {{if eq $TestImage "e2e-test-images/resource-consumer:1.13"}}
+        command:
+          - stress
+        args:
+          - --vm
+          - "1"
+          - --vm-bytes
+          - {{$Memory}}
+          - --vm-hang
+          - "0"
+          - --timeout
+          - "3600"
+          {{end}}
+        {{end}}
+        resources:
+          requests:
+            memory: {{$MemoryRequest}}
+      {{end}}
+      {{if eq $LoadType "cpu"}}
+      - name: resource-consumer-cpu
+        imagePullPolicy: IfNotPresent
+        {{if eq $OSType "windows"}}
+        image: {{$RegistryEndpoint}}/e2e-test-images/resource-consumer:1.13-windows-amd64-ltsc2022
+        command:
+          - /consume-cpu/consume-cpu.exe
+        {{else}}
+          {{if eq $Provider "aks"}}
+        image: {{$RegistryEndpoint}}/e2e-test-images/resource-consumer:1.13
+          {{else}}
+        image: registry.k8s.io/e2e-test-images/resource-consumer:1.13
+          {{end}}
+        command:
+          - /consume-cpu/consume-cpu
+        {{end}}
+        args:
+          - --duration-sec=3600
+          - {{$CPU}}
+        resources:
+          requests:
+            cpu: {{$CPURequest}}
+      {{end}}
+      tolerations:
+      - key: "cri-resource-consume"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      - key: "cri-resource-consume"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"
+      # Spread pods evenly across nodes (best-effort)
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            group: {{.Group}}

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config/kubelet-measurement.yaml
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config/kubelet-measurement.yaml
@@ -1,0 +1,108 @@
+{{$action := .action}} # start, gather
+
+steps:
+  - name: {{$action}} Kubelet Measurements
+    measurements:
+    - Identifier: KubeletPodStartupSLIDuration
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletPodStartupSLIDuration
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[10m])) by (node, le))
+          threshold: 5
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[10m])) by (node, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_sli_duration_seconds_bucket[10m])) by (node, le))
+    - Identifier: KubeletPodStartupDuration
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletPodStartupDuration
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_bucket[10m])) by (node, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_duration_seconds_bucket[10m])) by (node, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_duration_seconds_bucket[10m])) by (node, le))
+    - Identifier: KubeletPodStartupTotalDuration
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletPodStartupTotalDuration
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[10m])) by (node, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[10m])) by (node, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_pod_start_total_duration_seconds_bucket[10m])) by (node, le))
+    - Identifier: KubeletRuntimeOperationDurationWithoutPullImage
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletRuntimeOperationDurationWithoutPullImage
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+          - operation_type
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{operation_type!="pull_image"}[10m])) by (node, operation_type, le))
+        - name: Sum
+          query: kubelet_runtime_operations_duration_seconds_sum{operation_type!="pull_image"}
+    - Identifier: KubeletRuntimeOperationDurationWithPullImage
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletRuntimeOperationDurationWithPullImage
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+          - operation_type
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(avg_over_time(kubelet_runtime_operations_duration_seconds_bucket{operation_type="pull_image"}[5m])) by (node, operation_type, le))
+        - name: Sum
+          query: kubelet_runtime_operations_duration_seconds_sum{operation_type="pull_image"}
+    - Identifier: KubeletRunSandboxDuration
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: KubeletRunSandboxDuration
+        metricVersion: v1
+        unit: s
+        dimensions:
+          - node
+        queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(kubelet_run_podsandbox_duration_seconds_bucket[10m])) by (node, le))
+        - name: Perc90
+          query: histogram_quantile(0.90, sum(rate(kubelet_run_podsandbox_duration_seconds_bucket[10m])) by (node, le))
+        - name: Perc50
+          query: histogram_quantile(0.50, sum(rate(kubelet_run_podsandbox_duration_seconds_bucket[10m])) by (node, le))

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/cri.py
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/cri.py
@@ -1,0 +1,460 @@
+import json
+import os
+import argparse
+import math
+
+from datetime import datetime, timezone
+from clusterloader2.utils import parse_xml_to_json, run_cl2_command, get_measurement
+from clients.kubernetes_client import KubernetesClient, client as k8s_client
+from utils.logger_config import get_logger, setup_logging
+from utils.common import str2bool
+
+setup_logging()
+logger = get_logger(__name__)
+
+MEMORY_SCALE_FACTOR = 0.95 # 95% of the total allocatable memory to account for error margin
+
+# TODO: Refactor to use a config dataclass to reduce number of arguments
+# Reference: modules/python/clusterloader2/job_controller/job_controller.py
+def override_config_clusterloader2(
+    node_count, node_per_step, max_pods, repeats, operation_timeout,
+    load_type, scale_enabled, pod_startup_latency_threshold, provider,
+    registry_endpoint, test_image, os_type, scrape_kubelets, scrape_containerd, containerd_scrape_interval, host_network, override_file, memory_request_override=None):
+    client = KubernetesClient(os.path.expanduser("~/.kube/config"))
+    nodes = client.get_nodes(label_selector="cri-resource-consume=true")
+    if len(nodes) == 0:
+        raise Exception("No nodes found with the label cri-resource-consume=true")
+
+    node = nodes[0]
+    allocatable_cpu = node.status.allocatable["cpu"]
+    allocatable_memory = node.status.allocatable["memory"]
+    logger.info(f"Node {node.metadata.name} has allocatable cpu of {allocatable_cpu} and allocatable memory of {allocatable_memory}")
+
+    cpu_value = int(allocatable_cpu.replace("m", ""))
+    # Bottlerocket OS SKU on EKS has allocatable_memory property in Mi. AKS and Amazon Linux (default SKUs)
+    # user Ki. Handling the Mi case here and converting Mi to Ki, if needed.
+    if "Mi" in allocatable_memory:
+        memory_value = int(allocatable_memory.replace("Mi", "")) * 1024
+    elif "Ki" in allocatable_memory:
+        memory_value = int(allocatable_memory.replace("Ki", ""))
+    else:
+        raise Exception("Unexpected format of allocatable memory node property")
+
+    logger.info(f"Node {node.metadata.name} has cpu value of {cpu_value} and memory value of {memory_value}")
+
+    allocated_cpu, allocated_memory = client.get_daemonsets_pods_allocated_resources("kube-system", node.metadata.name)
+    logger.info(f"Node {node.metadata.name} has allocated cpu of {allocated_cpu} and allocated memory of {allocated_memory}")
+
+    cpu_value -= allocated_cpu
+    memory_value -= allocated_memory
+
+    # Calculate request cpu and memory for each pod
+    daemonset_count = client.get_daemonsets_pods_count("kube-system", node.metadata.name)
+    logger.info(f"Node {node.metadata.name} has {daemonset_count} daemonset pods")
+    pod_count = max_pods - daemonset_count
+    cpu_request = cpu_value // pod_count
+
+    # Use override if provided, otherwise calculate
+    if memory_request_override:
+        if memory_request_override.endswith("Mi"):
+            memory_request_in_ki = int(memory_request_override.replace("Mi", "")) * 1024
+        elif memory_request_override.endswith("Gi"):
+            memory_request_in_ki = int(memory_request_override.replace("Gi", "")) * 1024 * 1024
+        elif memory_request_override.endswith("Ki"):
+            memory_request_in_ki = int(memory_request_override.replace("Ki", ""))
+        else:
+            memory_request_in_ki = int(memory_request_override)
+        memory_request_in_k = int(memory_request_in_ki // 1.024)
+        memory_request_in_m = int(memory_request_in_k // 1000)
+        memory_request = memory_request_in_m if os_type == "windows" else memory_request_in_k
+        logger.info(f"Using memory request override: {memory_request_override}")
+    else:
+        memory_request_in_ki = math.ceil(memory_value * MEMORY_SCALE_FACTOR // pod_count)
+        memory_request_in_k = int(memory_request_in_ki // 1.024)
+        memory_request_in_m = int(memory_request_in_k // 1000)
+        memory_request = (
+            memory_request_in_m if os_type == "windows" else memory_request_in_k
+        )
+
+    logger.info(
+        f"CPU request for each pod: {cpu_request}m, memory request for each pod: {memory_request}, "
+        f"total pod per node: {pod_count}, os_type: {os_type}"
+    )
+
+    # Calculate the number of steps to scale up
+    steps = node_count // node_per_step
+    logger.info(
+        f"Scaled enabled: {scale_enabled}, node per step: {node_per_step}, steps: {steps}, "
+        f"scrape kubelets: {scrape_kubelets}, host network: {host_network}"
+    )
+
+    with open(override_file, 'w', encoding='utf-8') as file:
+        file.write(f"CL2_DEPLOYMENT_SIZE: {pod_count}\n")
+        file.write(f"CL2_RESOURCE_CONSUME_MEMORY: {memory_request}\n")
+        file.write(f"CL2_RESOURCE_CONSUME_MEMORY_KI: {memory_request_in_ki}Ki\n")
+        file.write(f"CL2_RESOURCE_CONSUME_CPU: {cpu_request}\n")
+        file.write(f"CL2_REPEATS: {repeats}\n")
+        file.write(f"CL2_NODE_COUNT: {node_count}\n")
+        file.write(f"CL2_NODE_PER_STEP: {node_per_step}\n")
+        file.write(f"CL2_STEPS: {steps}\n")
+        file.write(f"CL2_OPERATION_TIMEOUT: {operation_timeout}\n")
+        file.write(f"CL2_LOAD_TYPE: {load_type}\n")
+        file.write(f"CL2_SCALE_ENABLED: {str(scale_enabled).lower()}\n")
+        file.write("CL2_PROMETHEUS_TOLERATE_MASTER: true\n")
+        file.write("CL2_PROMETHEUS_CPU_SCALE_FACTOR: 30.0\n")
+        file.write("CL2_PROMETHEUS_MEMORY_LIMIT_FACTOR: 30.0\n")
+        file.write("CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 30.0\n")
+        file.write("CL2_PROMETHEUS_NODE_SELECTOR: \"prometheus: \\\"true\\\"\"\n")
+        file.write(f"CL2_POD_STARTUP_LATENCY_THRESHOLD: {pod_startup_latency_threshold}\n")
+        file.write(f"CL2_PROVIDER: {provider}\n")
+        file.write(f"CL2_REGISTRY_ENDPOINT: {registry_endpoint}\n")
+        file.write(f"CL2_TEST_IMAGE: {test_image}\n")
+        file.write(f"CL2_OS_TYPE: {os_type}\n")
+        file.write(f"CL2_SCRAPE_KUBELETS: {str(scrape_kubelets).lower()}\n")
+        file.write(f"CL2_SCRAPE_CONTAINERD: {str(scrape_containerd).lower()}\n")
+        if scrape_containerd:
+            file.write(f"CONTAINERD_SCRAPE_INTERVAL: {containerd_scrape_interval}\n")
+        file.write(f"CL2_HOST_NETWORK: {str(host_network).lower()}\n")
+
+    file.close()
+
+def execute_clusterloader2(cl2_image, cl2_config_dir, cl2_report_dir, kubeconfig, provider, scrape_kubelets, scrape_containerd):
+    run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, overrides=True, enable_prometheus=True,
+                    tear_down_prometheus=False, scrape_kubelets=scrape_kubelets, scrape_containerd=scrape_containerd)
+
+# Note: verify_measurement only checks kubelet metrics (accessible via node proxy endpoint).
+# Containerd metrics are only available via Prometheus and cannot be verified here.
+def verify_measurement():
+    client = KubernetesClient(os.path.expanduser("~/.kube/config"))
+    nodes = client.get_nodes(label_selector="cri-resource-consume=true")
+    user_pool = [node.metadata.name for node in nodes]
+    logger.info(f"User pool: {user_pool}")
+    # Create an API client
+    api_client = k8s_client.ApiClient()
+    for node_name in user_pool:
+        url = f"/api/v1/nodes/{node_name}/proxy/metrics"
+
+        try:
+            response = api_client.call_api(
+                resource_path=url,
+                method="GET",
+                auth_settings=['BearerToken'],
+                response_type="str",
+                _preload_content=True
+            )
+
+            metrics = response[0]  # The first item contains the response data
+            filtered_metrics = "\n".join(
+                line
+                for line in metrics.splitlines()
+                if line.startswith("kubelet_pod_start")
+                or line.startswith("kubelet_runtime_operations")
+                or line.startswith("kubelet_run_podsandbox")
+            )
+            logger.info(f"##[section]Metrics for node: {node_name}") # pylint: disable=logging-too-many-args
+            logger.info(filtered_metrics) # pylint: disable=logging-too-many-args
+
+        except k8s_client.ApiException as e:
+            logger.error(f"Error fetching metrics: {e}")
+
+def collect_clusterloader2(
+    node_count,
+    max_pods,
+    repeats,
+    load_type,
+    cl2_report_dir,
+    cloud_info,
+    run_id,
+    run_url,
+    result_file,
+    scrape_kubelets,
+    registry_info=""
+):
+    if scrape_kubelets:
+        verify_measurement()
+
+    if registry_info:
+        cloud_info = json.dumps({
+            **json.loads(cloud_info or "{}"),
+            "registry": json.loads(registry_info),
+        })
+
+    details = parse_xml_to_json(os.path.join(cl2_report_dir, "junit.xml"), indent = 2)
+    json_data = json.loads(details)
+    testsuites = json_data["testsuites"]
+
+    if testsuites:
+        status = "success" if testsuites[0]["failures"] == 0 else "failure"
+    else:
+        raise Exception(f"No testsuites found in the report! Raw data: {details}")
+
+    template = {
+        "timestamp": datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+        "node_count": node_count,
+        "max_pods": max_pods,
+        "churn_rate": repeats,
+        "load_type": load_type,
+        "status": status,
+        "group": None,
+        "measurement": None,
+        "percentile": None,
+        "data": None,
+        "cloud_info": cloud_info,
+        "run_id": run_id,
+        "run_url": run_url
+    }
+
+    content = ""
+    for f in os.listdir(cl2_report_dir):
+        file_path = os.path.join(cl2_report_dir, f)
+        with open(file_path, 'r', encoding='utf-8') as file:
+            measurement, group_name = get_measurement(file_path)
+            if not measurement:
+                continue
+            logger.info(f"Processing measurement: {measurement}, group: {group_name}")
+            data = json.loads(file.read())
+
+            if measurement == "ResourceUsageSummary":
+                for percentile, items in data.items():
+                    template["measurement"] = measurement
+                    template["group"] = group_name
+                    template["percentile"] = percentile
+                    for item in items:
+                        template["data"] = item
+                        content += json.dumps(template) + "\n"
+            elif "dataItems" in data:
+                items = data["dataItems"]
+                if not items:
+                    logger.info(f"No data items found in {file_path}")
+                    logger.info(f"Data:\n{data}")
+                    continue
+                for item in items:
+                    template["measurement"] = measurement
+                    template["group"] = group_name
+                    template["percentile"] = "dataItems"
+                    template["data"] = item
+                    content += json.dumps(template) + "\n"
+
+    os.makedirs(os.path.dirname(result_file), exist_ok=True)
+    with open(result_file, 'w', encoding='utf-8') as file:
+        file.write(content)
+
+def main():
+    parser = argparse.ArgumentParser(description="CRI Kubernetes resources.")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # Sub-command for override_config_clusterloader2
+    parser_override = subparsers.add_parser("override", help="Override CL2 config file")
+    parser_override.add_argument("--node_count", type=int, help="Number of nodes")
+    parser_override.add_argument(
+        "--node_per_step", type=int, help="Number of nodes to scale per step"
+    )
+    parser_override.add_argument(
+        "--max_pods", type=int, help="Number of maximum pods per node"
+    )
+    parser_override.add_argument(
+        "--repeats",
+        type=int,
+        help="Number of times to repeat the resource consumer deployment",
+    )
+    parser_override.add_argument(
+        "--operation_timeout", type=str, default="2m", help="Operation timeout"
+    )
+    parser_override.add_argument(
+        "--load_type",
+        type=str,
+        choices=["memory", "cpu"],
+        default="memory",
+        help="Type of load to generate",
+    )
+    parser_override.add_argument(
+        "--scale_enabled",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether scale operation is enabled. Must be either True or False",
+    )
+    parser_override.add_argument(
+        "--pod_startup_latency_threshold",
+        type=str,
+        default="15s",
+        help="Pod startup latency threshold",
+    )
+    parser_override.add_argument("--provider", type=str, help="Cloud provider name")
+    parser_override.add_argument(
+        "--os_type", type=str, choices=["linux", "windows"], default="linux"
+    )
+    parser_override.add_argument(
+        "--scrape_kubelets",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape kubelets",
+    )
+    parser_override.add_argument(
+        "--scrape_containerd",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape containerd",
+    )
+    parser_override.add_argument(
+        "--containerd_scrape_interval",
+        type=str,
+        default="15s",
+        help="Containerd scrape interval (e.g., 15s, 30s)",
+    )
+    parser_override.add_argument(
+        "--host_network",
+        type=str2bool,
+        choices=[True, False],
+        default=True,
+        help="Whether to enable host network",
+    )
+    parser_override.add_argument(
+        "--cl2_override_file", type=str, help="Path to the overrides of CL2 config file"
+    )
+    parser_override.add_argument(
+        "--registry_endpoint", type=str, help="Container registry endpoint"
+    )
+    parser_override.add_argument(
+        "--test_image",
+        type=str,
+        default="e2e-test-images/resource-consumer:1.13",
+        help="Test image to pull (relative to registry endpoint)"
+    )
+
+    parser_override.add_argument(
+        "--memory_request_override",
+        type=str,
+        default=None,
+        help="Override memory request per pod (e.g., 100Mi, 1Gi, 500Ki)"
+    )
+
+    # Sub-command for execute_clusterloader2
+    parser_execute = subparsers.add_parser(
+        "execute", help="Execute resource consume operation"
+    )
+    parser_execute.add_argument("--cl2_image", type=str, help="Name of the CL2 image")
+    parser_execute.add_argument(
+        "--cl2_config_dir", type=str, help="Path to the CL2 config directory"
+    )
+    parser_execute.add_argument(
+        "--cl2_report_dir", type=str, help="Path to the CL2 report directory"
+    )
+    parser_execute.add_argument(
+        "--kubeconfig", type=str, help="Path to the kubeconfig file"
+    )
+    parser_execute.add_argument("--provider", type=str, help="Cloud provider name")
+    parser_execute.add_argument(
+        "--scrape_kubelets",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape kubelets",
+    )
+    parser_execute.add_argument(
+        "--scrape_containerd",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape containerd",
+    )
+
+    # Sub-command for collect_clusterloader2
+    parser_collect = subparsers.add_parser(
+        "collect", help="Collect resource consume data"
+    )
+    parser_collect.add_argument("--node_count", type=int, help="Number of nodes")
+    parser_collect.add_argument(
+        "--max_pods", type=int, help="Number of maximum pods per node"
+    )
+    parser_collect.add_argument(
+        "--repeats",
+        type=int,
+        help="Number of times to repeat the resource consumer deployment",
+    )
+    parser_collect.add_argument(
+        "--load_type",
+        type=str,
+        choices=["memory", "cpu"],
+        default="memory",
+        help="Type of load to generate",
+    )
+    parser_collect.add_argument(
+        "--cl2_report_dir", type=str, help="Path to the CL2 report directory"
+    )
+    parser_collect.add_argument("--cloud_info", type=str, help="Cloud information")
+    parser_collect.add_argument("--run_id", type=str, help="Run ID")
+    parser_collect.add_argument("--run_url", type=str, help="Run URL")
+    parser_collect.add_argument(
+        "--result_file", type=str, help="Path to the result file"
+    )
+    parser_collect.add_argument(
+        "--scrape_kubelets",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape kubelets",
+    )
+    parser_collect.add_argument(
+        "--scrape_registry",
+        type=str2bool,
+        choices=[True, False],
+        default=False,
+        help="Whether to scrape container registry information",
+    )
+    parser_collect.add_argument(
+        "--registry_info", type=str, help="Container registry information scraped",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "override":
+        override_config_clusterloader2(
+            args.node_count,
+            args.node_per_step,
+            args.max_pods,
+            args.repeats,
+            args.operation_timeout,
+            args.load_type,
+            args.scale_enabled,
+            args.pod_startup_latency_threshold,
+            args.provider,
+            args.registry_endpoint,
+            args.test_image,
+            args.os_type,
+            args.scrape_kubelets,
+            args.scrape_containerd,
+            args.containerd_scrape_interval,
+            args.host_network,
+            args.cl2_override_file,
+            args.memory_request_override,
+        )
+    elif args.command == "execute":
+        execute_clusterloader2(
+            args.cl2_image,
+            args.cl2_config_dir,
+            args.cl2_report_dir,
+            args.kubeconfig,
+            args.provider,
+            args.scrape_kubelets,
+            args.scrape_containerd,
+        )
+    elif args.command == "collect":
+        collect_clusterloader2(
+            args.node_count,
+            args.max_pods,
+            args.repeats,
+            args.load_type,
+            args.cl2_report_dir,
+            args.cloud_info,
+            args.run_id,
+            args.run_url,
+            args.result_file,
+            args.scrape_kubelets,
+            args.registry_info
+        )
+
+if __name__ == "__main__":
+    main()

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/utils.py
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/utils.py
@@ -1,0 +1,218 @@
+from xml.dom import minidom
+import json
+import os
+import docker
+from clients.docker_client import DockerClient
+from utils.logger_config import get_logger, setup_logging
+
+setup_logging()
+logger = get_logger(__name__)
+
+POD_STARTUP_LATENCY_FILE_PREFIX_MEASUREMENT_MAP = {
+    "PodStartupLatency_PodStartupLatency_": "PodStartupLatency_PodStartupLatency",
+    "StatefulPodStartupLatency_PodStartupLatency_": "StatefulPodStartupLatency_PodStartupLatency",
+    "StatelessPodStartupLatency_PodStartupLatency_": "StatelessPodStartupLatency_PodStartupLatency",
+}
+NETWORK_METRIC_PREFIXES = ["APIResponsivenessPrometheus",
+                           "InClusterNetworkLatency", "NetworkProgrammingLatency"]
+PROM_QUERY_PREFIX = "GenericPrometheusQuery"
+RESOURCE_USAGE_SUMMARY_PREFIX = "ResourceUsageSummary"
+NETWORK_POLICY_SOAK_MEASUREMENT_PREFIX = "NetworkPolicySoakMeasurement"
+JOB_LIFECYCLE_LATENCY_PREFIX = "JobLifecycleLatency"
+SCHEDULING_THROUGHPUT_PROMETHEUS_PREFIX = "SchedulingThroughputPrometheus"
+SCHEDULING_THROUGHPUT_PREFIX = "SchedulingThroughput"
+
+
+def run_cl2_command(kubeconfig, cl2_image, cl2_config_dir, cl2_report_dir, provider, cl2_config_file="config.yaml", overrides=False, enable_prometheus=False, tear_down_prometheus=True,
+                    enable_exec_service=False, scrape_kubelets=False,
+                    scrape_containerd=False, scrape_ksm=False, scrape_metrics_server=False):
+    docker_client = DockerClient()
+
+    command = f"""--provider={provider} --v=2
+--enable-exec-service={enable_exec_service}
+--enable-prometheus-server={enable_prometheus}
+--prometheus-scrape-kubelets={scrape_kubelets}
+--kubeconfig /root/.kube/config
+--testconfig /root/perf-tests/clusterloader2/config/{cl2_config_file}
+--report-dir /root/perf-tests/clusterloader2/results
+--tear-down-prometheus-server={tear_down_prometheus}
+--prometheus-scrape-kube-state-metrics={scrape_ksm}
+--prometheus-scrape-metrics-server={scrape_metrics_server}"""
+
+    if scrape_containerd:
+        command += f" --prometheus-scrape-containerd={scrape_containerd}"
+
+    if overrides:
+        command += " --testoverrides=/root/perf-tests/clusterloader2/config/overrides.yaml"
+
+    volumes = {
+        kubeconfig: {'bind': '/root/.kube/config', 'mode': 'rw'},
+        cl2_config_dir: {'bind': '/root/perf-tests/clusterloader2/config', 'mode': 'rw'},
+        cl2_report_dir: {
+            'bind': '/root/perf-tests/clusterloader2/results', 'mode': 'rw'}
+    }
+
+    if provider == "aws":
+        aws_path = os.path.expanduser("~/.aws/credentials")
+        volumes[aws_path] = {'bind': '/root/.aws/credentials', 'mode': 'rw'}
+
+    if provider == "aks":
+        azure_path = os.path.expanduser("~/.azure")
+        volumes[azure_path] = {'bind': '/root/.azure', 'mode': 'rw'}
+
+    logger.info(
+        f"Running clusterloader2 with command: {command} and volumes: {volumes}")
+    try:
+        container = docker_client.run_container(
+            cl2_image, command, volumes, detach=True)
+        for log in container.logs(stream=True):
+            log_line = log.decode('utf-8').rstrip('\n')
+            if log_line:
+                logger.info(log_line)
+        result = container.wait()
+        exit_code = result['StatusCode']
+        if exit_code != 0:
+            logger.error(
+                f"clusterloader2 exited with a non-zero status code {exit_code}. Make sure to check the logs to confirm whether the error is expected!")
+    except docker.errors.ContainerError as e:
+        logger.error(
+            f"Container exited with a non-zero status code: {e.exit_status}\n{e.stderr.decode('utf-8')}")
+
+
+def get_measurement(file_path):
+    file_name = os.path.basename(file_path)
+    for file_prefix, measurement in POD_STARTUP_LATENCY_FILE_PREFIX_MEASUREMENT_MAP.items():
+        if file_name.startswith(file_prefix):
+            group_name = file_name.split("_")[2]
+            return measurement, group_name
+    for file_prefix in NETWORK_METRIC_PREFIXES:
+        if file_name.startswith(file_prefix):
+            group_name = file_name.split("_")[1]
+            return file_prefix, group_name
+    if file_name.startswith(PROM_QUERY_PREFIX):
+        # Remove "GenericPrometheusQuery " or "GenericPrometheusQuery_" prefix
+        if file_name.startswith(PROM_QUERY_PREFIX + " "):
+            remainder = file_name[len(PROM_QUERY_PREFIX) + 1:]
+        elif file_name.startswith(PROM_QUERY_PREFIX + "_"):
+            remainder = file_name[len(PROM_QUERY_PREFIX) + 1:]
+        else:
+            return None, None
+
+        # Format: <measurement>_<group>_<timestamp>.json
+        # Split on underscore to extract parts
+        parts = remainder.split("_")
+        if len(parts) >= 2:
+            # Find where the group starts (it's the part before the timestamp)
+            # Timestamp format: 2026-02-25T13:51:31Z.json (contains 'T' and 'Z')
+            for i in range(len(parts) - 1, 0, -1):
+                if 'T' in parts[i]:
+                    # Found timestamp, group is parts[i-1]
+                    group_name = parts[i - 1]
+                    # Measurement is everything before the group
+                    measurement_name = "_".join(parts[:i - 1]).rstrip("_")
+                    return measurement_name, group_name
+
+        return None, None
+    if file_name.startswith(JOB_LIFECYCLE_LATENCY_PREFIX):
+        group_name = file_name.split("_")[1]
+        return JOB_LIFECYCLE_LATENCY_PREFIX, group_name
+    if file_name.startswith(RESOURCE_USAGE_SUMMARY_PREFIX):
+        group_name = file_name.split("_")[1]
+        return RESOURCE_USAGE_SUMMARY_PREFIX, group_name
+    if file_name.startswith(NETWORK_POLICY_SOAK_MEASUREMENT_PREFIX):
+        group_name = file_name.split("_")[1]
+        return NETWORK_POLICY_SOAK_MEASUREMENT_PREFIX, group_name
+    if file_name.startswith(SCHEDULING_THROUGHPUT_PROMETHEUS_PREFIX):
+        group_name = file_name.split("_")[1]
+        return SCHEDULING_THROUGHPUT_PROMETHEUS_PREFIX, group_name
+    if file_name.startswith(SCHEDULING_THROUGHPUT_PREFIX):
+        group_name = file_name.split("_")[1]
+        return SCHEDULING_THROUGHPUT_PREFIX, group_name
+    return None, None
+
+def process_cl2_reports(cl2_report_dir, template):
+    content = ""
+    for f in os.listdir(cl2_report_dir):
+        file_path = os.path.join(cl2_report_dir, f)
+        with open(file_path, "r", encoding="utf-8") as file:
+            logger.info(f"Processing {file_path}")
+            measurement, group_name = get_measurement(file_path)
+            if not measurement:
+                continue
+            logger.info(f"Measurement: {measurement}, Group Name: {group_name}")
+            data = json.loads(file.read())
+
+            if "dataItems" in data:
+                items = data["dataItems"]
+                if not items:
+                    logger.info(f"No data items found in {file_path}")
+                    logger.info(f"Data:\n{data}")
+                    continue
+                for item in items:
+                    result = template.copy()
+                    result["group"] = group_name
+                    result["measurement"] = measurement
+                    result["result"] = item
+                    content += json.dumps(result) + "\n"
+            else:
+                result = template.copy()
+                result["group"] = group_name
+                result["measurement"] = measurement
+                result["result"] = data
+                content += json.dumps(result) + "\n"
+    return content
+
+
+def parse_xml_to_json(file_path, indent=0):
+    with open(file_path, 'r', encoding='utf-8') as file:
+        xml_content = file.read()
+
+    dom = minidom.parseString(xml_content)
+
+    result = {
+        "testsuites": []
+    }
+
+    # Extract test suites
+    testsuites = dom.getElementsByTagName("testsuite")
+    for testsuite in testsuites:
+        suite_name = testsuite.getAttribute("name")
+        suite_tests = int(testsuite.getAttribute("tests"))
+        suite_failures = int(testsuite.getAttribute("failures"))
+        suite_errors = int(testsuite.getAttribute("errors"))
+
+        suite_result = {
+            "name": suite_name,
+            "tests": suite_tests,
+            "failures": suite_failures,
+            "errors": suite_errors,
+            "testcases": []
+        }
+
+        # Extract test cases
+        testcases = testsuite.getElementsByTagName("testcase")
+        for testcase in testcases:
+            case_name = testcase.getAttribute("name")
+            case_classname = testcase.getAttribute("classname")
+            case_time = testcase.getAttribute("time")
+
+            case_result = {
+                "name": case_name,
+                "classname": case_classname,
+                "time": case_time,
+                "failure": None
+            }
+
+            # Check for failure
+            failure = testcase.getElementsByTagName("failure")
+            if failure:
+                failure_message = failure[0].firstChild.nodeValue
+                case_result["failure"] = failure_message
+
+            suite_result["testcases"].append(case_result)
+
+        result["testsuites"].append(suite_result)
+
+    # Convert the result dictionary to JSON
+    json_result = json.dumps(result, indent=indent)
+    return json_result

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/pipeline.k
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/pipeline.k
@@ -1,0 +1,758 @@
+import azure_pipelines.ap
+import azure_pipelines.ap.jobs.job
+import azure_pipelines.ap.steps
+import lib.const
+import lib.steps.azure
+import lib.steps.common
+import lib.util
+
+SUBSCRIPTION_ID = "$(AZURE_SUBSCRIPTION_ID)"
+SERVICE_CONNECTION = "$(AZURE_SERVICE_CONNECTION)"
+RESOURCE_GROUP = "$(RUN_ID)"
+LOCATION = "swedencentral"
+CLUSTER = "cri-resource-consume"
+VNET = "cri-vnet"
+SUBNET = "cri-subnet-1"
+NODE_SKU = "Standard_D16ds_v4"
+KUBERNETES_VERSION = "1.33"
+CL2_IMAGE = "ghcr.io/azure/clusterloader2:v20241016"
+ASSET_ROOT = "kcl/perf-eval/cni-benchmark/cni-ab-testing"
+CL2_PYTHON_ROOT = "$(Pipeline.Workspace)/s/${ASSET_ROOT}/assets/python"
+CL2_CONFIG_DIR = "${CL2_PYTHON_ROOT}/clusterloader2/cri/config"
+CL2_REPORT_DIR = "$(Pipeline.Workspace)/cl2-results"
+TEST_RESULTS_FILE = "$(Pipeline.Workspace)/cni-ab-results.jsonl"
+
+JOB_CONDITION = "or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))"
+MANAGED_RESOURCE_CONDITION = "not(\${{ parameters.skip_resource_management }})"
+BYO_RESOURCE_CONDITION = "\${{ parameters.skip_resource_management }}"
+CLEANUP_CONDITION = "and(always(), not(\${{ parameters.skip_resource_management }}), not(and(\${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))"
+SKIP_CLEANUP_CONDITION = "and(always(), not(\${{ parameters.skip_resource_management }}), \${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))"
+
+profileVariables = lambda maxPods: int, operationTimeout: str -> {str:str} {
+    {
+        NODE_COUNT = "10"
+        MAX_PODS = str(maxPods)
+        REPEATS = "1"
+        OPERATION_TIMEOUT = operationTimeout
+        LOAD_TYPE = "memory"
+        SCRAPE_KUBELETS = "True"
+        HOST_NETWORK = "False"
+    }
+}
+
+createAzureClusterStep = lambda variant: str, useCustomHeaders: bool -> steps.Step {
+    customHeaderEnv = {CUSTOM_HEADERS = "$(AKS_CLI_CUSTOM_HEADERS)"} if useCustomHeaders else Undefined
+    customHeaderSetup = """
+ADO_CUSTOM_HEADERS_LITERAL='$'\"(AKS_CLI_CUSTOM_HEADERS)\"
+if [ "\${CUSTOM_HEADERS:-}" != "$ADO_CUSTOM_HEADERS_LITERAL" ] && [ -n "\${CUSTOM_HEADERS:-}" ]; then
+  AKS_CUSTOM_FLAGS+=(--aks-custom-headers "$CUSTOM_HEADERS")
+fi
+""" if useCustomHeaders else ""
+    azure.AzCli(SERVICE_CONNECTION, "Create ${variant} AKS cluster", """
+AKS_CUSTOM_FLAGS=()
+${customHeaderSetup}
+
+SUBNET_ID=$(az network vnet subnet show \
+  --resource-group "${RESOURCE_GROUP}" \
+  --vnet-name "${VNET}" \
+  --name "${SUBNET}" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --query id -o tsv)
+
+az aks create \
+  --name "${CLUSTER}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --location "${LOCATION}" \
+  --kubernetes-version "${KUBERNETES_VERSION}" \
+  --dns-name-prefix "cri" \
+  --tier standard \
+  --nodepool-name default \
+  --node-count 3 \
+  --node-vm-size "${NODE_SKU}" \
+  --node-osdisk-type Ephemeral \
+  --nodepool-taints CriticalAddonsOnly=true:NoSchedule \
+  --max-pods 250 \
+  --network-plugin azure \
+  --network-plugin-mode overlay \
+  --pod-cidr 10.0.0.0/9 \
+  --service-cidr 192.168.0.0/16 \
+  --dns-service-ip 192.168.0.10 \
+  --vnet-subnet-id "$SUBNET_ID" \
+  --enable-managed-identity \
+  --generate-ssh-keys \
+  --tags "run_id=$(RUN_ID)" "role=client" "scenario=perf-eval-cni-ab-testing" "cni_variant=${variant}" \
+  "\${AKS_CUSTOM_FLAGS[@]}" \
+  --no-wait
+""", condition=MANAGED_RESOURCE_CONDITION, env=customHeaderEnv)
+}
+
+createAzureNodePoolsStep = lambda useCustomHeaders: bool -> steps.Step {
+    customHeaderEnv = {CUSTOM_HEADERS = "$(AKS_CLI_CUSTOM_HEADERS)"} if useCustomHeaders else Undefined
+    customHeaderSetup = """
+ADO_CUSTOM_HEADERS_LITERAL='$'\"(AKS_CLI_CUSTOM_HEADERS)\"
+if [ "\${CUSTOM_HEADERS:-}" != "$ADO_CUSTOM_HEADERS_LITERAL" ] && [ -n "\${CUSTOM_HEADERS:-}" ]; then
+  AKS_CUSTOM_HEADER_FLAGS+=(--aks-custom-headers "$CUSTOM_HEADERS")
+fi
+""" if useCustomHeaders else ""
+    azure.AzCli(SERVICE_CONNECTION, "Create CRI benchmark node pools", """
+AKS_CUSTOM_HEADER_FLAGS=()
+${customHeaderSetup}
+
+SUBNET_ID=$(az network vnet subnet show \
+  --resource-group "${RESOURCE_GROUP}" \
+  --vnet-name "${VNET}" \
+  --name "${SUBNET}" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --query id -o tsv)
+
+az aks nodepool add \
+  --cluster-name "${CLUSTER}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --name prompool \
+  --node-count 1 \
+  --node-vm-size "${NODE_SKU}" \
+  --node-osdisk-type Ephemeral \
+  --mode User \
+  --labels prometheus=true \
+  --max-pods 250 \
+  --vnet-subnet-id "$SUBNET_ID" \
+  "\${AKS_CUSTOM_HEADER_FLAGS[@]}"
+
+az aks nodepool add \
+  --cluster-name "${CLUSTER}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --name userpool0 \
+  --node-count 10 \
+  --node-vm-size "${NODE_SKU}" \
+  --node-osdisk-type Ephemeral \
+  --mode User \
+  --labels cri-resource-consume=true \
+  --node-taints cri-resource-consume=true:NoSchedule,cri-resource-consume=true:NoExecute \
+  --max-pods 250 \
+  --vnet-subnet-id "$SUBNET_ID" \
+  "\${AKS_CUSTOM_HEADER_FLAGS[@]}"
+""", condition=MANAGED_RESOURCE_CONDITION, env=customHeaderEnv)
+}
+
+azureResourceSetupSteps = lambda variant: str -> [steps.Step] {
+    [
+        steps.Bash {
+            bash = """
+set -euo pipefail
+CREATION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+DELETION_DUE_TIME=$(date -u -d "+2 hour" +'%Y-%m-%dT%H:%M:%SZ')
+echo "##vso[task.setvariable variable=CREATION_DATE]$CREATION_DATE"
+echo "##vso[task.setvariable variable=DELETION_DUE_TIME]$DELETION_DUE_TIME"
+echo "##vso[task.setvariable variable=OWNER]aks"
+"""
+            displayName = "Set resource lifecycle tags"
+            condition = MANAGED_RESOURCE_CONDITION
+        }
+        azure.AzCli(SERVICE_CONNECTION, "Create benchmark resource group", """
+az group create \
+  --name "${RESOURCE_GROUP}" \
+  --location "${LOCATION}" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --tags \
+"run_id=$(RUN_ID)" \
+"scenario=perf-eval-cni-ab-testing" \
+"owner=aks" \
+"creation_date=$(CREATION_DATE)" \
+"deletion_due_time=$(DELETION_DUE_TIME)" \
+"SkipAKSCluster=1" \
+"SkipASB_Audit=true" \
+"cni_variant=${variant}"
+""", condition=MANAGED_RESOURCE_CONDITION)
+        azure.AzCli(SERVICE_CONNECTION, "Create CRI benchmark network", """
+az network vnet create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${VNET}" \
+  --address-prefixes 10.0.0.0/9 \
+  --subscription "${SUBSCRIPTION_ID}"
+az network vnet subnet create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --vnet-name "${VNET}" \
+  --name "${SUBNET}" \
+  --address-prefixes 10.0.0.0/16 \
+  --subscription "${SUBSCRIPTION_ID}"
+""", condition=MANAGED_RESOURCE_CONDITION)
+    ]
+}
+
+waitForAzureClusterStep = lambda -> steps.Step {
+    azure.AzCli(SERVICE_CONNECTION, "Wait for AKS cluster to succeed", """
+while true; do
+  STATE=$(az aks show \
+--name "${CLUSTER}" \
+--resource-group "${RESOURCE_GROUP}" \
+--subscription "${SUBSCRIPTION_ID}" \
+--query provisioningState -o tsv)
+  echo "AKS provisioning state: $STATE"
+  case "$STATE" in
+Succeeded) break ;;
+Failed|Canceled) exit 1 ;;
+  esac
+  sleep 30
+done
+""", condition=MANAGED_RESOURCE_CONDITION)
+}
+
+waitForAzureNodePoolsStep = lambda -> steps.Step {
+    azure.AzCli(SERVICE_CONNECTION, "Wait for AKS node pools to succeed", """
+for POOL in prompool userpool0; do
+  while true; do
+STATE=$(az aks nodepool show \
+  --cluster-name "${CLUSTER}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --name "$POOL" \
+  --query provisioningState -o tsv)
+echo "Node pool $POOL provisioning state: $STATE"
+case "$STATE" in
+  Succeeded) break ;;
+  Failed|Canceled) exit 1 ;;
+esac
+sleep 30
+  done
+done
+""", condition=MANAGED_RESOURCE_CONDITION)
+}
+
+azureCredentialsSteps = lambda -> [steps.Step] {
+    [
+        azure.AzCli(SERVICE_CONNECTION, "Get managed AKS credentials", """
+az aks get-credentials \
+  --name "${CLUSTER}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --overwrite-existing
+""", condition=MANAGED_RESOURCE_CONDITION)
+        azure.AzCli(SERVICE_CONNECTION, "Validate OWNER and get BYO AKS credentials", """
+set -euo pipefail
+OWNER="\${{ parameters.owner }}"
+CLUSTER_NAME="\${{ parameters.byo_azure_cluster_name }}"
+CLUSTER_RESOURCE_GROUP="\${{ parameters.byo_azure_resource_group }}"
+if [ -z "$OWNER" ]; then
+  echo "##vso[task.logissue type=error;] OWNER is not set."
+  exit 1
+fi
+if [ -z "$CLUSTER_NAME" ] || [ -z "$CLUSTER_RESOURCE_GROUP" ]; then
+  echo "##vso[task.logissue type=error;] BYO Azure cluster name and resource group are required."
+  exit 1
+fi
+echo "##vso[task.setvariable variable=OWNER]$OWNER"
+az aks get-credentials \
+  --name "$CLUSTER_NAME" \
+  --resource-group "$CLUSTER_RESOURCE_GROUP" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --overwrite-existing
+""", condition=BYO_RESOURCE_CONDITION)
+    ]
+}
+
+validateNodesStep = lambda -> steps.Step {
+    steps.Bash {
+        bash = """
+set -euo pipefail
+
+deadline=$((SECONDS + 600))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+  ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+  echo "Cluster nodes: $ready/$total Ready; expected 14"
+  if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+    kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+    exit 0
+  fi
+  sleep 30
+done
+
+echo "Expected exactly 14 Ready nodes within 10 minutes."
+kubectl get nodes -o wide
+exit 1
+"""
+        displayName = "Validate 14 Ready nodes"
+        timeoutInMinutes = 11
+    }
+}
+
+cloudInfoStep = lambda cloud: str, region: str, variant: str -> steps.Step {
+    result = azure.AzCli(SERVICE_CONNECTION, "Collect AKS cloud info", """
+CLUSTER_NAME="${CLUSTER}"
+CLUSTER_RESOURCE_GROUP="${RESOURCE_GROUP}"
+BYO="\${{ parameters.skip_resource_management }}"
+if [ "\${BYO,,}" = "true" ]; then
+  CLUSTER_NAME="\${{ parameters.byo_azure_cluster_name }}"
+  CLUSTER_RESOURCE_GROUP="\${{ parameters.byo_azure_resource_group }}"
+fi
+AKS_INFO=$(az aks show \
+  --resource-group "$CLUSTER_RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --output json)
+CLOUD_INFO=$(echo "$AKS_INFO" | jq -c \
+  --arg variant "${variant}" \
+  '{cloud:"azure", region:.location, cluster:.name, kubernetes_version:.currentKubernetesVersion, sku_tier:.sku.tier, network_profile:.networkProfile, cni_variant:$variant}')
+echo "Cloud info: $CLOUD_INFO"
+echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+""") if cloud == "azure" else steps.Bash {
+        bash = """
+set -euo pipefail
+CLUSTER_NAME="$(RUN_ID)"
+BYO="\${{ parameters.skip_resource_management }}"
+if [ "\${BYO,,}" = "true" ]; then
+  CLUSTER_NAME="\${{ parameters.byo_aws_cluster_name }}"
+fi
+EKS_INFO=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "${region}")
+CLOUD_INFO=$(echo "$EKS_INFO" | jq -c '{cloud:"aws", region:.cluster.arn | split(":")[3], cluster:.cluster.name, kubernetes_version:.cluster.version}')
+echo "Cloud info: $CLOUD_INFO"
+echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+"""
+        displayName = "Collect EKS cloud info"
+    }
+    result
+}
+
+benchmarkSteps = lambda cloud: str, region: str, variant: str -> [steps.Step] {
+    provider = "aks" if cloud == "azure" else "aws"
+    registry = "akscritelescope.azurecr.io"
+    resultJson = """{
+    "status": "\${STATUS}",
+    "scenario_type": "perf-eval",
+    "scenario_name": "cni-ab-testing",
+    "owner": "\${{ parameters.owner }}",
+    "engine": "clusterloader2",
+    "topology": "cri-resource-consume",
+    "engine_input": {"image": "${CL2_IMAGE}"},
+    "byo_resources": "\${{ parameters.skip_resource_management }}",
+    "cloud": "${cloud}",
+    "region": "${region}",
+    "cni_variant": "${variant}",
+    "node_count": 10,
+    "max_pods": $(MAX_PODS),
+    "repeats": 1,
+    "load_type": "memory",
+    "host_network": false,
+    "scrape_kubelets": true,
+    "measurements": \${MEASUREMENTS}
+  }"""
+    [
+        steps.Bash {
+            bash = """
+set -euo pipefail
+
+rm -rf "$CL2_REPORT_DIR"
+mkdir -p "$CL2_REPORT_DIR"
+rm -f "$TEST_RESULTS_FILE"
+
+PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" \
+python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override \
+  --node_count "$NODE_COUNT" \
+  --node_per_step "$NODE_COUNT" \
+  --max_pods "$MAX_PODS" \
+  --repeats "$REPEATS" \
+  --operation_timeout "$OPERATION_TIMEOUT" \
+  --load_type "$LOAD_TYPE" \
+  --scale_enabled False \
+  --pod_startup_latency_threshold 15s \
+  --provider "${provider}" \
+  --registry_endpoint "${registry}" \
+  --test_image e2e-test-images/resource-consumer:1.13 \
+  --os_type linux \
+  --scrape_kubelets "$SCRAPE_KUBELETS" \
+  --scrape_containerd False \
+  --containerd_scrape_interval 15s \
+  --host_network "$HOST_NETWORK" \
+  --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" \
+python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute \
+  --cl2_image "$CL2_IMAGE" \
+  --cl2_config_dir "$CL2_CONFIG_DIR" \
+  --cl2_report_dir "$CL2_REPORT_DIR" \
+  --kubeconfig "$HOME/.kube/config" \
+  --provider "${provider}" \
+  --scrape_kubelets "$SCRAPE_KUBELETS" \
+  --scrape_containerd False
+"""
+            displayName = "Run ClusterLoader2 CRI benchmark"
+            env = {
+                CL2_PYTHON_ROOT = CL2_PYTHON_ROOT
+                CL2_CONFIG_DIR = CL2_CONFIG_DIR
+                CL2_REPORT_DIR = CL2_REPORT_DIR
+                TEST_RESULTS_FILE = TEST_RESULTS_FILE
+                CL2_IMAGE = CL2_IMAGE
+            }
+        }
+        cloudInfoStep(cloud, region, variant)
+        steps.Bash {
+            bash = """
+set -euo pipefail
+
+PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" \
+python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect \
+  --node_count "$NODE_COUNT" \
+  --max_pods "$MAX_PODS" \
+  --repeats "$REPEATS" \
+  --load_type "$LOAD_TYPE" \
+  --cl2_report_dir "$CL2_REPORT_DIR" \
+  --cloud_info "$CLOUD_INFO" \
+  --run_id "$(RUN_ID)" \
+  --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" \
+  --result_file "$TEST_RESULTS_FILE" \
+  --scrape_kubelets "$SCRAPE_KUBELETS" \
+  --registry_info ""
+"""
+            displayName = "Collect ClusterLoader2 results"
+            env = {
+                CL2_PYTHON_ROOT = CL2_PYTHON_ROOT
+                CL2_REPORT_DIR = CL2_REPORT_DIR
+                TEST_RESULTS_FILE = TEST_RESULTS_FILE
+            }
+        }
+        azure.AzCli(SERVICE_CONNECTION, "Build Telescope result", """
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+if [ -s "${TEST_RESULTS_FILE}" ]; then
+  MEASUREMENTS=$(jq -s '.' "${TEST_RESULTS_FILE}")
+  FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+else
+  MEASUREMENTS='[]'
+  FAILED=1
+fi
+STATUS="succeeded"
+if [ "$FAILED" -gt 0 ]; then
+  STATUS="failed"
+fi
+cat > /tmp/run-result.json << EOF
+${util.formatResult(resultJson)}
+EOF
+jq . /tmp/run-result.json
+""")
+        common.UploadResult(SERVICE_CONNECTION, const.DEFAULT_STORAGE_ACCOUNT, const.DEFAULT_STORAGE_SUBSCRIPTION_ID, const.DEFAULT_STORAGE_CONTAINER)
+    ]
+}
+
+azureCleanupSteps = lambda -> [steps.Step] {
+    [
+        steps.Bash {
+            bash = """
+echo "##vso[task.logissue type=warning;] Resource deletion was skipped for this manual run."
+echo "Delete manually with: az group delete --name $(RUN_ID) --subscription ${SUBSCRIPTION_ID} --yes"
+"""
+            displayName = "Report skipped cleanup"
+            condition = SKIP_CLEANUP_CONDITION
+        }
+        azure.DeleteResourceGroup(SERVICE_CONNECTION, RESOURCE_GROUP, SUBSCRIPTION_ID, condition=CLEANUP_CONDITION)
+    ]
+}
+
+makeAzureJob = lambda {
+    jobName: str,
+    variant: str,
+    useCustomHeaders: bool,
+    maxPods: int,
+    operationTimeout: str,
+} -> job.Job {
+    job.Job {
+        job = jobName
+        displayName = "${variant}: 10 nodes x ${maxPods} pods"
+        timeoutInMinutes = 120
+        condition = JOB_CONDITION
+        variables = profileVariables(maxPods, operationTimeout)
+        steps = [
+            common.SetRunId()
+            common.InstallPythonDependencies()
+            azure.Login(SERVICE_CONNECTION, SUBSCRIPTION_ID, LOCATION)
+        ] + azureResourceSetupSteps(variant) + [
+            createAzureClusterStep(variant, useCustomHeaders)
+            waitForAzureClusterStep()
+            createAzureNodePoolsStep(useCustomHeaders)
+            waitForAzureNodePoolsStep()
+        ] + azureCredentialsSteps() + [
+            validateNodesStep()
+        ] + benchmarkSteps("azure", LOCATION, variant) + azureCleanupSteps()
+    }
+}
+
+awsLoginSteps = lambda region: str -> [steps.Step] {
+    [
+        steps.Task {
+            task = "AWSShellScript@1"
+            inputs = {
+                awsCredentials = "\${{ parameters.aws_service_connection }}"
+                regionName = region
+                scriptType = "inline"
+                inlineScript = """
+echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
+echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
+if [ -n "\${AWS_SESSION_TOKEN:-}" ]; then
+  echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
+fi
+"""
+            }
+            displayName = "Get AWS credentials"
+        }
+        steps.Bash {
+            bash = """
+set -euo pipefail
+mkdir -p "$HOME/.aws"
+aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+ADO_LITERAL='$'"(AWS_SESSION_TOKEN)"
+if [ "\${AWS_SESSION_TOKEN:-}" = "$ADO_LITERAL" ]; then
+  AWS_SESSION_TOKEN=""
+fi
+if [ -n "\${AWS_SESSION_TOKEN:-}" ]; then
+  aws configure set aws_session_token "$AWS_SESSION_TOKEN"
+fi
+aws configure set default.region "${region}"
+aws sts get-caller-identity
+"""
+            displayName = "Configure AWS CLI"
+            env = {
+                AWS_ACCESS_KEY_ID = "$(AWS_ACCESS_KEY_ID)"
+                AWS_SECRET_ACCESS_KEY = "$(AWS_SECRET_ACCESS_KEY)"
+                AWS_SESSION_TOKEN = "$(AWS_SESSION_TOKEN)"
+            }
+        }
+    ]
+}
+
+createEksStep = lambda region: str -> steps.Step {
+    steps.Bash {
+        bash = """
+set -euo pipefail
+
+if ! command -v eksctl >/dev/null 2>&1; then
+  version="0.215.0"
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64) arch=amd64 ;;
+    aarch64) arch=arm64 ;;
+    *) echo "Unsupported architecture: $arch"; exit 1 ;;
+  esac
+  curl -fsSL "https://github.com/eksctl-io/eksctl/releases/download/v\${version}/eksctl_Linux_\${arch}.tar.gz" |
+    tar -xz -C /tmp
+  sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
+fi
+eksctl version
+
+cat > "$(Pipeline.Workspace)/eksctl-cni-ab.yaml" << EOF
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: $(RUN_ID)
+  region: ${region}
+  version: "${KUBERNETES_VERSION}"
+vpc:
+  cidr: 10.0.0.0/16
+  nat:
+    gateway: Single
+managedNodeGroups:
+  - name: default
+    instanceType: m5.4xlarge
+    desiredCapacity: 3
+    minSize: 3
+    maxSize: 3
+    amiFamily: AmazonLinux2023
+    privateNetworking: false
+  - name: prompool
+    instanceType: m5.4xlarge
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 1
+    amiFamily: AmazonLinux2023
+    privateNetworking: false
+    labels:
+      prometheus: "true"
+  - name: userpool0
+    instanceType: m5.4xlarge
+    desiredCapacity: 10
+    minSize: 10
+    maxSize: 10
+    amiFamily: AmazonLinux2023
+    privateNetworking: false
+    labels:
+      cri-resource-consume: "true"
+      agentpool: userpool0
+    taints:
+      - key: cri-resource-consume
+        value: "true"
+        effect: NoSchedule
+      - key: cri-resource-consume
+        value: "true"
+        effect: NoExecute
+addons:
+  - name: coredns
+  - name: vpc-cni
+  - name: kube-proxy
+EOF
+
+eksctl create cluster --config-file "$(Pipeline.Workspace)/eksctl-cni-ab.yaml"
+aws eks update-kubeconfig --name "$(RUN_ID)" --region "${region}"
+"""
+        displayName = "Create EKS benchmark cluster"
+        condition = MANAGED_RESOURCE_CONDITION
+    }
+}
+
+awsByoCredentialsStep = lambda region: str -> steps.Step {
+    steps.Bash {
+        bash = """
+set -euo pipefail
+OWNER="\${{ parameters.owner }}"
+CLUSTER_NAME="\${{ parameters.byo_aws_cluster_name }}"
+if [ -z "$OWNER" ]; then
+  echo "##vso[task.logissue type=error;] OWNER is not set."
+  exit 1
+fi
+if [ -z "$CLUSTER_NAME" ]; then
+  echo "##vso[task.logissue type=error;] BYO AWS cluster name is required."
+  exit 1
+fi
+echo "##vso[task.setvariable variable=OWNER]$OWNER"
+aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "${region}"
+"""
+        displayName = "Validate OWNER and get BYO EKS credentials"
+        condition = BYO_RESOURCE_CONDITION
+    }
+}
+
+awsCleanupSteps = lambda region: str -> [steps.Step] {
+    [
+        steps.Bash {
+            bash = """
+echo "##vso[task.logissue type=warning;] EKS deletion was skipped for this manual run."
+echo "Delete manually with: eksctl delete cluster --name $(RUN_ID) --region ${region}"
+"""
+            displayName = "Report skipped cleanup"
+            condition = SKIP_CLEANUP_CONDITION
+        }
+        steps.Bash {
+            bash = """
+set -euo pipefail
+eksctl delete cluster --name "$(RUN_ID)" --region "${region}" --wait
+"""
+            displayName = "Delete EKS benchmark cluster"
+            condition = CLEANUP_CONDITION
+        }
+    ]
+}
+
+makeAwsJob = lambda jobName: str, maxPods: int, operationTimeout: str -> job.Job {
+    region = "eu-west-1"
+    job.Job {
+        job = jobName
+        displayName = "aws: 10 nodes x ${maxPods} pods"
+        timeoutInMinutes = 120
+        condition = JOB_CONDITION
+        variables = profileVariables(maxPods, operationTimeout)
+        steps = [
+            common.SetRunId()
+            common.InstallPythonDependencies()
+        ] + awsLoginSteps(region) + [
+            createEksStep(region)
+            awsByoCredentialsStep(region)
+            validateNodesStep()
+        ] + benchmarkSteps("aws", region, "aws-vpc-cni") + awsCleanupSteps(region)
+    }
+}
+
+output = ap.Pipeline {
+    name = "CNI AB Testing"
+    trigger = "none"
+    pool = const.DEFAULT_POOL
+    parameters = [
+        ap.Parameter {
+            name = "aws_service_connection"
+            displayName = "AWS service connection"
+            type = "string"
+            default = "AWS-for-Telescope"
+        }
+        ap.Parameter {
+            name = "skip_resource_management"
+            displayName = "Use an existing cluster"
+            type = "boolean"
+            default = False
+        }
+        ap.Parameter {
+            name = "skip_resource_deletion"
+            displayName = "Keep resources after a manual run"
+            type = "boolean"
+            default = False
+        }
+        ap.Parameter {
+            name = "owner"
+            displayName = "Resource owner"
+            type = "string"
+            default = "aks"
+        }
+        ap.Parameter {
+            name = "byo_azure_cluster_name"
+            displayName = "Existing AKS cluster name"
+            type = "string"
+            default = ""
+        }
+        ap.Parameter {
+            name = "byo_azure_resource_group"
+            displayName = "Existing AKS resource group"
+            type = "string"
+            default = ""
+        }
+        ap.Parameter {
+            name = "byo_aws_cluster_name"
+            displayName = "Existing EKS cluster name"
+            type = "string"
+            default = ""
+        }
+    ]
+    schedules = [ap.Cron {
+        cron = "0 1-23/4 * * *"
+        displayName = "Every 4 Hour (1AM start)"
+        branches = {include = ["main"]}
+        always = True
+    }]
+    variables = {
+        SCENARIO_TYPE = "perf-eval"
+        SCENARIO_NAME = "cni-ab-testing"
+        AZURE_SERVICE_CONNECTION = const.DEFAULT_SERVICE_CONNECTION
+        AZURE_SUBSCRIPTION_ID = const.DEFAULT_SUBSCRIPTION_ID
+        AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME = const.DEFAULT_STORAGE_ACCOUNT
+    }
+    stages = [
+        ap.Stage {
+            stage = "azure_swedencentral_default"
+            displayName = "Default-CNI custom configuration"
+            dependsOn = []
+            variables = [ap.Group {group = "Default-CNI"}]
+            jobs = [
+                makeAzureJob("default_n10_p300_memory", "default", True, 30, "3m")
+                makeAzureJob("default_n10_p700_memory", "default", True, 70, "7m")
+                makeAzureJob("default_n10_p1100_memory", "default", True, 110, "11m")
+            ]
+        }
+        ap.Stage {
+            stage = "azure_swedencentral_stateless"
+            displayName = "Stock Azure CNI Overlay"
+            dependsOn = []
+            jobs = [
+                makeAzureJob("stateless_n10_p300_memory", "stateless", False, 30, "3m")
+                makeAzureJob("stateless_n10_p700_memory", "stateless", False, 70, "7m")
+                makeAzureJob("stateless_n10_p1100_memory", "stateless", False, 110, "11m")
+            ]
+        }
+        ap.Stage {
+            stage = "aws_westeurope"
+            displayName = "AWS VPC CNI"
+            dependsOn = []
+            jobs = [
+                makeAwsJob("aws_n10_p300_memory", 30, "3m")
+                makeAwsJob("aws_n10_p700_memory", 70, "7m")
+                makeAwsJob("aws_n10_p1100_memory", 110, "11m")
+            ]
+        }
+    ]
+}

--- a/kcl/perf-eval/cni-benchmark/cni-ab-testing/pipeline.yaml
+++ b/kcl/perf-eval/cni-benchmark/cni-ab-testing/pipeline.yaml
@@ -1,0 +1,2820 @@
+name: CNI AB Testing
+pool: AKS-Telescope-Airlock
+trigger: none
+parameters:
+- name: aws_service_connection
+  displayName: AWS service connection
+  type: string
+  default: AWS-for-Telescope
+- name: skip_resource_management
+  displayName: Use an existing cluster
+  type: boolean
+  default: false
+- name: skip_resource_deletion
+  displayName: Keep resources after a manual run
+  type: boolean
+  default: false
+- name: owner
+  displayName: Resource owner
+  type: string
+  default: aks
+- name: byo_azure_cluster_name
+  displayName: Existing AKS cluster name
+  type: string
+  default: ''
+- name: byo_azure_resource_group
+  displayName: Existing AKS resource group
+  type: string
+  default: ''
+- name: byo_aws_cluster_name
+  displayName: Existing EKS cluster name
+  type: string
+  default: ''
+schedules:
+- cron: '0 1-23/4 * * *'
+  displayName: Every 4 Hour (1AM start)
+  branches:
+    include:
+    - main
+  always: true
+variables:
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: cni-ab-testing
+  AZURE_SERVICE_CONNECTION: Azure-for-Telescope-internal
+  AZURE_SUBSCRIPTION_ID: b8ceb4e5-f05b-4562-a9f5-14acb1f24219
+  AZURE_TELESCOPE_STORAGE_ACCOUNT_NAME: telescopev2
+stages:
+- stage: azure_swedencentral_default
+  displayName: Default-CNI custom configuration
+  dependsOn: []
+  variables:
+  - group: Default-CNI
+  jobs:
+  - job: default_n10_p300_memory
+    displayName: 'default: 10 nodes x 30 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '30'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '3m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az account set --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az config set defaults.location="swedencentral"
+          az account show
+      displayName: Login to Azure
+    - bash: |
+        set -euo pipefail
+        CREATION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        DELETION_DUE_TIME=$(date -u -d "+2 hour" +'%Y-%m-%dT%H:%M:%SZ')
+        echo "##vso[task.setvariable variable=CREATION_DATE]$CREATION_DATE"
+        echo "##vso[task.setvariable variable=DELETION_DUE_TIME]$DELETION_DUE_TIME"
+        echo "##vso[task.setvariable variable=OWNER]aks"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Set resource lifecycle tags
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group create   --name "$(RUN_ID)"   --location "swedencentral"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --tags "run_id=$(RUN_ID)" "scenario=perf-eval-cni-ab-testing" "owner=aks" "creation_date=$(CREATION_DATE)" "deletion_due_time=$(DELETION_DUE_TIME)" "SkipAKSCluster=1" "SkipASB_Audit=true" "cni_variant=default"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create benchmark resource group
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az network vnet create   --resource-group "$(RUN_ID)"   --name "cri-vnet"   --address-prefixes 10.0.0.0/9   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az network vnet subnet create   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --address-prefixes 10.0.0.0/16   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark network
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_FLAGS=()
+          ADO_CUSTOM_HEADERS_LITERAL='$'"(AKS_CLI_CUSTOM_HEADERS)"
+          if [ "${CUSTOM_HEADERS:-}" != "$ADO_CUSTOM_HEADERS_LITERAL" ] && [ -n "${CUSTOM_HEADERS:-}" ]; then
+            AKS_CUSTOM_FLAGS+=(--aks-custom-headers "$CUSTOM_HEADERS")
+          fi
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks create   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --location "swedencentral"   --kubernetes-version "1.33"   --dns-name-prefix "cri"   --tier standard   --nodepool-name default   --node-count 3   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --nodepool-taints CriticalAddonsOnly=true:NoSchedule   --max-pods 250   --network-plugin azure   --network-plugin-mode overlay   --pod-cidr 10.0.0.0/9   --service-cidr 192.168.0.0/16   --dns-service-ip 192.168.0.10   --vnet-subnet-id "$SUBNET_ID"   --enable-managed-identity   --generate-ssh-keys   --tags "run_id=$(RUN_ID)" "role=client" "scenario=perf-eval-cni-ab-testing" "cni_variant=default"   "${AKS_CUSTOM_FLAGS[@]}"   --no-wait
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create default AKS cluster
+      env:
+        CUSTOM_HEADERS: $(AKS_CLI_CUSTOM_HEADERS)
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          while true; do
+            STATE=$(az aks show --name "cri-resource-consume" --resource-group "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --query provisioningState -o tsv)
+            echo "AKS provisioning state: $STATE"
+            case "$STATE" in
+          Succeeded) break ;;
+          Failed|Canceled) exit 1 ;;
+            esac
+            sleep 30
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS cluster to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_HEADER_FLAGS=()
+          ADO_CUSTOM_HEADERS_LITERAL='$'"(AKS_CLI_CUSTOM_HEADERS)"
+          if [ "${CUSTOM_HEADERS:-}" != "$ADO_CUSTOM_HEADERS_LITERAL" ] && [ -n "${CUSTOM_HEADERS:-}" ]; then
+            AKS_CUSTOM_HEADER_FLAGS+=(--aks-custom-headers "$CUSTOM_HEADERS")
+          fi
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name prompool   --node-count 1   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels prometheus=true   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name userpool0   --node-count 10   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels cri-resource-consume=true   --node-taints cri-resource-consume=true:NoSchedule,cri-resource-consume=true:NoExecute   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark node pools
+      env:
+        CUSTOM_HEADERS: $(AKS_CLI_CUSTOM_HEADERS)
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          for POOL in prompool userpool0; do
+            while true; do
+          STATE=$(az aks nodepool show   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name "$POOL"   --query provisioningState -o tsv)
+          echo "Node pool $POOL provisioning state: $STATE"
+          case "$STATE" in
+            Succeeded) break ;;
+            Failed|Canceled) exit 1 ;;
+          esac
+          sleep 30
+            done
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS node pools to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az aks get-credentials   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Get managed AKS credentials
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          set -euo pipefail
+          OWNER="${{ parameters.owner }}"
+          CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+          CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          if [ -z "$OWNER" ]; then
+            echo "##vso[task.logissue type=error;] OWNER is not set."
+            exit 1
+          fi
+          if [ -z "$CLUSTER_NAME" ] || [ -z "$CLUSTER_RESOURCE_GROUP" ]; then
+            echo "##vso[task.logissue type=error;] BYO Azure cluster name and resource group are required."
+            exit 1
+          fi
+          echo "##vso[task.setvariable variable=OWNER]$OWNER"
+          az aks get-credentials   --name "$CLUSTER_NAME"   --resource-group "$CLUSTER_RESOURCE_GROUP"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO AKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aks"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aks"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          CLUSTER_NAME="cri-resource-consume"
+          CLUSTER_RESOURCE_GROUP="$(RUN_ID)"
+          BYO="${{ parameters.skip_resource_management }}"
+          if [ "${BYO,,}" = "true" ]; then
+            CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+            CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          fi
+          AKS_INFO=$(az aks show   --resource-group "$CLUSTER_RESOURCE_GROUP"   --name "$CLUSTER_NAME"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --output json)
+          CLOUD_INFO=$(echo "$AKS_INFO" | jq -c   --arg variant "default"   '{cloud:"azure", region:.location, cluster:.name, kubernetes_version:.currentKubernetesVersion, sku_tier:.sku.tier, network_profile:.networkProfile, cni_variant:$variant}')
+          echo "Cloud info: $CLOUD_INFO"
+          echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect AKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "azure",
+              "region": "swedencentral",
+              "cni_variant": "default",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] Resource deletion was skipped for this manual run."
+        echo "Delete manually with: az group delete --name $(RUN_ID) --subscription $(AZURE_SUBSCRIPTION_ID) --yes"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group delete --name "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --yes
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete resource group ($(AZURE_SUBSCRIPTION_ID))
+  - job: default_n10_p700_memory
+    displayName: 'default: 10 nodes x 70 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '70'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '7m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az account set --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az config set defaults.location="swedencentral"
+          az account show
+      displayName: Login to Azure
+    - bash: |
+        set -euo pipefail
+        CREATION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        DELETION_DUE_TIME=$(date -u -d "+2 hour" +'%Y-%m-%dT%H:%M:%SZ')
+        echo "##vso[task.setvariable variable=CREATION_DATE]$CREATION_DATE"
+        echo "##vso[task.setvariable variable=DELETION_DUE_TIME]$DELETION_DUE_TIME"
+        echo "##vso[task.setvariable variable=OWNER]aks"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Set resource lifecycle tags
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group create   --name "$(RUN_ID)"   --location "swedencentral"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --tags "run_id=$(RUN_ID)" "scenario=perf-eval-cni-ab-testing" "owner=aks" "creation_date=$(CREATION_DATE)" "deletion_due_time=$(DELETION_DUE_TIME)" "SkipAKSCluster=1" "SkipASB_Audit=true" "cni_variant=default"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create benchmark resource group
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az network vnet create   --resource-group "$(RUN_ID)"   --name "cri-vnet"   --address-prefixes 10.0.0.0/9   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az network vnet subnet create   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --address-prefixes 10.0.0.0/16   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark network
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_FLAGS=()
+          ADO_CUSTOM_HEADERS_LITERAL='$'"(AKS_CLI_CUSTOM_HEADERS)"
+          if [ "${CUSTOM_HEADERS:-}" != "$ADO_CUSTOM_HEADERS_LITERAL" ] && [ -n "${CUSTOM_HEADERS:-}" ]; then
+            AKS_CUSTOM_FLAGS+=(--aks-custom-headers "$CUSTOM_HEADERS")
+          fi
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks create   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --location "swedencentral"   --kubernetes-version "1.33"   --dns-name-prefix "cri"   --tier standard   --nodepool-name default   --node-count 3   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --nodepool-taints CriticalAddonsOnly=true:NoSchedule   --max-pods 250   --network-plugin azure   --network-plugin-mode overlay   --pod-cidr 10.0.0.0/9   --service-cidr 192.168.0.0/16   --dns-service-ip 192.168.0.10   --vnet-subnet-id "$SUBNET_ID"   --enable-managed-identity   --generate-ssh-keys   --tags "run_id=$(RUN_ID)" "role=client" "scenario=perf-eval-cni-ab-testing" "cni_variant=default"   "${AKS_CUSTOM_FLAGS[@]}"   --no-wait
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create default AKS cluster
+      env:
+        CUSTOM_HEADERS: $(AKS_CLI_CUSTOM_HEADERS)
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          while true; do
+            STATE=$(az aks show --name "cri-resource-consume" --resource-group "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --query provisioningState -o tsv)
+            echo "AKS provisioning state: $STATE"
+            case "$STATE" in
+          Succeeded) break ;;
+          Failed|Canceled) exit 1 ;;
+            esac
+            sleep 30
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS cluster to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_HEADER_FLAGS=()
+          ADO_CUSTOM_HEADERS_LITERAL='$'"(AKS_CLI_CUSTOM_HEADERS)"
+          if [ "${CUSTOM_HEADERS:-}" != "$ADO_CUSTOM_HEADERS_LITERAL" ] && [ -n "${CUSTOM_HEADERS:-}" ]; then
+            AKS_CUSTOM_HEADER_FLAGS+=(--aks-custom-headers "$CUSTOM_HEADERS")
+          fi
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name prompool   --node-count 1   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels prometheus=true   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name userpool0   --node-count 10   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels cri-resource-consume=true   --node-taints cri-resource-consume=true:NoSchedule,cri-resource-consume=true:NoExecute   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark node pools
+      env:
+        CUSTOM_HEADERS: $(AKS_CLI_CUSTOM_HEADERS)
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          for POOL in prompool userpool0; do
+            while true; do
+          STATE=$(az aks nodepool show   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name "$POOL"   --query provisioningState -o tsv)
+          echo "Node pool $POOL provisioning state: $STATE"
+          case "$STATE" in
+            Succeeded) break ;;
+            Failed|Canceled) exit 1 ;;
+          esac
+          sleep 30
+            done
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS node pools to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az aks get-credentials   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Get managed AKS credentials
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          set -euo pipefail
+          OWNER="${{ parameters.owner }}"
+          CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+          CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          if [ -z "$OWNER" ]; then
+            echo "##vso[task.logissue type=error;] OWNER is not set."
+            exit 1
+          fi
+          if [ -z "$CLUSTER_NAME" ] || [ -z "$CLUSTER_RESOURCE_GROUP" ]; then
+            echo "##vso[task.logissue type=error;] BYO Azure cluster name and resource group are required."
+            exit 1
+          fi
+          echo "##vso[task.setvariable variable=OWNER]$OWNER"
+          az aks get-credentials   --name "$CLUSTER_NAME"   --resource-group "$CLUSTER_RESOURCE_GROUP"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO AKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aks"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aks"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          CLUSTER_NAME="cri-resource-consume"
+          CLUSTER_RESOURCE_GROUP="$(RUN_ID)"
+          BYO="${{ parameters.skip_resource_management }}"
+          if [ "${BYO,,}" = "true" ]; then
+            CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+            CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          fi
+          AKS_INFO=$(az aks show   --resource-group "$CLUSTER_RESOURCE_GROUP"   --name "$CLUSTER_NAME"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --output json)
+          CLOUD_INFO=$(echo "$AKS_INFO" | jq -c   --arg variant "default"   '{cloud:"azure", region:.location, cluster:.name, kubernetes_version:.currentKubernetesVersion, sku_tier:.sku.tier, network_profile:.networkProfile, cni_variant:$variant}')
+          echo "Cloud info: $CLOUD_INFO"
+          echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect AKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "azure",
+              "region": "swedencentral",
+              "cni_variant": "default",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] Resource deletion was skipped for this manual run."
+        echo "Delete manually with: az group delete --name $(RUN_ID) --subscription $(AZURE_SUBSCRIPTION_ID) --yes"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group delete --name "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --yes
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete resource group ($(AZURE_SUBSCRIPTION_ID))
+  - job: default_n10_p1100_memory
+    displayName: 'default: 10 nodes x 110 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '110'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '11m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az account set --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az config set defaults.location="swedencentral"
+          az account show
+      displayName: Login to Azure
+    - bash: |
+        set -euo pipefail
+        CREATION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        DELETION_DUE_TIME=$(date -u -d "+2 hour" +'%Y-%m-%dT%H:%M:%SZ')
+        echo "##vso[task.setvariable variable=CREATION_DATE]$CREATION_DATE"
+        echo "##vso[task.setvariable variable=DELETION_DUE_TIME]$DELETION_DUE_TIME"
+        echo "##vso[task.setvariable variable=OWNER]aks"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Set resource lifecycle tags
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group create   --name "$(RUN_ID)"   --location "swedencentral"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --tags "run_id=$(RUN_ID)" "scenario=perf-eval-cni-ab-testing" "owner=aks" "creation_date=$(CREATION_DATE)" "deletion_due_time=$(DELETION_DUE_TIME)" "SkipAKSCluster=1" "SkipASB_Audit=true" "cni_variant=default"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create benchmark resource group
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az network vnet create   --resource-group "$(RUN_ID)"   --name "cri-vnet"   --address-prefixes 10.0.0.0/9   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az network vnet subnet create   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --address-prefixes 10.0.0.0/16   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark network
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_FLAGS=()
+          ADO_CUSTOM_HEADERS_LITERAL='$'"(AKS_CLI_CUSTOM_HEADERS)"
+          if [ "${CUSTOM_HEADERS:-}" != "$ADO_CUSTOM_HEADERS_LITERAL" ] && [ -n "${CUSTOM_HEADERS:-}" ]; then
+            AKS_CUSTOM_FLAGS+=(--aks-custom-headers "$CUSTOM_HEADERS")
+          fi
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks create   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --location "swedencentral"   --kubernetes-version "1.33"   --dns-name-prefix "cri"   --tier standard   --nodepool-name default   --node-count 3   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --nodepool-taints CriticalAddonsOnly=true:NoSchedule   --max-pods 250   --network-plugin azure   --network-plugin-mode overlay   --pod-cidr 10.0.0.0/9   --service-cidr 192.168.0.0/16   --dns-service-ip 192.168.0.10   --vnet-subnet-id "$SUBNET_ID"   --enable-managed-identity   --generate-ssh-keys   --tags "run_id=$(RUN_ID)" "role=client" "scenario=perf-eval-cni-ab-testing" "cni_variant=default"   "${AKS_CUSTOM_FLAGS[@]}"   --no-wait
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create default AKS cluster
+      env:
+        CUSTOM_HEADERS: $(AKS_CLI_CUSTOM_HEADERS)
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          while true; do
+            STATE=$(az aks show --name "cri-resource-consume" --resource-group "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --query provisioningState -o tsv)
+            echo "AKS provisioning state: $STATE"
+            case "$STATE" in
+          Succeeded) break ;;
+          Failed|Canceled) exit 1 ;;
+            esac
+            sleep 30
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS cluster to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_HEADER_FLAGS=()
+          ADO_CUSTOM_HEADERS_LITERAL='$'"(AKS_CLI_CUSTOM_HEADERS)"
+          if [ "${CUSTOM_HEADERS:-}" != "$ADO_CUSTOM_HEADERS_LITERAL" ] && [ -n "${CUSTOM_HEADERS:-}" ]; then
+            AKS_CUSTOM_HEADER_FLAGS+=(--aks-custom-headers "$CUSTOM_HEADERS")
+          fi
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name prompool   --node-count 1   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels prometheus=true   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name userpool0   --node-count 10   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels cri-resource-consume=true   --node-taints cri-resource-consume=true:NoSchedule,cri-resource-consume=true:NoExecute   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark node pools
+      env:
+        CUSTOM_HEADERS: $(AKS_CLI_CUSTOM_HEADERS)
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          for POOL in prompool userpool0; do
+            while true; do
+          STATE=$(az aks nodepool show   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name "$POOL"   --query provisioningState -o tsv)
+          echo "Node pool $POOL provisioning state: $STATE"
+          case "$STATE" in
+            Succeeded) break ;;
+            Failed|Canceled) exit 1 ;;
+          esac
+          sleep 30
+            done
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS node pools to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az aks get-credentials   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Get managed AKS credentials
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          set -euo pipefail
+          OWNER="${{ parameters.owner }}"
+          CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+          CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          if [ -z "$OWNER" ]; then
+            echo "##vso[task.logissue type=error;] OWNER is not set."
+            exit 1
+          fi
+          if [ -z "$CLUSTER_NAME" ] || [ -z "$CLUSTER_RESOURCE_GROUP" ]; then
+            echo "##vso[task.logissue type=error;] BYO Azure cluster name and resource group are required."
+            exit 1
+          fi
+          echo "##vso[task.setvariable variable=OWNER]$OWNER"
+          az aks get-credentials   --name "$CLUSTER_NAME"   --resource-group "$CLUSTER_RESOURCE_GROUP"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO AKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aks"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aks"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          CLUSTER_NAME="cri-resource-consume"
+          CLUSTER_RESOURCE_GROUP="$(RUN_ID)"
+          BYO="${{ parameters.skip_resource_management }}"
+          if [ "${BYO,,}" = "true" ]; then
+            CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+            CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          fi
+          AKS_INFO=$(az aks show   --resource-group "$CLUSTER_RESOURCE_GROUP"   --name "$CLUSTER_NAME"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --output json)
+          CLOUD_INFO=$(echo "$AKS_INFO" | jq -c   --arg variant "default"   '{cloud:"azure", region:.location, cluster:.name, kubernetes_version:.currentKubernetesVersion, sku_tier:.sku.tier, network_profile:.networkProfile, cni_variant:$variant}')
+          echo "Cloud info: $CLOUD_INFO"
+          echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect AKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "azure",
+              "region": "swedencentral",
+              "cni_variant": "default",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] Resource deletion was skipped for this manual run."
+        echo "Delete manually with: az group delete --name $(RUN_ID) --subscription $(AZURE_SUBSCRIPTION_ID) --yes"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group delete --name "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --yes
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete resource group ($(AZURE_SUBSCRIPTION_ID))
+- stage: azure_swedencentral_stateless
+  displayName: Stock Azure CNI Overlay
+  dependsOn: []
+  jobs:
+  - job: stateless_n10_p300_memory
+    displayName: 'stateless: 10 nodes x 30 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '30'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '3m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az account set --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az config set defaults.location="swedencentral"
+          az account show
+      displayName: Login to Azure
+    - bash: |
+        set -euo pipefail
+        CREATION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        DELETION_DUE_TIME=$(date -u -d "+2 hour" +'%Y-%m-%dT%H:%M:%SZ')
+        echo "##vso[task.setvariable variable=CREATION_DATE]$CREATION_DATE"
+        echo "##vso[task.setvariable variable=DELETION_DUE_TIME]$DELETION_DUE_TIME"
+        echo "##vso[task.setvariable variable=OWNER]aks"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Set resource lifecycle tags
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group create   --name "$(RUN_ID)"   --location "swedencentral"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --tags "run_id=$(RUN_ID)" "scenario=perf-eval-cni-ab-testing" "owner=aks" "creation_date=$(CREATION_DATE)" "deletion_due_time=$(DELETION_DUE_TIME)" "SkipAKSCluster=1" "SkipASB_Audit=true" "cni_variant=stateless"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create benchmark resource group
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az network vnet create   --resource-group "$(RUN_ID)"   --name "cri-vnet"   --address-prefixes 10.0.0.0/9   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az network vnet subnet create   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --address-prefixes 10.0.0.0/16   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark network
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_FLAGS=()
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks create   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --location "swedencentral"   --kubernetes-version "1.33"   --dns-name-prefix "cri"   --tier standard   --nodepool-name default   --node-count 3   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --nodepool-taints CriticalAddonsOnly=true:NoSchedule   --max-pods 250   --network-plugin azure   --network-plugin-mode overlay   --pod-cidr 10.0.0.0/9   --service-cidr 192.168.0.0/16   --dns-service-ip 192.168.0.10   --vnet-subnet-id "$SUBNET_ID"   --enable-managed-identity   --generate-ssh-keys   --tags "run_id=$(RUN_ID)" "role=client" "scenario=perf-eval-cni-ab-testing" "cni_variant=stateless"   "${AKS_CUSTOM_FLAGS[@]}"   --no-wait
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create stateless AKS cluster
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          while true; do
+            STATE=$(az aks show --name "cri-resource-consume" --resource-group "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --query provisioningState -o tsv)
+            echo "AKS provisioning state: $STATE"
+            case "$STATE" in
+          Succeeded) break ;;
+          Failed|Canceled) exit 1 ;;
+            esac
+            sleep 30
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS cluster to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_HEADER_FLAGS=()
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name prompool   --node-count 1   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels prometheus=true   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name userpool0   --node-count 10   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels cri-resource-consume=true   --node-taints cri-resource-consume=true:NoSchedule,cri-resource-consume=true:NoExecute   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark node pools
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          for POOL in prompool userpool0; do
+            while true; do
+          STATE=$(az aks nodepool show   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name "$POOL"   --query provisioningState -o tsv)
+          echo "Node pool $POOL provisioning state: $STATE"
+          case "$STATE" in
+            Succeeded) break ;;
+            Failed|Canceled) exit 1 ;;
+          esac
+          sleep 30
+            done
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS node pools to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az aks get-credentials   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Get managed AKS credentials
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          set -euo pipefail
+          OWNER="${{ parameters.owner }}"
+          CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+          CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          if [ -z "$OWNER" ]; then
+            echo "##vso[task.logissue type=error;] OWNER is not set."
+            exit 1
+          fi
+          if [ -z "$CLUSTER_NAME" ] || [ -z "$CLUSTER_RESOURCE_GROUP" ]; then
+            echo "##vso[task.logissue type=error;] BYO Azure cluster name and resource group are required."
+            exit 1
+          fi
+          echo "##vso[task.setvariable variable=OWNER]$OWNER"
+          az aks get-credentials   --name "$CLUSTER_NAME"   --resource-group "$CLUSTER_RESOURCE_GROUP"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO AKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aks"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aks"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          CLUSTER_NAME="cri-resource-consume"
+          CLUSTER_RESOURCE_GROUP="$(RUN_ID)"
+          BYO="${{ parameters.skip_resource_management }}"
+          if [ "${BYO,,}" = "true" ]; then
+            CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+            CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          fi
+          AKS_INFO=$(az aks show   --resource-group "$CLUSTER_RESOURCE_GROUP"   --name "$CLUSTER_NAME"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --output json)
+          CLOUD_INFO=$(echo "$AKS_INFO" | jq -c   --arg variant "stateless"   '{cloud:"azure", region:.location, cluster:.name, kubernetes_version:.currentKubernetesVersion, sku_tier:.sku.tier, network_profile:.networkProfile, cni_variant:$variant}')
+          echo "Cloud info: $CLOUD_INFO"
+          echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect AKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "azure",
+              "region": "swedencentral",
+              "cni_variant": "stateless",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] Resource deletion was skipped for this manual run."
+        echo "Delete manually with: az group delete --name $(RUN_ID) --subscription $(AZURE_SUBSCRIPTION_ID) --yes"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group delete --name "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --yes
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete resource group ($(AZURE_SUBSCRIPTION_ID))
+  - job: stateless_n10_p700_memory
+    displayName: 'stateless: 10 nodes x 70 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '70'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '7m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az account set --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az config set defaults.location="swedencentral"
+          az account show
+      displayName: Login to Azure
+    - bash: |
+        set -euo pipefail
+        CREATION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        DELETION_DUE_TIME=$(date -u -d "+2 hour" +'%Y-%m-%dT%H:%M:%SZ')
+        echo "##vso[task.setvariable variable=CREATION_DATE]$CREATION_DATE"
+        echo "##vso[task.setvariable variable=DELETION_DUE_TIME]$DELETION_DUE_TIME"
+        echo "##vso[task.setvariable variable=OWNER]aks"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Set resource lifecycle tags
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group create   --name "$(RUN_ID)"   --location "swedencentral"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --tags "run_id=$(RUN_ID)" "scenario=perf-eval-cni-ab-testing" "owner=aks" "creation_date=$(CREATION_DATE)" "deletion_due_time=$(DELETION_DUE_TIME)" "SkipAKSCluster=1" "SkipASB_Audit=true" "cni_variant=stateless"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create benchmark resource group
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az network vnet create   --resource-group "$(RUN_ID)"   --name "cri-vnet"   --address-prefixes 10.0.0.0/9   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az network vnet subnet create   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --address-prefixes 10.0.0.0/16   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark network
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_FLAGS=()
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks create   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --location "swedencentral"   --kubernetes-version "1.33"   --dns-name-prefix "cri"   --tier standard   --nodepool-name default   --node-count 3   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --nodepool-taints CriticalAddonsOnly=true:NoSchedule   --max-pods 250   --network-plugin azure   --network-plugin-mode overlay   --pod-cidr 10.0.0.0/9   --service-cidr 192.168.0.0/16   --dns-service-ip 192.168.0.10   --vnet-subnet-id "$SUBNET_ID"   --enable-managed-identity   --generate-ssh-keys   --tags "run_id=$(RUN_ID)" "role=client" "scenario=perf-eval-cni-ab-testing" "cni_variant=stateless"   "${AKS_CUSTOM_FLAGS[@]}"   --no-wait
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create stateless AKS cluster
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          while true; do
+            STATE=$(az aks show --name "cri-resource-consume" --resource-group "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --query provisioningState -o tsv)
+            echo "AKS provisioning state: $STATE"
+            case "$STATE" in
+          Succeeded) break ;;
+          Failed|Canceled) exit 1 ;;
+            esac
+            sleep 30
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS cluster to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_HEADER_FLAGS=()
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name prompool   --node-count 1   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels prometheus=true   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name userpool0   --node-count 10   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels cri-resource-consume=true   --node-taints cri-resource-consume=true:NoSchedule,cri-resource-consume=true:NoExecute   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark node pools
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          for POOL in prompool userpool0; do
+            while true; do
+          STATE=$(az aks nodepool show   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name "$POOL"   --query provisioningState -o tsv)
+          echo "Node pool $POOL provisioning state: $STATE"
+          case "$STATE" in
+            Succeeded) break ;;
+            Failed|Canceled) exit 1 ;;
+          esac
+          sleep 30
+            done
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS node pools to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az aks get-credentials   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Get managed AKS credentials
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          set -euo pipefail
+          OWNER="${{ parameters.owner }}"
+          CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+          CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          if [ -z "$OWNER" ]; then
+            echo "##vso[task.logissue type=error;] OWNER is not set."
+            exit 1
+          fi
+          if [ -z "$CLUSTER_NAME" ] || [ -z "$CLUSTER_RESOURCE_GROUP" ]; then
+            echo "##vso[task.logissue type=error;] BYO Azure cluster name and resource group are required."
+            exit 1
+          fi
+          echo "##vso[task.setvariable variable=OWNER]$OWNER"
+          az aks get-credentials   --name "$CLUSTER_NAME"   --resource-group "$CLUSTER_RESOURCE_GROUP"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO AKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aks"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aks"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          CLUSTER_NAME="cri-resource-consume"
+          CLUSTER_RESOURCE_GROUP="$(RUN_ID)"
+          BYO="${{ parameters.skip_resource_management }}"
+          if [ "${BYO,,}" = "true" ]; then
+            CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+            CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          fi
+          AKS_INFO=$(az aks show   --resource-group "$CLUSTER_RESOURCE_GROUP"   --name "$CLUSTER_NAME"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --output json)
+          CLOUD_INFO=$(echo "$AKS_INFO" | jq -c   --arg variant "stateless"   '{cloud:"azure", region:.location, cluster:.name, kubernetes_version:.currentKubernetesVersion, sku_tier:.sku.tier, network_profile:.networkProfile, cni_variant:$variant}')
+          echo "Cloud info: $CLOUD_INFO"
+          echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect AKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "azure",
+              "region": "swedencentral",
+              "cni_variant": "stateless",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] Resource deletion was skipped for this manual run."
+        echo "Delete manually with: az group delete --name $(RUN_ID) --subscription $(AZURE_SUBSCRIPTION_ID) --yes"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group delete --name "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --yes
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete resource group ($(AZURE_SUBSCRIPTION_ID))
+  - job: stateless_n10_p1100_memory
+    displayName: 'stateless: 10 nodes x 110 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '110'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '11m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az account set --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az config set defaults.location="swedencentral"
+          az account show
+      displayName: Login to Azure
+    - bash: |
+        set -euo pipefail
+        CREATION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        DELETION_DUE_TIME=$(date -u -d "+2 hour" +'%Y-%m-%dT%H:%M:%SZ')
+        echo "##vso[task.setvariable variable=CREATION_DATE]$CREATION_DATE"
+        echo "##vso[task.setvariable variable=DELETION_DUE_TIME]$DELETION_DUE_TIME"
+        echo "##vso[task.setvariable variable=OWNER]aks"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Set resource lifecycle tags
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group create   --name "$(RUN_ID)"   --location "swedencentral"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --tags "run_id=$(RUN_ID)" "scenario=perf-eval-cni-ab-testing" "owner=aks" "creation_date=$(CREATION_DATE)" "deletion_due_time=$(DELETION_DUE_TIME)" "SkipAKSCluster=1" "SkipASB_Audit=true" "cni_variant=stateless"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create benchmark resource group
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az network vnet create   --resource-group "$(RUN_ID)"   --name "cri-vnet"   --address-prefixes 10.0.0.0/9   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+          az network vnet subnet create   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --address-prefixes 10.0.0.0/16   --subscription "$(AZURE_SUBSCRIPTION_ID)"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark network
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_FLAGS=()
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks create   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --location "swedencentral"   --kubernetes-version "1.33"   --dns-name-prefix "cri"   --tier standard   --nodepool-name default   --node-count 3   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --nodepool-taints CriticalAddonsOnly=true:NoSchedule   --max-pods 250   --network-plugin azure   --network-plugin-mode overlay   --pod-cidr 10.0.0.0/9   --service-cidr 192.168.0.0/16   --dns-service-ip 192.168.0.10   --vnet-subnet-id "$SUBNET_ID"   --enable-managed-identity   --generate-ssh-keys   --tags "run_id=$(RUN_ID)" "role=client" "scenario=perf-eval-cni-ab-testing" "cni_variant=stateless"   "${AKS_CUSTOM_FLAGS[@]}"   --no-wait
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create stateless AKS cluster
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          while true; do
+            STATE=$(az aks show --name "cri-resource-consume" --resource-group "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --query provisioningState -o tsv)
+            echo "AKS provisioning state: $STATE"
+            case "$STATE" in
+          Succeeded) break ;;
+          Failed|Canceled) exit 1 ;;
+            esac
+            sleep 30
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS cluster to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          AKS_CUSTOM_HEADER_FLAGS=()
+
+
+          SUBNET_ID=$(az network vnet subnet show   --resource-group "$(RUN_ID)"   --vnet-name "cri-vnet"   --name "cri-subnet-1"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --query id -o tsv)
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name prompool   --node-count 1   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels prometheus=true   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+
+          az aks nodepool add   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name userpool0   --node-count 10   --node-vm-size "Standard_D16ds_v4"   --node-osdisk-type Ephemeral   --mode User   --labels cri-resource-consume=true   --node-taints cri-resource-consume=true:NoSchedule,cri-resource-consume=true:NoExecute   --max-pods 250   --vnet-subnet-id "$SUBNET_ID"   "${AKS_CUSTOM_HEADER_FLAGS[@]}"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create CRI benchmark node pools
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          for POOL in prompool userpool0; do
+            while true; do
+          STATE=$(az aks nodepool show   --cluster-name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --name "$POOL"   --query provisioningState -o tsv)
+          echo "Node pool $POOL provisioning state: $STATE"
+          case "$STATE" in
+            Succeeded) break ;;
+            Failed|Canceled) exit 1 ;;
+          esac
+          sleep 30
+            done
+          done
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Wait for AKS node pools to succeed
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az aks get-credentials   --name "cri-resource-consume"   --resource-group "$(RUN_ID)"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Get managed AKS credentials
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          set -euo pipefail
+          OWNER="${{ parameters.owner }}"
+          CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+          CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          if [ -z "$OWNER" ]; then
+            echo "##vso[task.logissue type=error;] OWNER is not set."
+            exit 1
+          fi
+          if [ -z "$CLUSTER_NAME" ] || [ -z "$CLUSTER_RESOURCE_GROUP" ]; then
+            echo "##vso[task.logissue type=error;] BYO Azure cluster name and resource group are required."
+            exit 1
+          fi
+          echo "##vso[task.setvariable variable=OWNER]$OWNER"
+          az aks get-credentials   --name "$CLUSTER_NAME"   --resource-group "$CLUSTER_RESOURCE_GROUP"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --overwrite-existing
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO AKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aks"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aks"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          CLUSTER_NAME="cri-resource-consume"
+          CLUSTER_RESOURCE_GROUP="$(RUN_ID)"
+          BYO="${{ parameters.skip_resource_management }}"
+          if [ "${BYO,,}" = "true" ]; then
+            CLUSTER_NAME="${{ parameters.byo_azure_cluster_name }}"
+            CLUSTER_RESOURCE_GROUP="${{ parameters.byo_azure_resource_group }}"
+          fi
+          AKS_INFO=$(az aks show   --resource-group "$CLUSTER_RESOURCE_GROUP"   --name "$CLUSTER_NAME"   --subscription "$(AZURE_SUBSCRIPTION_ID)"   --output json)
+          CLOUD_INFO=$(echo "$AKS_INFO" | jq -c   --arg variant "stateless"   '{cloud:"azure", region:.location, cluster:.name, kubernetes_version:.currentKubernetesVersion, sku_tier:.sku.tier, network_profile:.networkProfile, cni_variant:$variant}')
+          echo "Cloud info: $CLOUD_INFO"
+          echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect AKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "azure",
+              "region": "swedencentral",
+              "cni_variant": "stateless",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] Resource deletion was skipped for this manual run."
+        echo "Delete manually with: az group delete --name $(RUN_ID) --subscription $(AZURE_SUBSCRIPTION_ID) --yes"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az group delete --name "$(RUN_ID)" --subscription "$(AZURE_SUBSCRIPTION_ID)" --yes
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete resource group ($(AZURE_SUBSCRIPTION_ID))
+- stage: aws_westeurope
+  displayName: AWS VPC CNI
+  dependsOn: []
+  jobs:
+  - job: aws_n10_p300_memory
+    displayName: 'aws: 10 nodes x 30 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '30'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '3m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AWSShellScript@1
+      inputs:
+        awsCredentials: ${{ parameters.aws_service_connection }}
+        regionName: eu-west-1
+        scriptType: inline
+        inlineScript: |
+          echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
+          echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
+          if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+            echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
+          fi
+      displayName: Get AWS credentials
+    - bash: |
+        set -euo pipefail
+        mkdir -p "$HOME/.aws"
+        aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+        aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+        ADO_LITERAL='$'"(AWS_SESSION_TOKEN)"
+        if [ "${AWS_SESSION_TOKEN:-}" = "$ADO_LITERAL" ]; then
+          AWS_SESSION_TOKEN=""
+        fi
+        if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+          aws configure set aws_session_token "$AWS_SESSION_TOKEN"
+        fi
+        aws configure set default.region "eu-west-1"
+        aws sts get-caller-identity
+      displayName: Configure AWS CLI
+      env:
+        AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+        AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+        AWS_SESSION_TOKEN: $(AWS_SESSION_TOKEN)
+    - bash: |
+        set -euo pipefail
+
+        if ! command -v eksctl >/dev/null 2>&1; then
+          version="0.215.0"
+          arch=$(uname -m)
+          case "$arch" in
+            x86_64) arch=amd64 ;;
+            aarch64) arch=arm64 ;;
+            *) echo "Unsupported architecture: $arch"; exit 1 ;;
+          esac
+          curl -fsSL "https://github.com/eksctl-io/eksctl/releases/download/v${version}/eksctl_Linux_${arch}.tar.gz" |
+            tar -xz -C /tmp
+          sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
+        fi
+        eksctl version
+
+        cat > "$(Pipeline.Workspace)/eksctl-cni-ab.yaml" << EOF
+        apiVersion: eksctl.io/v1alpha5
+        kind: ClusterConfig
+        metadata:
+          name: $(RUN_ID)
+          region: eu-west-1
+          version: "1.33"
+        vpc:
+          cidr: 10.0.0.0/16
+          nat:
+            gateway: Single
+        managedNodeGroups:
+          - name: default
+            instanceType: m5.4xlarge
+            desiredCapacity: 3
+            minSize: 3
+            maxSize: 3
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+          - name: prompool
+            instanceType: m5.4xlarge
+            desiredCapacity: 1
+            minSize: 1
+            maxSize: 1
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+            labels:
+              prometheus: "true"
+          - name: userpool0
+            instanceType: m5.4xlarge
+            desiredCapacity: 10
+            minSize: 10
+            maxSize: 10
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+            labels:
+              cri-resource-consume: "true"
+              agentpool: userpool0
+            taints:
+              - key: cri-resource-consume
+                value: "true"
+                effect: NoSchedule
+              - key: cri-resource-consume
+                value: "true"
+                effect: NoExecute
+        addons:
+          - name: coredns
+          - name: vpc-cni
+          - name: kube-proxy
+        EOF
+
+        eksctl create cluster --config-file "$(Pipeline.Workspace)/eksctl-cni-ab.yaml"
+        aws eks update-kubeconfig --name "$(RUN_ID)" --region "eu-west-1"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create EKS benchmark cluster
+    - bash: |
+        set -euo pipefail
+        OWNER="${{ parameters.owner }}"
+        CLUSTER_NAME="${{ parameters.byo_aws_cluster_name }}"
+        if [ -z "$OWNER" ]; then
+          echo "##vso[task.logissue type=error;] OWNER is not set."
+          exit 1
+        fi
+        if [ -z "$CLUSTER_NAME" ]; then
+          echo "##vso[task.logissue type=error;] BYO AWS cluster name is required."
+          exit 1
+        fi
+        echo "##vso[task.setvariable variable=OWNER]$OWNER"
+        aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "eu-west-1"
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO EKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aws"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aws"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - bash: |
+        set -euo pipefail
+        CLUSTER_NAME="$(RUN_ID)"
+        BYO="${{ parameters.skip_resource_management }}"
+        if [ "${BYO,,}" = "true" ]; then
+          CLUSTER_NAME="${{ parameters.byo_aws_cluster_name }}"
+        fi
+        EKS_INFO=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "eu-west-1")
+        CLOUD_INFO=$(echo "$EKS_INFO" | jq -c '{cloud:"aws", region:.cluster.arn | split(":")[3], cluster:.cluster.name, kubernetes_version:.cluster.version}')
+        echo "Cloud info: $CLOUD_INFO"
+        echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect EKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "aws",
+              "region": "eu-west-1",
+              "cni_variant": "aws-vpc-cni",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] EKS deletion was skipped for this manual run."
+        echo "Delete manually with: eksctl delete cluster --name $(RUN_ID) --region eu-west-1"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - bash: |
+        set -euo pipefail
+        eksctl delete cluster --name "$(RUN_ID)" --region "eu-west-1" --wait
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete EKS benchmark cluster
+  - job: aws_n10_p700_memory
+    displayName: 'aws: 10 nodes x 70 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '70'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '7m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AWSShellScript@1
+      inputs:
+        awsCredentials: ${{ parameters.aws_service_connection }}
+        regionName: eu-west-1
+        scriptType: inline
+        inlineScript: |
+          echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
+          echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
+          if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+            echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
+          fi
+      displayName: Get AWS credentials
+    - bash: |
+        set -euo pipefail
+        mkdir -p "$HOME/.aws"
+        aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+        aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+        ADO_LITERAL='$'"(AWS_SESSION_TOKEN)"
+        if [ "${AWS_SESSION_TOKEN:-}" = "$ADO_LITERAL" ]; then
+          AWS_SESSION_TOKEN=""
+        fi
+        if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+          aws configure set aws_session_token "$AWS_SESSION_TOKEN"
+        fi
+        aws configure set default.region "eu-west-1"
+        aws sts get-caller-identity
+      displayName: Configure AWS CLI
+      env:
+        AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+        AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+        AWS_SESSION_TOKEN: $(AWS_SESSION_TOKEN)
+    - bash: |
+        set -euo pipefail
+
+        if ! command -v eksctl >/dev/null 2>&1; then
+          version="0.215.0"
+          arch=$(uname -m)
+          case "$arch" in
+            x86_64) arch=amd64 ;;
+            aarch64) arch=arm64 ;;
+            *) echo "Unsupported architecture: $arch"; exit 1 ;;
+          esac
+          curl -fsSL "https://github.com/eksctl-io/eksctl/releases/download/v${version}/eksctl_Linux_${arch}.tar.gz" |
+            tar -xz -C /tmp
+          sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
+        fi
+        eksctl version
+
+        cat > "$(Pipeline.Workspace)/eksctl-cni-ab.yaml" << EOF
+        apiVersion: eksctl.io/v1alpha5
+        kind: ClusterConfig
+        metadata:
+          name: $(RUN_ID)
+          region: eu-west-1
+          version: "1.33"
+        vpc:
+          cidr: 10.0.0.0/16
+          nat:
+            gateway: Single
+        managedNodeGroups:
+          - name: default
+            instanceType: m5.4xlarge
+            desiredCapacity: 3
+            minSize: 3
+            maxSize: 3
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+          - name: prompool
+            instanceType: m5.4xlarge
+            desiredCapacity: 1
+            minSize: 1
+            maxSize: 1
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+            labels:
+              prometheus: "true"
+          - name: userpool0
+            instanceType: m5.4xlarge
+            desiredCapacity: 10
+            minSize: 10
+            maxSize: 10
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+            labels:
+              cri-resource-consume: "true"
+              agentpool: userpool0
+            taints:
+              - key: cri-resource-consume
+                value: "true"
+                effect: NoSchedule
+              - key: cri-resource-consume
+                value: "true"
+                effect: NoExecute
+        addons:
+          - name: coredns
+          - name: vpc-cni
+          - name: kube-proxy
+        EOF
+
+        eksctl create cluster --config-file "$(Pipeline.Workspace)/eksctl-cni-ab.yaml"
+        aws eks update-kubeconfig --name "$(RUN_ID)" --region "eu-west-1"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create EKS benchmark cluster
+    - bash: |
+        set -euo pipefail
+        OWNER="${{ parameters.owner }}"
+        CLUSTER_NAME="${{ parameters.byo_aws_cluster_name }}"
+        if [ -z "$OWNER" ]; then
+          echo "##vso[task.logissue type=error;] OWNER is not set."
+          exit 1
+        fi
+        if [ -z "$CLUSTER_NAME" ]; then
+          echo "##vso[task.logissue type=error;] BYO AWS cluster name is required."
+          exit 1
+        fi
+        echo "##vso[task.setvariable variable=OWNER]$OWNER"
+        aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "eu-west-1"
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO EKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aws"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aws"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - bash: |
+        set -euo pipefail
+        CLUSTER_NAME="$(RUN_ID)"
+        BYO="${{ parameters.skip_resource_management }}"
+        if [ "${BYO,,}" = "true" ]; then
+          CLUSTER_NAME="${{ parameters.byo_aws_cluster_name }}"
+        fi
+        EKS_INFO=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "eu-west-1")
+        CLOUD_INFO=$(echo "$EKS_INFO" | jq -c '{cloud:"aws", region:.cluster.arn | split(":")[3], cluster:.cluster.name, kubernetes_version:.cluster.version}')
+        echo "Cloud info: $CLOUD_INFO"
+        echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect EKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "aws",
+              "region": "eu-west-1",
+              "cni_variant": "aws-vpc-cni",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] EKS deletion was skipped for this manual run."
+        echo "Delete manually with: eksctl delete cluster --name $(RUN_ID) --region eu-west-1"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - bash: |
+        set -euo pipefail
+        eksctl delete cluster --name "$(RUN_ID)" --region "eu-west-1" --wait
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete EKS benchmark cluster
+  - job: aws_n10_p1100_memory
+    displayName: 'aws: 10 nodes x 110 pods'
+    condition: or(eq(variables['Build.Reason'], 'Manual'), and(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.SourceBranchName'], 'main')))
+    timeoutInMinutes: 120
+    variables:
+      NODE_COUNT: '10'
+      MAX_PODS: '110'
+      REPEATS: '1'
+      OPERATION_TIMEOUT: '11m'
+      LOAD_TYPE: memory
+      SCRAPE_KUBELETS: 'True'
+      HOST_NETWORK: 'False'
+    steps:
+    - bash: |
+        set -eo pipefail
+
+        job_id="$(System.JobId)"
+        RUN_ID=$(Build.BuildId)-${job_id:0:8}
+        echo "Run ID: $RUN_ID"
+
+        echo "##vso[task.setvariable variable=RUN_ID]$RUN_ID"
+      displayName: Set Run ID
+    - bash: |-
+        set -exo pipefail
+        pip3 install --upgrade "pip<24"
+        pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+      displayName: Install Python dependencies
+    - task: AWSShellScript@1
+      inputs:
+        awsCredentials: ${{ parameters.aws_service_connection }}
+        regionName: eu-west-1
+        scriptType: inline
+        inlineScript: |
+          echo "##vso[task.setvariable variable=AWS_ACCESS_KEY_ID;issecret=true]$AWS_ACCESS_KEY_ID"
+          echo "##vso[task.setvariable variable=AWS_SECRET_ACCESS_KEY;issecret=true]$AWS_SECRET_ACCESS_KEY"
+          if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+            echo "##vso[task.setvariable variable=AWS_SESSION_TOKEN;issecret=true]$AWS_SESSION_TOKEN"
+          fi
+      displayName: Get AWS credentials
+    - bash: |
+        set -euo pipefail
+        mkdir -p "$HOME/.aws"
+        aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+        aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+        ADO_LITERAL='$'"(AWS_SESSION_TOKEN)"
+        if [ "${AWS_SESSION_TOKEN:-}" = "$ADO_LITERAL" ]; then
+          AWS_SESSION_TOKEN=""
+        fi
+        if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+          aws configure set aws_session_token "$AWS_SESSION_TOKEN"
+        fi
+        aws configure set default.region "eu-west-1"
+        aws sts get-caller-identity
+      displayName: Configure AWS CLI
+      env:
+        AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+        AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+        AWS_SESSION_TOKEN: $(AWS_SESSION_TOKEN)
+    - bash: |
+        set -euo pipefail
+
+        if ! command -v eksctl >/dev/null 2>&1; then
+          version="0.215.0"
+          arch=$(uname -m)
+          case "$arch" in
+            x86_64) arch=amd64 ;;
+            aarch64) arch=arm64 ;;
+            *) echo "Unsupported architecture: $arch"; exit 1 ;;
+          esac
+          curl -fsSL "https://github.com/eksctl-io/eksctl/releases/download/v${version}/eksctl_Linux_${arch}.tar.gz" |
+            tar -xz -C /tmp
+          sudo install -m 0755 /tmp/eksctl /usr/local/bin/eksctl
+        fi
+        eksctl version
+
+        cat > "$(Pipeline.Workspace)/eksctl-cni-ab.yaml" << EOF
+        apiVersion: eksctl.io/v1alpha5
+        kind: ClusterConfig
+        metadata:
+          name: $(RUN_ID)
+          region: eu-west-1
+          version: "1.33"
+        vpc:
+          cidr: 10.0.0.0/16
+          nat:
+            gateway: Single
+        managedNodeGroups:
+          - name: default
+            instanceType: m5.4xlarge
+            desiredCapacity: 3
+            minSize: 3
+            maxSize: 3
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+          - name: prompool
+            instanceType: m5.4xlarge
+            desiredCapacity: 1
+            minSize: 1
+            maxSize: 1
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+            labels:
+              prometheus: "true"
+          - name: userpool0
+            instanceType: m5.4xlarge
+            desiredCapacity: 10
+            minSize: 10
+            maxSize: 10
+            amiFamily: AmazonLinux2023
+            privateNetworking: false
+            labels:
+              cri-resource-consume: "true"
+              agentpool: userpool0
+            taints:
+              - key: cri-resource-consume
+                value: "true"
+                effect: NoSchedule
+              - key: cri-resource-consume
+                value: "true"
+                effect: NoExecute
+        addons:
+          - name: coredns
+          - name: vpc-cni
+          - name: kube-proxy
+        EOF
+
+        eksctl create cluster --config-file "$(Pipeline.Workspace)/eksctl-cni-ab.yaml"
+        aws eks update-kubeconfig --name "$(RUN_ID)" --region "eu-west-1"
+      condition: not(${{ parameters.skip_resource_management }})
+      displayName: Create EKS benchmark cluster
+    - bash: |
+        set -euo pipefail
+        OWNER="${{ parameters.owner }}"
+        CLUSTER_NAME="${{ parameters.byo_aws_cluster_name }}"
+        if [ -z "$OWNER" ]; then
+          echo "##vso[task.logissue type=error;] OWNER is not set."
+          exit 1
+        fi
+        if [ -z "$CLUSTER_NAME" ]; then
+          echo "##vso[task.logissue type=error;] BYO AWS cluster name is required."
+          exit 1
+        fi
+        echo "##vso[task.setvariable variable=OWNER]$OWNER"
+        aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "eu-west-1"
+      condition: ${{ parameters.skip_resource_management }}
+      displayName: Validate OWNER and get BYO EKS credentials
+    - bash: |
+        set -euo pipefail
+
+        deadline=$((SECONDS + 600))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+          total=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          ready=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          echo "Cluster nodes: $ready/$total Ready; expected 14"
+          if [ "$total" -eq 14 ] && [ "$ready" -eq 14 ]; then
+            kubectl get nodes -L agentpool,prometheus,cri-resource-consume
+            exit 0
+          fi
+          sleep 30
+        done
+
+        echo "Expected exactly 14 Ready nodes within 10 minutes."
+        kubectl get nodes -o wide
+        exit 1
+      displayName: Validate 14 Ready nodes
+      timeoutInMinutes: 11
+    - bash: |
+        set -euo pipefail
+
+        rm -rf "$CL2_REPORT_DIR"
+        mkdir -p "$CL2_REPORT_DIR"
+        rm -f "$TEST_RESULTS_FILE"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" override   --node_count "$NODE_COUNT"   --node_per_step "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --operation_timeout "$OPERATION_TIMEOUT"   --load_type "$LOAD_TYPE"   --scale_enabled False   --pod_startup_latency_threshold 15s   --provider "aws"   --registry_endpoint "akscritelescope.azurecr.io"   --test_image e2e-test-images/resource-consumer:1.13   --os_type linux   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False   --containerd_scrape_interval 15s   --host_network "$HOST_NETWORK"   --cl2_override_file "$CL2_CONFIG_DIR/overrides.yaml"
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" execute   --cl2_image "$CL2_IMAGE"   --cl2_config_dir "$CL2_CONFIG_DIR"   --cl2_report_dir "$CL2_REPORT_DIR"   --kubeconfig "$HOME/.kube/config"   --provider "aws"   --scrape_kubelets "$SCRAPE_KUBELETS"   --scrape_containerd False
+      displayName: Run ClusterLoader2 CRI benchmark
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_CONFIG_DIR: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/cri/config
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+        CL2_IMAGE: ghcr.io/azure/clusterloader2:v20241016
+    - bash: |
+        set -euo pipefail
+        CLUSTER_NAME="$(RUN_ID)"
+        BYO="${{ parameters.skip_resource_management }}"
+        if [ "${BYO,,}" = "true" ]; then
+          CLUSTER_NAME="${{ parameters.byo_aws_cluster_name }}"
+        fi
+        EKS_INFO=$(aws eks describe-cluster --name "$CLUSTER_NAME" --region "eu-west-1")
+        CLOUD_INFO=$(echo "$EKS_INFO" | jq -c '{cloud:"aws", region:.cluster.arn | split(":")[3], cluster:.cluster.name, kubernetes_version:.cluster.version}')
+        echo "Cloud info: $CLOUD_INFO"
+        echo "##vso[task.setvariable variable=CLOUD_INFO]$CLOUD_INFO"
+      displayName: Collect EKS cloud info
+    - bash: |
+        set -euo pipefail
+
+        PYTHONPATH="$(Pipeline.Workspace)/s/modules/python:$CL2_PYTHON_ROOT" python3 "$CL2_PYTHON_ROOT/clusterloader2/cri/cri.py" collect   --node_count "$NODE_COUNT"   --max_pods "$MAX_PODS"   --repeats "$REPEATS"   --load_type "$LOAD_TYPE"   --cl2_report_dir "$CL2_REPORT_DIR"   --cloud_info "$CLOUD_INFO"   --run_id "$(RUN_ID)"   --run_url "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)"   --result_file "$TEST_RESULTS_FILE"   --scrape_kubelets "$SCRAPE_KUBELETS"   --registry_info ""
+      displayName: Collect ClusterLoader2 results
+      env:
+        CL2_PYTHON_ROOT: $(Pipeline.Workspace)/s/kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python
+        CL2_REPORT_DIR: $(Pipeline.Workspace)/cl2-results
+        TEST_RESULTS_FILE: $(Pipeline.Workspace)/cni-ab-results.jsonl
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          if [ -s "$(Pipeline.Workspace)/cni-ab-results.jsonl" ]; then
+            MEASUREMENTS=$(jq -s '.' "$(Pipeline.Workspace)/cni-ab-results.jsonl")
+            FAILED=$(echo "$MEASUREMENTS" | jq '[.[] | select(.status == "failure")] | length')
+          else
+            MEASUREMENTS='[]'
+            FAILED=1
+          fi
+          STATUS="succeeded"
+          if [ "$FAILED" -gt 0 ]; then
+            STATUS="failed"
+          fi
+          cat > /tmp/run-result.json << EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "run_id": "$(RUN_ID)",
+            "run_url": "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)",
+            "pipeline": "$(Build.DefinitionName)",
+            "result": {
+              "status": "${STATUS}",
+              "scenario_type": "perf-eval",
+              "scenario_name": "cni-ab-testing",
+              "owner": "${{ parameters.owner }}",
+              "engine": "clusterloader2",
+              "topology": "cri-resource-consume",
+              "engine_input": {"image": "ghcr.io/azure/clusterloader2:v20241016"},
+              "byo_resources": "${{ parameters.skip_resource_management }}",
+              "cloud": "aws",
+              "region": "eu-west-1",
+              "cni_variant": "aws-vpc-cni",
+              "node_count": 10,
+              "max_pods": $(MAX_PODS),
+              "repeats": 1,
+              "load_type": "memory",
+              "host_network": false,
+              "scrape_kubelets": true,
+              "measurements": ${MEASUREMENTS}
+            }
+          }
+          EOF
+          jq . /tmp/run-result.json
+      displayName: Build Telescope result
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -exo pipefail
+          az storage blob upload \
+            --account-name "telescopev2" \
+            --subscription "137f0351-8235-42a6-ac7a-6b46be2d21c7" \
+            --container-name "aks" \
+            --name "$(RUN_ID)/run-result.json" \
+            --file /tmp/run-result.json \
+            --auth-mode key
+      displayName: Upload result to storage account
+    - bash: |
+        echo "##vso[task.logissue type=warning;] EKS deletion was skipped for this manual run."
+        echo "Delete manually with: eksctl delete cluster --name $(RUN_ID) --region eu-west-1"
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), ${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))
+      displayName: Report skipped cleanup
+    - bash: |
+        set -euo pipefail
+        eksctl delete cluster --name "$(RUN_ID)" --region "eu-west-1" --wait
+      condition: and(always(), not(${{ parameters.skip_resource_management }}), not(and(${{ parameters.skip_resource_deletion }}, eq(variables['Build.Reason'], 'Manual'))))
+      displayName: Delete EKS benchmark cluster

--- a/modules/python/clients/docker_client.py
+++ b/modules/python/clients/docker_client.py
@@ -1,0 +1,8 @@
+import docker
+
+class DockerClient:
+    def __init__(self):
+        self.client = docker.from_env()
+
+    def run_container(self, image, command, volumes, detach):
+        return self.client.containers.run(image, command, volumes=volumes, detach=detach)


### PR DESCRIPTION
## Summary
Automated migration of `pipelines/perf-eval/CNI Benchmark/cni-ab-testing.yml` (and its full template + scenario closure) into the v2 KCL pipeline layout.

## Contents
- `kcl/perf-eval/cni-benchmark/cni-ab-testing/pipeline.k` — new KCL module.
- `kcl/perf-eval/cni-benchmark/cni-ab-testing/pipeline.yaml` — generated by `kcl run`, in sync with `pipeline.k`.
- `kcl/perf-eval/cni-benchmark/cni-ab-testing/assets/python/clusterloader2/` — vendored upstream CL2 `cri` assets (marked with `UPSTREAM`).
- Minor extension to `kcl/lib/steps/azure/az_cli.k` and a new `modules/python/clients/docker_client.py` used by the new pipeline.

## Validated by automated V1↔V2 review
The `AgentReviewer` ran a rigorous 4-round review against the v1 reference bundle and mapped every AKS-facing v1 behavior onto a v2 mechanism:

- Scenario identity (`perf-eval` / `cni-ab-testing`, owner/engine/topology metadata).
- Trigger surface: `AKS-Telescope-Airlock` pool, `0 1-23/4 * * *` schedule on `main`, Manual OR (Schedule AND main) condition, `always: true`.
- 3-way matrix (`n10-p{300,700,1100}-memory`, `max_pods={30,70,110}`, `operation_timeout={3m,7m,11m}`, `load_type=memory`, `scrape_kubelets=True`, `host_network=False`, 120-min timeout).
- A/B differentiator: `azure_swedencentral_default` binds `Default-CNI` variable group and forwards `$(AKS_CLI_CUSTOM_HEADERS)`; `azure_swedencentral_stateless` runs the same cluster shape without them.
- Cluster shape: AKS `cri-resource-consume`, k8s `1.33`, `--tier standard`, azure CNI overlay, `--pod-cidr 10.0.0.0/9`, `--service-cidr 192.168.0.0/16`, `--dns-service-ip 192.168.0.10`, attached to `cri-vnet` (10.0.0.0/9) / `cri-subnet-1` (10.0.0.0/16).
- Node pools: `default` 3 × `Standard_D16ds_v4` Ephemeral with `CriticalAddonsOnly`; `prompool` 1 × `Standard_D16ds_v4` labeled `prometheus=true`; `userpool0` 10 × `Standard_D16ds_v4` labeled `cri-resource-consume=true` and tainted `NoSchedule`+`NoExecute`.
- 14-Ready-nodes assertion (within 10 min).
- Workload: CL2 `override`+`execute`+`collect` with identical args, `ghcr.io/azure/clusterloader2:v20241016`, resource-consumer 1.13, `pod_startup_latency_threshold=15s`. `cloud_info` collected and threaded into every result row.
- BYO mode gating (`skip_resource_management` + OWNER check).
- Teardown: RG delete under `always()` with lifecycle tags (`owner=aks`, `creation_date`, `deletion_due_time`, `SkipAKSCluster=1`, `SkipASB_Audit=true`), plus EKS teardown via `eksctl`.
- AWS baseline: `eksctl` config reproducing `aws.tfvars` (k8s 1.33, VPC 10.0.0.0/16, m5.4xlarge, 3/1/10 pools, same labels/taints, coredns/vpc-cni/kube-proxy addons).

## Test plan
- [ ] `kcl run kcl/perf-eval/cni-benchmark/cni-ab-testing/pipeline.k -o /tmp/out.yaml` and diff against the committed `pipeline.yaml`.
- [ ] Dry-run the generated pipeline in ADO to confirm it validates.
- [ ] One end-to-end pipeline run on `swedencentral` to verify AKS creation, CL2 execution, result upload, and teardown.
