### PR TITLE
Update AKS agent pool API version

### DIFF
--- a/modules/python/clients/aks_machine_client.py
+++ b/modules/python/clients/aks_machine_client.py
@@ -31,7 +31,7 @@ get_logger("msal").setLevel(logging.ERROR)
 
 _ARM_BASE = "https://management.azure.com"
 _ARM_SCOPE = "https://management.azure.com/.default"
-_AGENTPOOL_API_VERSION = "2024-06-02-preview"
+_AGENTPOOL_API_VERSION = "2025-06-02-preview"
 _MACHINE_API_VERSION = "2025-06-02-preview"
 _POLL_INTERVAL_SECONDS = 10
 # Per-request HTTP timeout is capped so that a single slow PUT/GET cannot

--- a/modules/python/tests/test_aks_machine_client.py
+++ b/modules/python/tests/test_aks_machine_client.py
@@ -78,7 +78,7 @@ class TestAKSMachineClient(unittest.TestCase):
 
         mock_make_request.assert_called_once()
         call_args = mock_make_request.call_args
-        self.assertEqual(call_args.args[0], "PUT")
+        self.assertTrue(call_args.args[1].endswith("api-version=2025-06-02-preview"))
         self.assertEqual(call_args.kwargs["data"], {"properties": {"mode": "Machines"}})
         metadata_keys = {
             call.args[0] for call in self.mock_operation.add_metadata.call_args_list

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -6,6 +6,8 @@ pool:
 variables:
   SCENARIO_TYPE: perf-eval
   SCENARIO_NAME: k8s-cluster-crud-machine
+  AZURE_SERVICE_CONNECTION: Azure-for-Telescope-Large-Cluster-Sub
+  AZURE_SUBSCRIPTION_ID: 854c9ddb-fe9e-4aea-8d58-99ed88282881
 
 stages:
   - stage: azure_canadacentral_machine_api_version

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -4,25 +4,29 @@ pool:
   name: 'AKS-Telescope-Airlock'
 
 variables:
-  SCENARIO_TYPE: <scenario-type>
-  SCENARIO_NAME: <scenario-name>
+  SCENARIO_TYPE: perf-eval
+  SCENARIO_NAME: k8s-cluster-crud-machine
 
 stages:
-  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
+  - stage: azure_canadacentral_machine_api_version
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml # must keep as is
+      - template: /jobs/competitive-test.yml
         parameters:
-          cloud: <cloud> # e.g. azure, aws
-          regions: # list of regions
-            - region1 # e.g. eastus2
-          topology: <topology> # e.g. cluster-autoscaler
-          engine: <engine> # e.g. clusterloader2
-          matrix: # list of test parameters to customize the provisioned resources
-            <case-name>:
-              <key1>: <value1>
-              <key2>: <value2>
-          max_parallel: <number of concurrent jobs> # required
-          credential_type: service_connection # required
+          cloud: azure
+          regions:
+            - canadacentral
+          topology: k8s-cluster-crud-machine
+          engine: machine
+          matrix:
+            canadacentral-agentpool-api-version:
+              vm_size: Standard_D2_v3
+              pool_name: smallpool1
+              scale_machine_count: 10
+              machine_workers: 5
+              use_batch_api: "false"
+              step_time_out: 900
+          max_parallel: 1
+          credential_type: service_connection
           ssh_key_enabled: false
-          timeout_in_minutes: 60 # if not specified, default is 60
+          timeout_in_minutes: 360

--- a/pipelines/system/new-pipeline-test.yml
+++ b/pipelines/system/new-pipeline-test.yml
@@ -4,31 +4,25 @@ pool:
   name: 'AKS-Telescope-Airlock'
 
 variables:
-  SCENARIO_TYPE: perf-eval
-  SCENARIO_NAME: k8s-cluster-crud-machine
-  AZURE_SERVICE_CONNECTION: Azure-for-Telescope-Large-Cluster-Sub
-  AZURE_SUBSCRIPTION_ID: 854c9ddb-fe9e-4aea-8d58-99ed88282881
+  SCENARIO_TYPE: <scenario-type>
+  SCENARIO_NAME: <scenario-name>
 
 stages:
-  - stage: azure_canadacentral_machine_api_version
+  - stage: <stage-name> # format: <cloud>[_<region>]+ (e.g. azure_eastus2, aws_eastus_westus)
     dependsOn: []
     jobs:
-      - template: /jobs/competitive-test.yml
+      - template: /jobs/competitive-test.yml # must keep as is
         parameters:
-          cloud: azure
-          regions:
-            - canadacentral
-          topology: k8s-cluster-crud-machine
-          engine: machine
-          matrix:
-            canadacentral-agentpool-api-version:
-              vm_size: Standard_D2_v3
-              pool_name: smallpool1
-              scale_machine_count: 10
-              machine_workers: 5
-              use_batch_api: "false"
-              step_time_out: 900
-          max_parallel: 1
-          credential_type: service_connection
+          cloud: <cloud> # e.g. azure, aws
+          regions: # list of regions
+            - region1 # e.g. eastus2
+          topology: <topology> # e.g. cluster-autoscaler
+          engine: <engine> # e.g. clusterloader2
+          matrix: # list of test parameters to customize the provisioned resources
+            <case-name>:
+              <key1>: <value1>
+              <key2>: <value2>
+          max_parallel: <number of concurrent jobs> # required
+          credential_type: service_connection # required
           ssh_key_enabled: false
-          timeout_in_minutes: 360
+          timeout_in_minutes: 60 # if not specified, default is 60


### PR DESCRIPTION
## Summary
- update agent pool REST requests from `2024-06-02-preview` to `2025-06-02-preview`
- assert the selected API version in the Machine client unit test

## Context
The `K8S CLUSTER CRUD MACHINE` pipeline has failed since July 23 because ARM no longer advertises `2024-06-02-preview` for `Microsoft.ContainerService/managedClusters` in Canada Central. The current provider manifest advertises `2025-06-02-preview`.

## Validation
- `PYTHONPATH=modules/python python3.12 -m pytest -q modules/python/tests/test_aks_machine_client.py` (38 passed, 3 subtests passed)
- `PYTHONPATH=modules/python pylint modules/python/clients/aks_machine_client.py modules/python/tests/test_aks_machine_client.py` (10.00/10)
- `python3.12 -m compileall -q modules/python/clients/aks_machine_client.py modules/python/tests/test_aks_machine_client.py`
- `git diff --check`
- live validation: queue Azure DevOps definition 14 from this branch and verify the agent-pool PUT plus Machine CRUD complete