### PR TITLE
Add hyperscale migration benchmark scaffolding

### DIFF
--- a/kcl/ccp_team/hyperscale_migration/README.md
+++ b/kcl/ccp_team/hyperscale_migration/README.md
@@ -1,0 +1,50 @@
+# Hyperscale Migration Benchmark
+
+This Azure DevOps pipeline benchmarks migration of a fresh Standard-tier AKS
+cluster to an H2, H4, or H8 control-plane profile.
+
+## Workflow
+
+1. Create an AKS 1.36 cluster in `westus2`.
+2. Add a 20-node `Standard_D4_v3` pool for KWOK controllers.
+3. Create and validate 2,000 simulated KWOK Nodes.
+4. Install the Go migration verifier and ingest a fixed 2 GiB workload.
+5. Start the selected H-profile migration and wait for completion.
+6. Verify the ingested Kubernetes objects and etcd shard data.
+7. Delete the resource group unless `keep_cluster` is enabled.
+
+The workload consists of deterministic ConfigMaps, Secrets, and Deployments so
+payload integrity can be checked after migration. Etcd shard verification uses
+`etcdctl` to confirm replicated data.
+
+## Payload Verification
+
+The Go verifier generates each payload deterministically from the seed,
+resource kind, object index, and payload block index. During ingestion it stores
+the complete payload in the Kubernetes object and records its SHA-256 hash in a
+manifest.
+
+After migration, the verifier reads every object through the Kubernetes API,
+hashes the complete stored payload again, and compares it with the manifest.
+Missing, unexpected, or mismatched objects fail verification. This confirms
+logical object correctness; the separate `etcdctl` step checks that shard data
+is present on all etcd replicas.
+
+## Parameters
+
+- `scaling_size`: `H2`, `H4`, or `H8`.
+- `keep_cluster`: retain the cluster after the run.
+
+## Current Status
+
+Cluster and KWOK provisioning are implemented. Migration-verifier installation,
+workload ingestion, migration, waiting, and verification are currently
+placeholder steps.
+
+Generate the pipeline YAML with:
+
+```bash
+kcl run kcl/ccp_team/hyperscale_migration/ \
+  -S output \
+  -o kcl/ccp_team/hyperscale_migration/pipeline.yaml
+```

--- a/kcl/ccp_team/hyperscale_migration/kwok-node.yaml
+++ b/kcl/ccp_team/hyperscale_migration/kwok-node.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Node
+metadata:
+  name: {{node_name}}
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: {{node_name}}
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    kwok-controller-group: "{{controller_group}}"
+    kwok.x-k8s.io/node: "fake"
+    type: kwok
+spec:
+  providerID: "kwok://{{node_name}}"
+  unschedulable: false
+  taints:
+    - effect: NoSchedule
+      key: kubernetes.io/arch
+      value: arm64
+status:
+  addresses:
+    - type: InternalIP
+      address: {{node_ip}}
+  allocatable:
+    cpu: {{node_cpu}}
+    memory: {{node_memory}}
+    pods: {{node_pods}}
+    nvidia.com/gpu: {{node_gpu}}
+  capacity:
+    cpu: {{node_cpu}}
+    memory: {{node_memory}}
+    pods: {{node_pods}}
+    nvidia.com/gpu: {{node_gpu}}
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: KubeletReady
+      message: kubelet is posting ready status
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running

