### PR TITLE
Right-size vn100-p10k virtualnodes and runner pools

### DIFF
--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -33,7 +33,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
+            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.xlarge,n1-standard-8"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -33,7 +33,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.xlarge,n1-standard-8"
+            vc_affinity: "eks.amazonaws.com/nodegroup=virtualnodes"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
@@ -58,7 +58,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
+            vc_affinity: "cloud.google.com/gke-nodepool=virtualnodes"
           max_parallel: 2
           timeout_in_minutes: 360
           credential_type: service_connection
@@ -88,7 +88,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
+            vc_affinity: "agentpool=virtualnodes"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
@@ -122,7 +122,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
+            vc_affinity: "agentpool=virtualnodes"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
@@ -156,7 +156,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
-            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
+            vc_affinity: "agentpool=virtualnodes"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection

--- a/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
+++ b/pipelines/perf-eval/API Server Benchmark/apiserver-benchmark-virtualnodes100-pods10k.yml
@@ -33,6 +33,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
@@ -57,6 +58,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
           max_parallel: 2
           timeout_in_minutes: 360
           credential_type: service_connection
@@ -86,6 +88,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
@@ -119,6 +122,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection
@@ -152,6 +156,7 @@ stages:
             runner_image: ghcr.io/azure/kperf:0.3.4
             benchmark_subcmd: node100_pod10k
             benchmark_subcmd_args: "--total 72000 --deployments=10 --interval 24h --cpu 64 --memory 192"
+            vc_affinity: "node.kubernetes.io/instance-type=Standard_D2s_v3,m4.2xlarge,n1-standard-8"
           max_parallel: 2
           timeout_in_minutes: 760
           credential_type: service_connection

