### PR TITLE
fix(kperf): retry runner group creation after cleanup

### DIFF
--- a/kcl/lib/steps/kperf/run_benchmark.k
+++ b/kcl/lib/steps/kperf/run_benchmark.k
@@ -32,12 +32,32 @@ RunKperfRunnerGroup = lambda runnerImage: str, runnerGroup: str, flowcontrol: st
 set -euo pipefail
 set -x
 
-kperf rg delete
+cleanup_rg() {
+  kperf rg delete || true
+  kubectl -n runnergroups-kperf-io delete pod runnergroup-server \\
+    --force --grace-period=0 --ignore-not-found=true --timeout=120s || true
+}
 
-kperf rg run \\
+cleanup_rg
+
+attempt=0
+max_attempts=10
+until kperf rg run \\
   --runner-image=${runnerImage} \\
   --runnergroup="${runnerGroup}" \\
-  ${flowcontrolFlag}${affinityFlag}
+  ${flowcontrolFlag}${affinityFlag}; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "kperf rg run failed after $attempt attempts" >&2
+    kubectl -n runnergroups-kperf-io get pods -o wide || true
+    kubectl -n runnergroups-kperf-io describe pod runnergroup-server || true
+    kubectl -n runnergroups-kperf-io get events --sort-by=.lastTimestamp | tail -50 || true
+    exit 1
+  fi
+  echo "attempt $attempt failed; retry in 120s" >&2
+  sleep 120
+  cleanup_rg
+done
 """
         displayName = "Run kperf runner group"
         target = target

--- a/kcl/lib/steps/kperf/run_benchmark.k
+++ b/kcl/lib/steps/kperf/run_benchmark.k
@@ -64,9 +64,9 @@ until run_rg; do
     kubectl -n runnergroups-kperf-io get events --sort-by=.lastTimestamp | tail -50 || true
     exit 1
   fi
-  echo "attempt $attempt failed; retry in 120s" >&2
-  sleep 120
   cleanup_rg
+  echo "attempt $attempt failed; cleaning up and retrying in 120s" >&2
+  sleep 120
 done
 """
         displayName = "Run kperf runner group"

--- a/kcl/lib/steps/kperf/run_benchmark.k
+++ b/kcl/lib/steps/kperf/run_benchmark.k
@@ -25,12 +25,25 @@ runkperf -v 3 bench \\
 # RunKperfRunnerGroup runs `kperf rg run` with the specified runner image, runner
 # group manifest, optional flow control setting, and optional affinity selector.
 RunKperfRunnerGroup = lambda runnerImage: str, runnerGroup: str, flowcontrol: str = "", affinity: str = "", target: str = None -> steps.Step {
-    flowcontrolFlag = "--runner-flowcontrol=\"${flowcontrol}\" \\\n  " if flowcontrol else ""
-    affinityFlag = "--affinity=\"${affinity}\" \\\n  " if affinity else ""
     steps.Script {
         script = """
 set -euo pipefail
 set -x
+
+run_rg() {
+  args=(
+    rg run
+    --runner-image="${runnerImage}"
+    --runnergroup="${runnerGroup}"
+  )
+  if [ -n "${flowcontrol}" ]; then
+    args+=(--runner-flowcontrol="${flowcontrol}")
+  fi
+  if [ -n "${affinity}" ]; then
+    args+=(--affinity="${affinity}")
+  fi
+  kperf "\${args[@]}"
+}
 
 cleanup_rg() {
   kperf rg delete || true
@@ -42,10 +55,7 @@ cleanup_rg
 
 attempt=0
 max_attempts=10
-until kperf rg run \\
-  --runner-image=${runnerImage} \\
-  --runnergroup="${runnerGroup}" \\
-  ${flowcontrolFlag}${affinityFlag}; do
+until run_rg; do
   attempt=$((attempt + 1))
   if [ "$attempt" -ge "$max_attempts" ]; then
     echo "kperf rg run failed after $attempt attempts" >&2


### PR DESCRIPTION
Add retries to handle transient failures caused by stale runner group resources during frequent delete-and-create operations.