--- a/kcl/ccp_team/hyperscale_migration/pipeline.k
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.k
@@ -1,0 +1,241 @@
+import azure_pipelines.ap
+import azure_pipelines.ap.jobs.job
+import azure_pipelines.ap.steps
+import lib.const
+import lib.steps.azure
+import lib.steps.common
+import lib.steps.k8s
+import lib.util.asi_dashboard
+
+SUBSCRIPTION_ID = "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"
+LOCATION = "westus2"
+KUBERNETES_VERSION = "1.36"
+AKS_PREVIEW_EXTENSION_VERSION = "20.0.0b6"
+
+SIMULATED_NODE_COUNT = 2000
+KWOK_NODES_PER_CONTROLLER = 100
+RESULT_ARTIFACT = "hyperscale-migration-results"
+RESULT_DIR = "$(Build.ArtifactStagingDirectory)/hyperscale-migration"
+
+CLUSTER = "hyperscale-migration-$(Build.BuildId)"
+RESOURCE_GROUP = "hyperscale-migration-$(Build.BuildId)"
+
+KWOK_POOL = azure.NodePool {
+  name = "kwokpool"
+    sku = "Standard_D2_v4"
+  count = 20
+    taintPrefix = "kwok"
+    labels = "kwok=true"
+}
+
+installMigrationTool = steps.Script {
+    script = """
+echo "Install migration tool placeholder"
+"""
+        displayName = "Install migration tool [placeholder]"
+}
+
+createClusterScript = """
+az extension add \
+  --name aks-preview \
+  --version ${AKS_PREVIEW_EXTENSION_VERSION} \
+  --allow-preview true \
+  --yes
+
+az aks create \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CLUSTER}" \
+  --location "${LOCATION}" \
+  --kubernetes-version "${KUBERNETES_VERSION}" \
+  --dns-name-prefix "${CLUSTER}-dns" \
+  --tier standard \
+  --enable-managed-identity \
+  --generate-ssh-keys \
+  --nodepool-name systempool \
+  --node-count 3 \
+  --node-vm-size Standard_D8S_v4 \
+  --max-pods 250 \
+  --network-plugin azure \
+  --network-plugin-mode overlay \
+  --pod-cidr 10.64.0.0/10 \
+  --service-cidr 10.0.0.0/16 \
+  --dns-service-ip 10.0.0.10 \
+  --outbound-type managedNATGateway \
+  --nat-gateway-managed-outbound-ip-count 10 \
+  --tags SkipAKSCluster=true \
+  --yes
+"""
+
+migrationScript = """
+echo "Migration API placeholder: migrate ${CLUSTER} to \${{ parameters.scaling_size }}"
+"""
+
+benchmarkJob = job.Job {
+    job = "benchmark"
+    displayName = "Create, ingest, migrate, and verify"
+    timeoutInMinutes = 1440
+    steps = [
+        installMigrationTool,
+        common.InstallPythonDependencies(),
+        azure.Login(const.DEFAULT_SERVICE_CONNECTION, SUBSCRIPTION_ID, LOCATION),
+        azure.CreateResourceGroup(
+            const.DEFAULT_SERVICE_CONNECTION,
+            RESOURCE_GROUP,
+            LOCATION,
+            SUBSCRIPTION_ID),
+        azure.AzCli(
+            const.DEFAULT_SERVICE_CONNECTION,
+            "Create standard-tier cluster",
+            createClusterScript),
+        azure.WaitForClusterSucceeded(
+            const.DEFAULT_SERVICE_CONNECTION,
+            CLUSTER,
+            RESOURCE_GROUP,
+            SUBSCRIPTION_ID),
+        azure.CreateNodePool(
+            const.DEFAULT_SERVICE_CONNECTION,
+            CLUSTER,
+            RESOURCE_GROUP,
+            SUBSCRIPTION_ID,
+            KWOK_POOL),
+        azure.GetCredentials(
+            const.DEFAULT_SERVICE_CONNECTION,
+            CLUSTER,
+            RESOURCE_GROUP,
+            SUBSCRIPTION_ID),
+        *k8s.CreateKwokNodes(
+            SIMULATED_NODE_COUNT,
+            params = {
+                "node-manifest-path": "$(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml"
+                "nodes-per-controller": "${KWOK_NODES_PER_CONTROLLER}"
+                "node-selector": "kwok=true"
+                "node-lease-duration-seconds": "100"
+                "pod-play-stage-parallelism": "500"
+            }),
+        steps.Script {
+            script = """
+set -euo pipefail
+START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+echo "##vso[task.setvariable variable=BENCHMARK_START_TIME]$START_TIME"
+echo "Ingest fixed 2 GiB workload placeholder"
+"""
+            displayName = "Ingest fixed 2 GiB workload [placeholder]"
+        },
+        azure.AzCli(
+            const.DEFAULT_SERVICE_CONNECTION,
+          "Migration API Call [placeholder]",
+            migrationScript),
+        azure.GetCredentials(
+            const.DEFAULT_SERVICE_CONNECTION,
+            CLUSTER,
+            RESOURCE_GROUP,
+            SUBSCRIPTION_ID),
+        steps.Script {
+            script = """
+set -euo pipefail
+export PYTHONPATH=$PYTHONPATH:$(pwd)
+python3 kwok/kwok.py \
+  --action validate \
+  --node-count ${SIMULATED_NODE_COUNT} \
+  --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml \
+  --nodes-per-controller ${KWOK_NODES_PER_CONTROLLER} \
+  --node-selector kwok=true \
+  --node-lease-duration-seconds 100 \
+  --pod-play-stage-parallelism 500
+"""
+            workingDirectory = "modules/python"
+            displayName = "Validate KWOK nodes after migration"
+        },
+        steps.Script {
+            script = """
+echo "Verify ingested objects placeholder"
+"""
+            displayName = "Verify ingested objects [placeholder]"
+        },
+        asi_dashboard.PrintAsiDashboardUrl(
+            const.DEFAULT_SERVICE_CONNECTION,
+            CLUSTER,
+            RESOURCE_GROUP,
+            SUBSCRIPTION_ID,
+            startTime="$(BENCHMARK_START_TIME)"),
+        steps.Publish {
+            publish = RESULT_DIR
+            artifact = RESULT_ARTIFACT
+            condition = "always()"
+            displayName = "Publish benchmark results"
+        },
+    ]
+}
+
+# This is intentionally a raw YAML-shaped object. The dependency schema types
+# timeoutInMinutes as an int, while ADO accepts a parameter expression here.
+manualValidationJob = {
+    job = "manual_validation"
+    displayName = "Verify etcd replication"
+    dependsOn = "benchmark"
+    condition = "succeeded('benchmark')"
+    pool = "server"
+    timeoutInMinutes = "\${{ parameters.manual_validation_timeout_minutes }}"
+    steps = [
+        steps.Task {
+            task = "ManualValidation@0"
+            inputs = {
+                notifyUsers = ""
+                instructions = "Use privileged etcdctl access to verify representative ConfigMap, Secret, and Deployment keys on all three members of every shard. Cluster: ${CLUSTER}. Resource group: ${RESOURCE_GROUP}. Target profile: \${{ parameters.scaling_size }}."
+                onTimeout = "reject"
+            }
+            displayName = "Approve etcd replica verification"
+        },
+    ]
+}
+
+cleanupJob = job.Job {
+    job = "cleanup"
+    displayName = "Cleanup"
+    timeoutInMinutes = 60
+    dependsOn = ["benchmark", "manual_validation"]
+    condition = "always()"
+    steps = [
+        azure.DeleteResourceGroup(
+            const.DEFAULT_SERVICE_CONNECTION,
+            RESOURCE_GROUP,
+            SUBSCRIPTION_ID,
+            condition="and(always(), not(\${{ parameters.keep_cluster }}))"),
+        steps.Script {
+            script = """
+echo "Retained cluster ${CLUSTER} in resource group ${RESOURCE_GROUP}"
+"""
+            displayName = "Print retained cluster"
+            condition = "and(always(), \${{ parameters.keep_cluster }})"
+        },
+    ]
+}
+
+output = {
+    name = "Hyperscale Migration Benchmark"
+    trigger = "none"
+    pool = const.DEFAULT_POOL
+    parameters = [
+        ap.Parameter {
+            name = "scaling_size"
+            displayName = "Control plane scaling size"
+            type = "string"
+            default = "H2"
+            values = ["H2", "H4", "H8"]
+        }
+        ap.Parameter {
+            name = "manual_validation_timeout_minutes"
+            displayName = "Manual etcd validation timeout (minutes)"
+            type = "number"
+            default = 60
+        }
+        ap.Parameter {
+            name = "keep_cluster"
+            displayName = "Keep cluster after benchmark"
+            type = "boolean"
+            default = False
+        }
+    ]
+    jobs = [benchmarkJob, manualValidationJob, cleanupJob]
+}