--- a/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/aws.tfvars
@@ -75,11 +75,14 @@ eks_config_list = [{
       name           = "virtualnodes"
       ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.xlarge"]
-      min_size       = 2
-      max_size       = 2
-      desired_size   = 2
-      capacity_type  = "ON_DEMAND"
-      labels         = { terraform = "true", k8s = "true", role = "apiserver-eval" } # Optional input
+      # AWS requires 2 nodes because each node is bounded by 4 ENIs and 15 IPs per ENI,
+      # limiting it to fewer than 60 pods.
+      # See https://docs.aws.amazon.com/ec2/latest/instancetypes/pg.html#pg_network.
+      min_size      = 2
+      max_size      = 2
+      desired_size  = 2
+      capacity_type = "ON_DEMAND"
+      labels        = { terraform = "true", k8s = "true", role = "apiserver-eval" } # Optional input
     },
     {
       name           = "runner"

--- a/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/aws.tfvars
@@ -74,7 +74,7 @@ eks_config_list = [{
     {
       name           = "virtualnodes"
       ami_type       = "AL2023_x86_64_STANDARD"
-      instance_types = ["m4.2xlarge"]
+      instance_types = ["m4.xlarge"]
       min_size       = 2
       max_size       = 2
       desired_size   = 2

--- a/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/aws.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/aws.tfvars
@@ -75,9 +75,9 @@ eks_config_list = [{
       name           = "virtualnodes"
       ami_type       = "AL2023_x86_64_STANDARD"
       instance_types = ["m4.2xlarge"]
-      min_size       = 5
-      max_size       = 5
-      desired_size   = 5
+      min_size       = 2
+      max_size       = 2
+      desired_size   = 2
       capacity_type  = "ON_DEMAND"
       labels         = { terraform = "true", k8s = "true", role = "apiserver-eval" } # Optional input
     },

--- a/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/azure.tfvars
@@ -18,7 +18,7 @@ aks_cli_config_list = [
       {
         name       = "virtualnodes"
         node_count = 1
-        vm_size    = "Standard_D8s_v3"
+        vm_size    = "Standard_D2s_v3"
       },
       {
         name       = "runner"

--- a/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/azure.tfvars
+++ b/scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/azure.tfvars
@@ -17,12 +17,12 @@ aks_cli_config_list = [
     extra_node_pool = [
       {
         name       = "virtualnodes"
-        node_count = 5
+        node_count = 1
         vm_size    = "Standard_D8s_v3"
       },
       {
         name       = "runner"
-        node_count = 3
+        node_count = 2
         vm_size    = "Standard_D16s_v3"
       }
     ]

--- a/steps/engine/kperf/execute.yml
+++ b/steps/engine/kperf/execute.yml
@@ -55,15 +55,22 @@ steps:
       cmd_name=warmup
     fi
 
+    vc_affinity_args=()
+    if [[ -n "${VC_AFFINITY}" ]]; then
+      vc_affinity_args+=(--vc-affinity="${VC_AFFINITY}")
+    fi
+
     sudo -E $(command -v runkperf) -v 3 ${cmd_name} \
       --kubeconfig ~/.kube/config \
       --runner-image ${RUNNER_IMAGE} ${is_eks} \
+      "${vc_affinity_args[@]}" \
       ${WARMUP_SUBCMD_ARGS}
   env:
     CLOUD: ${{ parameters.cloud }}
     RUNNER_IMAGE: ${{ parameters.engine_input.runner_image }}
     DISABLE_WARMUP: ${{ parameters.disable_warmup }}
     WARMUP_SUBCMD_ARGS: ${{ parameters.warmup_subcmd_args }}
+    VC_AFFINITY: ${{ coalesce(parameters.engine_input.vc_affinity, '') }}
   displayName: "Warmup"
 - script: |
     set -euo pipefail
@@ -79,10 +86,16 @@ steps:
       is_eks=""
     fi
 
+    vc_affinity_args=()
+    if [[ -n "${VC_AFFINITY}" ]]; then
+      vc_affinity_args+=(--vc-affinity="${VC_AFFINITY}")
+    fi
+
     sudo -E $(command -v runkperf) -v 3 bench ${is_eks} \
       --kubeconfig ~/.kube/config \
       --runner-image="${RUNNER_IMAGE}" \
       --runner-flowcontrol="${FLOWCONTROL}" \
+      "${vc_affinity_args[@]}" \
       --result $(TEST_RESULTS_DIR)/tmp_results.json \
       ${BENCHMARK_SUBCMD} ${BENCHMARK_SUBCMD_ARGS} ${EXTRA_BENCHMARK_SUBCMD_ARGS}
 
@@ -94,4 +107,5 @@ steps:
     BENCHMARK_SUBCMD_ARGS: ${{ parameters.engine_input.benchmark_subcmd_args }}
     EXTRA_BENCHMARK_SUBCMD_ARGS: ${{ parameters.extra_benchmark_subcmd_args }}
     FLOWCONTROL: ${{ parameters.flowcontrol }}
+    VC_AFFINITY: ${{ coalesce(parameters.engine_input.vc_affinity, '') }}
   displayName: "Run Benchmark"


### PR DESCRIPTION
## Summary
- change the Azure `vn100-p10k` virtualnodes pool from 5 `Standard_D8s_v3` nodes to 1 `Standard_D2s_v3`.
- reduce the runner pool from 3 to 2 `Standard_D16s_v3` nodes
- downsize AWS job to 2 `m4.xlarge` instances
- update kperf config to use agentpool as affinity label instead of SKUs

## Utilization analysis
The original configuration (5 D8s_v3 virtualnodes, 3 D16s_v3 runners) was sampled every five minutes:
- virtualnodes: majority of time CPU < 1 core and memory < 3.6 GiB
- runner peak: 20.618 CPU cores and 7,349 MiB memory

## Validation
- `terraform fmt -check scenarios/perf-eval/apiserver-vn100pod10k/terraform-inputs/azure.tfvars`
- targeted `yamllint` using the repository configuration
- `git diff --check`
- [Run 20260902.1](https://akstelescope.visualstudio.com/telescope/_build/results?buildId=78675&view=results) exposed kperf's default D8s_v3 affinity; fixed by commit `e9a79035f`
- [Run 20260902.2](https://akstelescope.visualstudio.com/telescope/_build/results?buildId=78681&view=results) succeeded and provided the D4 sizing data
- [Run 20260907.4](https://akstelescope.visualstudio.com/telescope/_build/results?buildId=79310&view=results) succeeded and validated the final D2/runner configuration