### PR TITLE
refactor(kcl): extract shared busybox image into const

### DIFF
--- a/kcl/lib/const.k
+++ b/kcl/lib/const.k
@@ -5,3 +5,6 @@ DEFAULT_SUBSCRIPTION_ID = "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"
 DEFAULT_STORAGE_ACCOUNT = "telescopev2"
 DEFAULT_STORAGE_SUBSCRIPTION_ID = "137f0351-8235-42a6-ac7a-6b46be2d21c7"
 DEFAULT_STORAGE_CONTAINER = "aks"
+
+# Shared busybox image used by the AKS component validation steps.
+BUSYBOX_IMAGE = "mcr.microsoft.com/azurelinux/busybox:1.36"

--- a/kcl/lib/steps/azure/validate_aks_cns.k
+++ b/kcl/lib/steps/azure/validate_aks_cns.k
@@ -1,4 +1,5 @@
 import azure_pipelines.ap.steps
+import lib.const
 
 # azure-cns: a new pod gets an IP from the CNI IPAM, and the pod dataplane can
 # reach in-cluster services. For daemonset/pod health, pair with
@@ -14,7 +15,7 @@ trap 'kubectl delete pod "$pod" --ignore-not-found >/dev/null 2>&1' EXIT
 # Verify CNI IP allocation and routing to the kubernetes API ClusterIP.
 # Kubernetes provides the API service address through KUBERNETES_SERVICE_HOST
 # and KUBERNETES_SERVICE_PORT.
-reach_out=$(kubectl run "$pod" --image=mcr.microsoft.com/azurelinux/busybox:1.36 --restart=Never -i --rm --pod-running-timeout=120s \
+reach_out=$(kubectl run "$pod" --image=${const.BUSYBOX_IMAGE} --restart=Never -i --rm --pod-running-timeout=120s \
   --command -- sh -c 'nc -w5 "$KUBERNETES_SERVICE_HOST" "$KUBERNETES_SERVICE_PORT" && echo REACHABLE' 2>&1)
 echo "dataplane check: $reach_out"
 if ! echo "$reach_out" | grep -q 'REACHABLE'; then

--- a/kcl/lib/steps/azure/validate_aks_coredns.k
+++ b/kcl/lib/steps/azure/validate_aks_coredns.k
@@ -1,4 +1,5 @@
 import azure_pipelines.ap.steps
+import lib.const
 
 # coredns: a DNS query resolves the in-cluster kubernetes API service to a
 # valid ClusterIP. For pod/controller health, pair with
@@ -10,7 +11,7 @@ set +e
 
 pod="aks-validation-dns-$RANDOM"
 trap 'kubectl delete pod "$pod" --ignore-not-found >/dev/null 2>&1' EXIT
-out=$(kubectl run "$pod" --image=mcr.microsoft.com/azurelinux/busybox:1.36 --restart=Never -i --rm --pod-running-timeout=120s \
+out=$(kubectl run "$pod" --image=${const.BUSYBOX_IMAGE} --restart=Never -i --rm --pod-running-timeout=120s \
   --command -- nslookup kubernetes.default.svc.cluster.local 2>&1)
 echo "$out"
 # busybox nslookup prints the resolved name followed by an Address line.


### PR DESCRIPTION
Move the hardcoded busybox image used by AKS validation steps into a single BUSYBOX_IMAGE constant in lib/const.k for easier version management.