### PR TITLE
Support fractional totalGiB in kperf data ingest

### DIFF
--- a/kcl/lib/steps/kperf/data_ingest.k
+++ b/kcl/lib/steps/kperf/data_ingest.k
@@ -57,12 +57,8 @@ for batch in $(seq 1 $TOTAL_BATCHES); do
       exit 1
     fi
     echo "Batch $batch attempt $attempt failed; cleaning up before retry..."
-<<<<<<< HEAD
     # delete reconstructs names <set>-<0..total-1>, so total must cover the whole batch.
     runkperf data ${dataType} --namespace ${namespace} delete ${name}-b$batch --total $COUNT || true
-=======
-    runkperf data ${dataType} --namespace ${namespace} delete ${name}-b$batch || true
->>>>>>> 70e38325 (Make kperf ingest batch names predictable and avoid residue on retry)
   done
 
   completed=$((completed + COUNT))

--- a/kcl/lib/steps/kperf/data_ingest.k
+++ b/kcl/lib/steps/kperf/data_ingest.k
@@ -57,8 +57,12 @@ for batch in $(seq 1 $TOTAL_BATCHES); do
       exit 1
     fi
     echo "Batch $batch attempt $attempt failed; cleaning up before retry..."
+<<<<<<< HEAD
     # delete reconstructs names <set>-<0..total-1>, so total must cover the whole batch.
     runkperf data ${dataType} --namespace ${namespace} delete ${name}-b$batch --total $COUNT || true
+=======
+    runkperf data ${dataType} --namespace ${namespace} delete ${name}-b$batch || true
+>>>>>>> 70e38325 (Make kperf ingest batch names predictable and avoid residue on retry)
   done
 
   completed=$((completed + COUNT))

--- a/kcl/lib/steps/kperf/data_ingest.k
+++ b/kcl/lib/steps/kperf/data_ingest.k
@@ -22,7 +22,7 @@ RunKperfDataIngest = lambda dataType: str, namespace: str, name: str, totalGiB: 
 set -euo pipefail
 set -x
 
-TOTAL_OBJECTS_COUNT=$(( ${totalGiB} * ${BYTES_PER_GIB} / ${size} ))
+TOTAL_OBJECTS_COUNT=$(awk 'BEGIN{printf "%d", ${totalGiB} * ${BYTES_PER_GIB} / ${size}}')
 TOTAL_BATCHES=$(( (TOTAL_OBJECTS_COUNT + ${BATCH_SIZE} - 1) / ${BATCH_SIZE} ))
 
 kubectl create namespace ${namespace} 2>/dev/null || true


### PR DESCRIPTION
Compute object count with awk instead of shell integer arithmetic so values like 0.5 GiB work; bash $(( )) rejects decimals.