--- a/kcl/ccp_team/hyperscale_migration/pipeline.k
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.k
@@ -21,18 +21,11 @@ CLUSTER = "hyperscale-migration-$(Build.BuildId)"
 RESOURCE_GROUP = "hyperscale-migration-$(Build.BuildId)"
 
 KWOK_POOL = azure.NodePool {
-  name = "kwokpool"
-    sku = "Standard_D2_v4"
-  count = 20
+    name = "kwokpool"
+    sku = "Standard_D4_v3"
+    count = 20
     taintPrefix = "kwok"
     labels = "kwok=true"
-}
-
-installMigrationTool = steps.Script {
-    script = """
-echo "Install migration tool placeholder"
-"""
-        displayName = "Install migration tool [placeholder]"
 }
 
 createClusterScript = """
@@ -76,7 +69,6 @@ benchmarkJob = job.Job {
     displayName = "Create, ingest, migrate, and verify"
     timeoutInMinutes = 1440
     steps = [
-        installMigrationTool,
         common.InstallPythonDependencies(),
         azure.Login(const.DEFAULT_SERVICE_CONNECTION, SUBSCRIPTION_ID, LOCATION),
         azure.CreateResourceGroup(
@@ -113,19 +105,6 @@ benchmarkJob = job.Job {
                 "node-lease-duration-seconds": "100"
                 "pod-play-stage-parallelism": "500"
             }),
-        steps.Script {
-            script = """
-set -euo pipefail
-START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-echo "##vso[task.setvariable variable=BENCHMARK_START_TIME]$START_TIME"
-echo "Ingest fixed 2 GiB workload placeholder"
-"""
-            displayName = "Ingest fixed 2 GiB workload [placeholder]"
-        },
-        azure.AzCli(
-            const.DEFAULT_SERVICE_CONNECTION,
-          "Migration API Call [placeholder]",
-            migrationScript),
         azure.GetCredentials(
             const.DEFAULT_SERVICE_CONNECTION,
             CLUSTER,
@@ -149,9 +128,28 @@ python3 kwok/kwok.py \
         },
         steps.Script {
             script = """
