### PR TITLE
Reduce Configmaps benchmark system pool to one node

### DIFF
--- a/kcl/apiserver_benchmark/configmaps100/pipeline.k
+++ b/kcl/apiserver_benchmark/configmaps100/pipeline.k
@@ -23,7 +23,7 @@ az aks create \\
   --subscription "${SUBSCRIPTION_ID}" \\
   --location "${LOCATION}" \\
   --kubernetes-version "1.35" \\
-  --node-count 2 \\
+    --node-count 1 \
   --node-vm-size "Standard_D2s_v3" \\
   --network-plugin azure \\
   --network-plugin-mode overlay \\

--- a/kcl/apiserver_benchmark/configmaps100/pipeline.k
+++ b/kcl/apiserver_benchmark/configmaps100/pipeline.k
@@ -23,7 +23,7 @@ az aks create \\
   --subscription "${SUBSCRIPTION_ID}" \\
   --location "${LOCATION}" \\
   --kubernetes-version "1.35" \\
-    --node-count 1 \
+  --node-count 1 \\
   --node-vm-size "Standard_D2s_v3" \\
   --network-plugin azure \\
   --network-plugin-mode overlay \\

--- a/kcl/apiserver_benchmark/configmaps100/pipeline.yaml
+++ b/kcl/apiserver_benchmark/configmaps100/pipeline.yaml
@@ -71,8 +71,7 @@ stages:
             --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
             --location "uksouth" \
             --kubernetes-version "1.35" \
-            --node-count 2 \
-            --node-vm-size "Standard_D2s_v3" \
+              --node-count 1   --node-vm-size "Standard_D2s_v3" \
             --network-plugin azure \
             --network-plugin-mode overlay \
             --nodepool-taints "CriticalAddonsOnly=true:NoSchedule" \
@@ -303,8 +302,7 @@ stages:
             --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
             --location "uksouth" \
             --kubernetes-version "1.35" \
-            --node-count 2 \
-            --node-vm-size "Standard_D2s_v3" \
+              --node-count 1   --node-vm-size "Standard_D2s_v3" \
             --network-plugin azure \
             --network-plugin-mode overlay \
             --nodepool-taints "CriticalAddonsOnly=true:NoSchedule" \

--- a/kcl/apiserver_benchmark/configmaps100/pipeline.yaml
+++ b/kcl/apiserver_benchmark/configmaps100/pipeline.yaml
@@ -71,7 +71,8 @@ stages:
             --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
             --location "uksouth" \
             --kubernetes-version "1.35" \
-              --node-count 1   --node-vm-size "Standard_D2s_v3" \
+            --node-count 1 \
+            --node-vm-size "Standard_D2s_v3" \
             --network-plugin azure \
             --network-plugin-mode overlay \
             --nodepool-taints "CriticalAddonsOnly=true:NoSchedule" \
@@ -302,7 +303,8 @@ stages:
             --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
             --location "uksouth" \
             --kubernetes-version "1.35" \
-              --node-count 1   --node-vm-size "Standard_D2s_v3" \
+            --node-count 1 \
+            --node-vm-size "Standard_D2s_v3" \
             --network-plugin azure \
             --network-plugin-mode overlay \
             --nodepool-taints "CriticalAddonsOnly=true:NoSchedule" \


### PR DESCRIPTION
## Summary

Reduce the API Server List Configmaps benchmark system pool from two to one `Standard_D2s_v3` node in both `workload_low` and `exempt` stages. The runner pool remains at three `Standard_D16s_v3` nodes.

The generated pipeline YAML is updated from the KCL source.

## Observed resource usage

Validated with successful full pipeline [build 79349](https://akstelescope.visualstudio.com/telescope/_build/results?buildId=79349), which ran both stages and sampled all agent pools.

| Stage / pool | Tested size | Average CPU used | Peak CPU used | Average memory used | Peak memory used |
|---|---|---:|---:|---:|---:|
| Workload-low `nodepool1` | 1 x `Standard_D2s_v3` | 0.15 cores (7.83%) | 0.20 cores (10.58%) | 1.27 GiB (22.54%) | 1.30 GiB (23.02%) |
| Workload-low `runner` | 3 x `Standard_D16s_v3` | 25.91 cores (54.87%) | 32.86 cores (69.60%) | 3.61 GiB (2.08%) | 3.79 GiB (2.19%) |
| Exempt `nodepool1` | 1 x `Standard_D2s_v3` | 0.26 cores (13.93%) | 0.66 cores (34.63%) | 1.30 GiB (23.04%) | 1.38 GiB (24.42%) |
| Exempt `runner` | 3 x `Standard_D16s_v3` | 28.01 cores (59.32%) | 33.96 cores (71.91%) | 3.58 GiB (2.07%) | 3.68 GiB (2.12%) |

The single-node system pool has sufficient CPU and memory headroom in both stages. The runner pool is intentionally unchanged: two `D16s_v3` nodes provide about 31.48 allocatable cores, below the observed 33.96-core peak.

## Validation

- Full two-stage benchmark build 79349 succeeded
- Regenerated YAML with `kcl run kcl/apiserver_benchmark/configmaps100/pipeline.k -S output -o kcl/apiserver_benchmark/configmaps100/pipeline.yaml`
- Confirmed both AKS create blocks use `--node-count 1`
- Confirmed both runner blocks remain at `--node-count 3`
- `git diff --check` passes