-echo "Verify ingested objects placeholder"
+                    echo "Install Go app image"
+                    """
+            displayName = "Install ingestion client [placeholder]"
+        }
+        steps.Script {
+            script = """
+set -euo pipefail
+START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+echo "##vso[task.setvariable variable=BENCHMARK_START_TIME]$START_TIME"
+echo "Ingest fixed 2 GiB workload placeholder"
 """
-            displayName = "Verify ingested objects [placeholder]"
+            displayName = "Ingest data workload for migration [placeholder]"
+        },
+        azure.AzCli(
+            const.DEFAULT_SERVICE_CONNECTION,
+          "Migration API Call [placeholder]",
+            migrationScript),
+        steps.Bash {
+            bash = """
+echo "Wait for migration complete placeholder"
+"""
+            displayName = "Wait for migration complete [placeholder]"
         },
         asi_dashboard.PrintAsiDashboardUrl(
             const.DEFAULT_SERVICE_CONNECTION,
@@ -159,33 +157,26 @@ echo "Verify ingested objects placeholder"
             RESOURCE_GROUP,
             SUBSCRIPTION_ID,
             startTime="$(BENCHMARK_START_TIME)"),
-        steps.Publish {
-            publish = RESULT_DIR
-            artifact = RESULT_ARTIFACT
-            condition = "always()"
-            displayName = "Publish benchmark results"
-        },
     ]
 }
 
-# This is intentionally a raw YAML-shaped object. The dependency schema types
-# timeoutInMinutes as an int, while ADO accepts a parameter expression here.
-manualValidationJob = {
-    job = "manual_validation"
-    displayName = "Verify etcd replication"
+verificationJob = job.Job {
+    job = "verification"
+    displayName = "Verify ingested objects"
     dependsOn = "benchmark"
     condition = "succeeded('benchmark')"
-    pool = "server"
-    timeoutInMinutes = "\${{ parameters.manual_validation_timeout_minutes }}"
     steps = [
-        steps.Task {
-            task = "ManualValidation@0"
-            inputs = {
-                notifyUsers = ""
-                instructions = "Use privileged etcdctl access to verify representative ConfigMap, Secret, and Deployment keys on all three members of every shard. Cluster: ${CLUSTER}. Resource group: ${RESOURCE_GROUP}. Target profile: \${{ parameters.scaling_size }}."
-                onTimeout = "reject"
-            }
-            displayName = "Approve etcd replica verification"
+        steps.Bash {
+            bash = """
+echo "Verify ingested objects placeholder"
+"""
+            displayName = "Verify ingested objects [placeholder]"
+        },
+        steps.Bash {
+            bash = """
+echo "Verify etcd shards data with etcdctl placeholder"
+"""
+            displayName = "Verify etcd shards data (etcdctl)"
         },
     ]
 }
@@ -194,7 +185,7 @@ cleanupJob = job.Job {
     job = "cleanup"
     displayName = "Cleanup"
     timeoutInMinutes = 60
-    dependsOn = ["benchmark", "manual_validation"]
+    dependsOn = ["benchmark", "verification"]
     condition = "always()"
     steps = [
         azure.DeleteResourceGroup(
@@ -225,17 +216,11 @@ output = {
             values = ["H2", "H4", "H8"]
         }
         ap.Parameter {
-            name = "manual_validation_timeout_minutes"
-            displayName = "Manual etcd validation timeout (minutes)"
-            type = "number"
-            default = 60
-        }
-        ap.Parameter {
             name = "keep_cluster"
             displayName = "Keep cluster after benchmark"
             type = "boolean"
             default = False
         }
     ]
-    jobs = [benchmarkJob, manualValidationJob, cleanupJob]
+    jobs = [benchmarkJob, verificationJob, cleanupJob]
 }

--- a/kcl/ccp_team/hyperscale_migration/pipeline.k
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.k
@@ -105,27 +105,6 @@ benchmarkJob = job.Job {
                 "node-lease-duration-seconds": "100"
                 "pod-play-stage-parallelism": "500"
             }),
-        azure.GetCredentials(
-            const.DEFAULT_SERVICE_CONNECTION,
-            CLUSTER,
-            RESOURCE_GROUP,
-            SUBSCRIPTION_ID),
-        steps.Script {
-            script = """
-set -euo pipefail
-export PYTHONPATH=$PYTHONPATH:$(pwd)
-python3 kwok/kwok.py \
-  --action validate \
-  --node-count ${SIMULATED_NODE_COUNT} \
-  --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml \
-  --nodes-per-controller ${KWOK_NODES_PER_CONTROLLER} \
-  --node-selector kwok=true \
-  --node-lease-duration-seconds 100 \
-  --pod-play-stage-parallelism 500
-"""
-            workingDirectory = "modules/python"
-            displayName = "Validate KWOK nodes after migration"
-        },
         steps.Script {
             script = """
                     echo "Install Go app image"

--- a/kcl/ccp_team/hyperscale_migration/pipeline.k
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.k
@@ -129,15 +129,6 @@ echo "Wait for migration complete placeholder"
             RESOURCE_GROUP,
             SUBSCRIPTION_ID,
             startTime="$(BENCHMARK_START_TIME)"),
-    ]
-}
-
-verificationJob = job.Job {
-    job = "verification"
-    displayName = "Verify ingested objects"
-    dependsOn = "benchmark"
-    condition = "succeeded('benchmark')"
-    steps = [
         steps.Bash {
             bash = """
 echo "Verify ingested objects placeholder"
@@ -150,28 +141,11 @@ echo "Verify etcd shards data with etcdctl placeholder"
 """
             displayName = "Verify etcd shards data (etcdctl)"
         },
-    ]
-}
-
-cleanupJob = job.Job {
-    job = "cleanup"
-    displayName = "Cleanup"
-    timeoutInMinutes = 60
-    dependsOn = ["benchmark", "verification"]
-    condition = "always()"
-    steps = [
         azure.DeleteResourceGroup(
             const.DEFAULT_SERVICE_CONNECTION,
             RESOURCE_GROUP,
             SUBSCRIPTION_ID,
             condition="and(always(), not(\${{ parameters.keep_cluster }}))"),
-        steps.Script {
-            script = """
-echo "Retained cluster ${CLUSTER} in resource group ${RESOURCE_GROUP}"
-"""
-            displayName = "Print retained cluster"
-            condition = "and(always(), \${{ parameters.keep_cluster }})"
-        },
     ]
 }
 
@@ -194,5 +168,5 @@ output = {
             default = False
         }
     ]
-    jobs = [benchmarkJob, verificationJob, cleanupJob]
+    jobs = [benchmarkJob]
 }

--- a/kcl/ccp_team/hyperscale_migration/pipeline.k
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.k
@@ -10,12 +10,6 @@ import lib.util.asi_dashboard
 SUBSCRIPTION_ID = "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"
 LOCATION = "westus2"
 KUBERNETES_VERSION = "1.36"
-AKS_PREVIEW_EXTENSION_VERSION = "20.0.0b6"
-
-SIMULATED_NODE_COUNT = 2000
-KWOK_NODES_PER_CONTROLLER = 100
-RESULT_ARTIFACT = "hyperscale-migration-results"
-RESULT_DIR = "$(Build.ArtifactStagingDirectory)/hyperscale-migration"
 
 CLUSTER = "hyperscale-migration-$(Build.BuildId)"
 RESOURCE_GROUP = "hyperscale-migration-$(Build.BuildId)"
@@ -31,7 +25,7 @@ KWOK_POOL = azure.NodePool {
 createClusterScript = """
 az extension add \
   --name aks-preview \
-  --version ${AKS_PREVIEW_EXTENSION_VERSION} \
+  --version 20.0.0b6 \
   --allow-preview true \
   --yes
 
@@ -58,10 +52,6 @@ az aks create \
   --nat-gateway-managed-outbound-ip-count 10 \
   --tags SkipAKSCluster=true \
   --yes
-"""
-
-migrationScript = """
-echo "Migration API placeholder: migrate ${CLUSTER} to \${{ parameters.scaling_size }}"
 """
 
 benchmarkJob = job.Job {
@@ -96,11 +86,12 @@ benchmarkJob = job.Job {
             CLUSTER,
             RESOURCE_GROUP,
             SUBSCRIPTION_ID),
+        # Create 2,000 simulated nodes across 20 controllers (100 nodes each).
         *k8s.CreateKwokNodes(
-            SIMULATED_NODE_COUNT,
+            2000,
             params = {
                 "node-manifest-path": "$(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml"
-                "nodes-per-controller": "${KWOK_NODES_PER_CONTROLLER}"
+                "nodes-per-controller": "100"
                 "node-selector": "kwok=true"
                 "node-lease-duration-seconds": "100"
                 "pod-play-stage-parallelism": "500"
@@ -123,7 +114,9 @@ echo "Ingest fixed 2 GiB workload placeholder"
         azure.AzCli(
             const.DEFAULT_SERVICE_CONNECTION,
           "Migration API Call [placeholder]",
-            migrationScript),
+                        """
+echo "Migration API placeholder: migrate ${CLUSTER} to \${{ parameters.scaling_size }}"
+"""),
         steps.Bash {
             bash = """
 echo "Wait for migration complete placeholder"

--- a/kcl/ccp_team/hyperscale_migration/pipeline.yaml
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.yaml
@@ -1,0 +1,292 @@
+name: Hyperscale Migration Benchmark
+trigger: none
+pool: AKS-Telescope-Airlock
+parameters:
+- name: scaling_size
+  displayName: Control plane scaling size
+  type: string
+  default: H2
+  values:
+  - H2
+  - H4
+  - H8
+- name: manual_validation_timeout_minutes
+  displayName: Manual etcd validation timeout (minutes)
+  type: number
+  default: 60
+- name: keep_cluster
+  displayName: Keep cluster after benchmark
+  type: boolean
+  default: false
+jobs:
+- job: benchmark
+  displayName: Create, ingest, migrate, and verify
+  timeoutInMinutes: 1440
+  steps:
+  - script: |2
+
+      echo "Install migration tool placeholder"
+    displayName: Install migration tool [placeholder]
+  - bash: |-
+      set -exo pipefail
+      pip3 install --upgrade "pip<24"
+      pip3 install -r $(Pipeline.Workspace)/s/modules/python/requirements.txt
+    displayName: Install Python dependencies
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az account set --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"
+        az config set defaults.location="westus2"
+        az account show
+    displayName: Login to Azure
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |+
+        set -exo pipefail
+
+        az group create \
+          --name "hyperscale-migration-$(Build.BuildId)" \
+          --location "westus2" \
+          --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
+
+    displayName: Create resource group in westus2 (b8ceb4e5-f05b-4562-a9f5-14acb1f24219)
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az extension add   --name aks-preview   --version 20.0.0b6   --allow-preview true   --yes
+
+        az aks create   --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219"   --resource-group "hyperscale-migration-$(Build.BuildId)"   --name "hyperscale-migration-$(Build.BuildId)"   --location "westus2"   --kubernetes-version "1.36"   --dns-name-prefix "hyperscale-migration-$(Build.BuildId)-dns"   --tier standard   --enable-managed-identity   --generate-ssh-keys   --nodepool-name systempool   --node-count 3   --node-vm-size Standard_D8S_v4   --max-pods 250   --network-plugin azure   --network-plugin-mode overlay   --pod-cidr 10.64.0.0/10   --service-cidr 10.0.0.0/16   --dns-service-ip 10.0.0.10   --outbound-type managedNATGateway   --nat-gateway-managed-outbound-ip-count 10   --tags SkipAKSCluster=true   --yes
+    displayName: Create standard-tier cluster
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        while true; do
+          STATE=$(az aks show \
+            --name "hyperscale-migration-$(Build.BuildId)" \
+            --resource-group "hyperscale-migration-$(Build.BuildId)" \
+            --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
+            --query "provisioningState" \
+            --output tsv)
+          echo "Cluster provisioning state: $STATE"
+          if [ "$STATE" = "Succeeded" ]; then
+            echo "Cluster is ready."
+            break
+          elif [ "$STATE" = "Failed" ] || [ "$STATE" = "Canceled" ]; then
+            echo "Cluster failed with state: $STATE."
+            exit 1
+          else
+            echo "Provisioning state: $STATE. Retry in 30 seconds"
+          fi
+          sleep 30
+        done
+    displayName: Wait for cluster to succeed
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        deadline=$(($(date +%s) + 600))
+        sleep_between=30
+        attempt=0
+        while :; do
+          attempt=$((attempt + 1))
+          set +e
+          output=$(az aks nodepool add \
+            --cluster-name "hyperscale-migration-$(Build.BuildId)" \
+            --resource-group "hyperscale-migration-$(Build.BuildId)" \
+            --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
+            --name "kwokpool" \
+            --node-count 20 \
+            --node-vm-size "Standard_D2_v4" \
+            --mode User \
+            --node-taints kwok=true:NoSchedule \
+          --labels "kwok=true" 2>&1)
+          rc=$?
+          set -e
+          echo "$output"
+          if [ $rc -eq 0 ]; then
+            exit 0
+          fi
+          if echo "$output" | grep -qiE "OperationNotAllowed"; then
+            now=$(date +%s)
+            if [ $now -ge $deadline ]; then
+              echo "Retriable error persisted past 600s retry window ($attempt attempts); giving up."
+              exit $rc
+            fi
+            remaining=$((deadline - now))
+            echo "Attempt $attempt matched retriable pattern; retrying in $sleep_between seconds ($remaining seconds remain in retry window)."
+            sleep $sleep_between
+          else
+            echo "Non-retriable error (rc=$rc); giving up after attempt $attempt."
+            exit $rc
+          fi
+        done
+    displayName: Create node pool kwokpool
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks get-credentials \
+          --name "hyperscale-migration-$(Build.BuildId)" \
+          --resource-group "hyperscale-migration-$(Build.BuildId)" \
+          --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
+          --overwrite-existing
+    displayName: Get credentials for hyperscale-migration-$(Build.BuildId)
+  - script: |2-
+
+      set -exo pipefail
+      export PYTHONPATH=$PYTHONPATH:$(pwd)
+      python3 kwok/kwok.py   --action create   --node-count 2000   --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml --nodes-per-controller 100 --node-selector kwok=true --node-lease-duration-seconds 100 --pod-play-stage-parallelism 500
+    workingDirectory: modules/python
+    displayName: Create KWOK Nodes
+  - script: |2-
+
+      set -exo pipefail
+      export PYTHONPATH=$PYTHONPATH:$(pwd)
+      python3 kwok/kwok.py   --action validate   --node-count 2000   --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml --nodes-per-controller 100 --node-selector kwok=true --node-lease-duration-seconds 100 --pod-play-stage-parallelism 500
+    workingDirectory: modules/python
+    displayName: Validate KWOK Nodes
+  - script: |2
+
+      set -euo pipefail
+      START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+      echo "##vso[task.setvariable variable=BENCHMARK_START_TIME]$START_TIME"
+      echo "Ingest fixed 2 GiB workload placeholder"
+    displayName: Ingest fixed 2 GiB workload [placeholder]
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        echo "Migration API placeholder: migrate hyperscale-migration-$(Build.BuildId) to ${{ parameters.scaling_size }}"
+    displayName: Migration API Call [placeholder]
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az aks get-credentials \
+          --name "hyperscale-migration-$(Build.BuildId)" \
+          --resource-group "hyperscale-migration-$(Build.BuildId)" \
+          --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
+          --overwrite-existing
+    displayName: Get credentials for hyperscale-migration-$(Build.BuildId)
+  - script: |2
+
+      set -euo pipefail
+      export PYTHONPATH=$PYTHONPATH:$(pwd)
+      python3 kwok/kwok.py   --action validate   --node-count 2000   --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml   --nodes-per-controller 100   --node-selector kwok=true   --node-lease-duration-seconds 100   --pod-play-stage-parallelism 500
+    workingDirectory: modules/python
+    displayName: Validate KWOK nodes after migration
+  - script: |2
+
+      echo "Verify ingested objects placeholder"
+    displayName: Verify ingested objects [placeholder]
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        RESOURCE_UID=$(az aks show \
+          --resource-group "hyperscale-migration-$(Build.BuildId)" \
+          --name "hyperscale-migration-$(Build.BuildId)" \
+          --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
+          --query "resourceUid" -o tsv)
+
+        if [ -z "$RESOURCE_UID" ]; then
+          echo "##[warning]Failed to fetch resourceUid, skipping ASI URL"
+          exit 1
+        fi
+
+        END_TIME=""
+        if [ -z "$END_TIME" ]; then
+          END_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+        fi
+
+        FROM_ENCODED=$(echo "$(BENCHMARK_START_TIME)" | sed 's/:/%3A/g')
+        TO_ENCODED=$(echo "$END_TIME" | sed 's/:/%3A/g')
+
+        echo "============================================"
+        echo "ASI Managed Cluster Dashboard URL:"
+        echo "https://asi.azure.ms/services/AKS/pages/Managed%20Cluster?clusterVersion=$RESOURCE_UID&globalFrom=$FROM_ENCODED&globalTo=$TO_ENCODED"
+        echo ""
+        echo "ASI API Server Analyzer URL:"
+        echo "https://asi.azure.ms/services/AKS/pages/API%20Server%20Analyzer?clusterVersion=$RESOURCE_UID&globalFrom=$FROM_ENCODED&globalTo=$TO_ENCODED"
+        echo "============================================"
+    continueOnError: true
+    displayName: Print ASI dashboard URL
+  - publish: $(Build.ArtifactStagingDirectory)/hyperscale-migration
+    artifact: hyperscale-migration-results
+    condition: always()
+    displayName: Publish benchmark results
+- job: manual_validation
+  displayName: Verify etcd replication
+  dependsOn: benchmark
+  condition: succeeded('benchmark')
+  pool: server
+  timeoutInMinutes: ${{ parameters.manual_validation_timeout_minutes }}
+  steps:
+  - task: ManualValidation@0
+    inputs:
+      notifyUsers: ''
+      instructions: 'Use privileged etcdctl access to verify representative ConfigMap, Secret, and Deployment keys on all three members of every shard. Cluster: hyperscale-migration-$(Build.BuildId). Resource group: hyperscale-migration-$(Build.BuildId). Target profile: ${{ parameters.scaling_size }}.'
+      onTimeout: reject
+    displayName: Approve etcd replica verification
+- job: cleanup
+  displayName: Cleanup
+  dependsOn:
+  - benchmark
+  - manual_validation
+  condition: always()
+  timeoutInMinutes: 60
+  steps:
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        az group delete --name "hyperscale-migration-$(Build.BuildId)" --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" --yes
+    condition: and(always(), not(${{ parameters.keep_cluster }}))
+    displayName: Delete resource group (b8ceb4e5-f05b-4562-a9f5-14acb1f24219)
+  - script: |2
+
+      echo "Retained cluster hyperscale-migration-$(Build.BuildId) in resource group hyperscale-migration-$(Build.BuildId)"
+    condition: and(always(), ${{ parameters.keep_cluster }})
+    displayName: Print retained cluster

--- a/kcl/ccp_team/hyperscale_migration/pipeline.yaml
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.yaml
@@ -222,11 +222,6 @@ jobs:
         echo "============================================"
     continueOnError: true
     displayName: Print ASI dashboard URL
-- job: verification
-  displayName: Verify ingested objects
-  dependsOn: benchmark
-  condition: succeeded('benchmark')
-  steps:
   - bash: |2
 
       echo "Verify ingested objects placeholder"
@@ -235,14 +230,6 @@ jobs:
 
       echo "Verify etcd shards data with etcdctl placeholder"
     displayName: Verify etcd shards data (etcdctl)
-- job: cleanup
-  displayName: Cleanup
-  dependsOn:
-  - benchmark
-  - verification
-  condition: always()
-  timeoutInMinutes: 60
-  steps:
   - task: AzureCLI@2
     inputs:
       azureSubscription: Azure-for-Telescope-internal
@@ -254,8 +241,3 @@ jobs:
         az group delete --name "hyperscale-migration-$(Build.BuildId)" --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" --yes
     condition: and(always(), not(${{ parameters.keep_cluster }}))
     displayName: Delete resource group (b8ceb4e5-f05b-4562-a9f5-14acb1f24219)
-  - script: |2
-
-      echo "Retained cluster hyperscale-migration-$(Build.BuildId) in resource group hyperscale-migration-$(Build.BuildId)"
-    condition: and(always(), ${{ parameters.keep_cluster }})
-    displayName: Print retained cluster

--- a/kcl/ccp_team/hyperscale_migration/pipeline.yaml
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.yaml
@@ -10,10 +10,6 @@ parameters:
   - H2
   - H4
   - H8
-- name: manual_validation_timeout_minutes
-  displayName: Manual etcd validation timeout (minutes)
-  type: number
-  default: 60
 - name: keep_cluster
   displayName: Keep cluster after benchmark
   type: boolean
@@ -23,10 +19,6 @@ jobs:
   displayName: Create, ingest, migrate, and verify
   timeoutInMinutes: 1440
   steps:
-  - script: |2
-
-      echo "Install migration tool placeholder"
-    displayName: Install migration tool [placeholder]
   - bash: |-
       set -exo pipefail
       pip3 install --upgrade "pip<24"
@@ -118,7 +110,7 @@ jobs:
             --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
             --name "kwokpool" \
             --node-count 20 \
-            --node-vm-size "Standard_D2_v4" \
+            --node-vm-size "Standard_D4_v3" \
             --mode User \
             --node-taints kwok=true:NoSchedule \
           --labels "kwok=true" 2>&1)
@@ -171,23 +163,6 @@ jobs:
       python3 kwok/kwok.py   --action validate   --node-count 2000   --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml --nodes-per-controller 100 --node-selector kwok=true --node-lease-duration-seconds 100 --pod-play-stage-parallelism 500
     workingDirectory: modules/python
     displayName: Validate KWOK Nodes
-  - script: |2
-
-      set -euo pipefail
-      START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-      echo "##vso[task.setvariable variable=BENCHMARK_START_TIME]$START_TIME"
-      echo "Ingest fixed 2 GiB workload placeholder"
-    displayName: Ingest fixed 2 GiB workload [placeholder]
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        echo "Migration API placeholder: migrate hyperscale-migration-$(Build.BuildId) to ${{ parameters.scaling_size }}"
-    displayName: Migration API Call [placeholder]
   - task: AzureCLI@2
     inputs:
       azureSubscription: Azure-for-Telescope-internal
@@ -209,10 +184,29 @@ jobs:
       python3 kwok/kwok.py   --action validate   --node-count 2000   --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml   --nodes-per-controller 100   --node-selector kwok=true   --node-lease-duration-seconds 100   --pod-play-stage-parallelism 500
     workingDirectory: modules/python
     displayName: Validate KWOK nodes after migration
+  - script: "\n                    echo \"Install Go app image\"\n                    "
+    displayName: Install ingestion client [placeholder]
   - script: |2
 
-      echo "Verify ingested objects placeholder"
-    displayName: Verify ingested objects [placeholder]
+      set -euo pipefail
+      START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+      echo "##vso[task.setvariable variable=BENCHMARK_START_TIME]$START_TIME"
+      echo "Ingest fixed 2 GiB workload placeholder"
+    displayName: Ingest data workload for migration [placeholder]
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: Azure-for-Telescope-internal
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -exo pipefail
+
+        echo "Migration API placeholder: migrate hyperscale-migration-$(Build.BuildId) to ${{ parameters.scaling_size }}"
+    displayName: Migration API Call [placeholder]
+  - bash: |2
+
+      echo "Wait for migration complete placeholder"
+    displayName: Wait for migration complete [placeholder]
   - task: AzureCLI@2
     inputs:
       azureSubscription: Azure-for-Telescope-internal
@@ -249,28 +243,24 @@ jobs:
         echo "============================================"
     continueOnError: true
     displayName: Print ASI dashboard URL
-  - publish: $(Build.ArtifactStagingDirectory)/hyperscale-migration
-    artifact: hyperscale-migration-results
-    condition: always()
-    displayName: Publish benchmark results
-- job: manual_validation
-  displayName: Verify etcd replication
+- job: verification
+  displayName: Verify ingested objects
   dependsOn: benchmark
   condition: succeeded('benchmark')
-  pool: server
-  timeoutInMinutes: ${{ parameters.manual_validation_timeout_minutes }}
   steps:
-  - task: ManualValidation@0
-    inputs:
-      notifyUsers: ''
-      instructions: 'Use privileged etcdctl access to verify representative ConfigMap, Secret, and Deployment keys on all three members of every shard. Cluster: hyperscale-migration-$(Build.BuildId). Resource group: hyperscale-migration-$(Build.BuildId). Target profile: ${{ parameters.scaling_size }}.'
-      onTimeout: reject
-    displayName: Approve etcd replica verification
+  - bash: |2
+
+      echo "Verify ingested objects placeholder"
+    displayName: Verify ingested objects [placeholder]
+  - bash: |2
+
+      echo "Verify etcd shards data with etcdctl placeholder"
+    displayName: Verify etcd shards data (etcdctl) [placeholder]
 - job: cleanup
   displayName: Cleanup
   dependsOn:
   - benchmark
-  - manual_validation
+  - verification
   condition: always()
   timeoutInMinutes: 60
   steps:

--- a/kcl/ccp_team/hyperscale_migration/pipeline.yaml
+++ b/kcl/ccp_team/hyperscale_migration/pipeline.yaml
@@ -163,27 +163,6 @@ jobs:
       python3 kwok/kwok.py   --action validate   --node-count 2000   --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml --nodes-per-controller 100 --node-selector kwok=true --node-lease-duration-seconds 100 --pod-play-stage-parallelism 500
     workingDirectory: modules/python
     displayName: Validate KWOK Nodes
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: Azure-for-Telescope-internal
-      scriptType: bash
-      scriptLocation: inlineScript
-      inlineScript: |
-        set -exo pipefail
-
-        az aks get-credentials \
-          --name "hyperscale-migration-$(Build.BuildId)" \
-          --resource-group "hyperscale-migration-$(Build.BuildId)" \
-          --subscription "b8ceb4e5-f05b-4562-a9f5-14acb1f24219" \
-          --overwrite-existing
-    displayName: Get credentials for hyperscale-migration-$(Build.BuildId)
-  - script: |2
-
-      set -euo pipefail
-      export PYTHONPATH=$PYTHONPATH:$(pwd)
-      python3 kwok/kwok.py   --action validate   --node-count 2000   --node-manifest-path $(Pipeline.Workspace)/s/kcl/ccp_team/hyperscale_migration/kwok-node.yaml   --nodes-per-controller 100   --node-selector kwok=true   --node-lease-duration-seconds 100   --pod-play-stage-parallelism 500
-    workingDirectory: modules/python
-    displayName: Validate KWOK nodes after migration
   - script: "\n                    echo \"Install Go app image\"\n                    "
     displayName: Install ingestion client [placeholder]
   - script: |2
@@ -255,7 +234,7 @@ jobs:
   - bash: |2
 
       echo "Verify etcd shards data with etcdctl placeholder"
-    displayName: Verify etcd shards data (etcdctl) [placeholder]
+    displayName: Verify etcd shards data (etcdctl)
 - job: cleanup
   displayName: Cleanup
   dependsOn:


### PR DESCRIPTION
## Summary

- add KCL and generated Azure DevOps YAML for the hyperscale migration benchmark
- create a fresh Standard-tier AKS cluster in `westus2` with a 20-node `Standard_D4_v3` KWOK controller pool and 2,000 simulated nodes
- add separate verification and cleanup jobs

## Validation

- generated `pipeline.yaml` from `pipeline.k`
- parsed generated YAML and verified expected jobs/parameters
- checked generated Bash syntax