### PR TITLE
Fix azure SDK namespace shadowing in CRUD pipeline steps (run via -m crud.main)

### DIFF
--- a/steps/engine/crud/k8s/collect.yml
+++ b/steps/engine/crud/k8s/collect.yml
@@ -9,12 +9,11 @@ steps:
 - script: |
     set -eo pipefail
 
-    PYTHONPATH=$PYTHONPATH:$(pwd) python3 $PYTHON_SCRIPT_FILE collect
+    PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main collect
 
   displayName: 'Collect K8s CRUD Operations data for ${{ parameters.cloud }}'
   workingDirectory: modules/python
   env:
-    PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
     RESULT_DIR: $(System.DefaultWorkingDirectory)/$(RUN_ID)
     RUN_URL: $(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&view=logs&j=$(System.JobId)
     REGION: ${{ parameters.region }}

--- a/steps/engine/crud/k8s/execute.yml
+++ b/steps/engine/crud/k8s/execute.yml
@@ -6,7 +6,7 @@ steps:
     set -eo pipefail
 
     # Create Node Pool
-    PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" create \
+    PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main create \
       --cloud "$CLOUD" \
       --run-id "$RUN_ID" \
       --result-dir "$RESULT_DIR" \
@@ -21,7 +21,7 @@ steps:
       --capacity-type "${CAPACITY_TYPE:-ON_DEMAND}"
 
     # Scale Up Node Pool
-    PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" scale \
+    PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main scale \
       --cloud "$CLOUD" \
       --run-id "$RUN_ID" \
       --result-dir "$RESULT_DIR" \
@@ -38,7 +38,6 @@ steps:
   displayName: 'Execute K8s Create & Scale Up Operations for ${{ parameters.cloud }}'
   workingDirectory: modules/python
   env:
-    PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
     VM_SIZE: $(VM_SIZE)
     CREATE_NODE_COUNT: $(CREATE_NODE_COUNT)
     SCALE_NODE_COUNT: $(SCALE_NODE_COUNT)
@@ -60,7 +59,7 @@ steps:
       set -eo pipefail
 
       # Deploy Workloads
-      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" deployment \
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main deployment \
         --cloud "$CLOUD" \
         --run-id "$RUN_ID" \
         --result-dir "$RESULT_DIR" \
@@ -74,7 +73,6 @@ steps:
     displayName: 'Execute K8s Workload operations for ${{ parameters.cloud }}'
     workingDirectory: modules/python
     env:
-      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
       POOL_NAME: $(POOL_NAME)
       CLOUD: ${{ parameters.cloud }}
       STEP_TIME_OUT: $(STEP_TIME_OUT)
@@ -89,7 +87,7 @@ steps:
       set -eo pipefail
 
       # Deploy StatefulSets
-      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" statefulset \
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main statefulset \
         --cloud "$CLOUD" \
         --run-id "$RUN_ID" \
         --result-dir "$RESULT_DIR" \
@@ -103,7 +101,6 @@ steps:
     displayName: 'Execute K8s StatefulSet operations for ${{ parameters.cloud }}'
     workingDirectory: modules/python
     env:
-      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
       POOL_NAME: $(POOL_NAME)
       CLOUD: ${{ parameters.cloud }}
       STEP_TIME_OUT: $(STEP_TIME_OUT)
@@ -118,7 +115,7 @@ steps:
       set -eo pipefail
 
       # Deploy Jobs
-      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" job \
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main job \
         --cloud "$CLOUD" \
         --run-id "$RUN_ID" \
         --result-dir "$RESULT_DIR" \
@@ -132,7 +129,6 @@ steps:
     displayName: 'Execute K8s Job operations for ${{ parameters.cloud }}'
     workingDirectory: modules/python
     env:
-      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
       POOL_NAME: $(POOL_NAME)
       CLOUD: ${{ parameters.cloud }}
       STEP_TIME_OUT: $(STEP_TIME_OUT)
@@ -147,7 +143,7 @@ steps:
     set -eo pipefail
 
     # Scale Down Node Pool
-    PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" scale \
+    PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main scale \
       --cloud "$CLOUD" \
       --run-id "$RUN_ID" \
       --result-dir "$RESULT_DIR" \
@@ -162,7 +158,7 @@ steps:
       $([[ "${ENABLE_MANAGED_GPU,,}" == "true" && "${GPU_MIG_STRATEGY}" =~ ^(mixed|single)$ ]] && echo "--gpu-mig-strategy ${GPU_MIG_STRATEGY}" || true)
 
     # Delete Node Pool
-    PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" delete \
+    PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main delete \
       --cloud "$CLOUD" \
       --run-id "$RUN_ID" \
       --result-dir "$RESULT_DIR" \
@@ -172,7 +168,6 @@ steps:
   condition: always()
   workingDirectory: modules/python
   env:
-    PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
     VM_SIZE: $(VM_SIZE)
     CREATE_NODE_COUNT: $(CREATE_NODE_COUNT)
     SCALE_NODE_COUNT: $(SCALE_NODE_COUNT)

--- a/steps/engine/machine/k8s/collect.yml
+++ b/steps/engine/machine/k8s/collect.yml
@@ -10,12 +10,11 @@ steps:
       region: ${{ parameters.region }}
   - script: |
       set -eo pipefail
-      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" collect
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main collect
     workingDirectory: modules/python
     displayName: "Collect Machine API results"
     condition: always()
     env:
-      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
       RUN_ID: $(RUN_ID)
       REGION: ${{ parameters.region }}
       RESULT_DIR: $(System.DefaultWorkingDirectory)/$(RUN_ID)

--- a/steps/engine/machine/k8s/execute.yml
+++ b/steps/engine/machine/k8s/execute.yml
@@ -6,7 +6,7 @@ steps:
   - script: |
       set -eo pipefail
 
-      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" create-machine \
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main create-machine \
         --cloud "$CLOUD" \
         --run-id "$RUN_ID" \
         --node-pool-name "$POOL_NAME" \
@@ -19,7 +19,7 @@ steps:
         use_batch_args+=(--use-batch-api)
       fi
 
-      PYTHONPATH=$PYTHONPATH:$(pwd) python3 "$PYTHON_SCRIPT_FILE" scale-machine \
+      PYTHONPATH=$PYTHONPATH:$(pwd) python3 -m crud.main scale-machine \
         --cloud "$CLOUD" \
         --run-id "$RUN_ID" \
         --node-pool-name "$POOL_NAME" \
@@ -33,7 +33,6 @@ steps:
     workingDirectory: modules/python
     displayName: "Execute Machine API CRUD"
     env:
-      PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
       CLOUD: ${{ parameters.cloud }}
       VM_SIZE: $(VM_SIZE)
       POOL_NAME: $(POOL_NAME)


### PR DESCRIPTION
## Problem

The **GPU Cluster CRUD** pipeline (and other CRUD/Machine-API pipelines) have failed on every run since #1231 merged. Both CRUD tasks fail immediately:

```
File ".../modules/python/crud/main.py", line 19
  from crud.azure.node_pool_crud import NodePoolCRUD
File ".../modules/python/clients/aks_client.py", line 20
  from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
ModuleNotFoundError: No module named 'azure.core'
```

`azure-core` **is** installed correctly by "Install Dependencies" — this is namespace shadowing, not a missing dependency.

## Root cause

The steps run the script as a **file**:

```yaml
workingDirectory: modules/python
env:
  PYTHON_SCRIPT_FILE: $(Pipeline.Workspace)/s/modules/python/crud/main.py
script: python3 "$PYTHON_SCRIPT_FILE" create ...
```

Running `python3 .../crud/main.py` puts the script's own directory — `modules/python/crud/` — at `sys.path[0]`. #1231 added `modules/python/crud/azure/__init__.py`, turning `crud/azure/` into a **regular package**. Found first on `sys.path`, it shadows the installed `azure` SDK namespace package, so `azure.core` can no longer be resolved.

Unit tests didn't catch this because pytest runs with a different `sys.path` that never places `crud/` at `sys.path[0]`.

## Fix

Invoke the module with `-m` instead of running the file. `python3 -m crud.main` puts `modules/python` (the working directory) on `sys.path[0]` instead of `crud/`, so the `azure` SDK resolves from site-packages while `crud.azure` still imports. This is also what the `telescope-crud` entry point registered in #1231 was intended for. The now-unused `PYTHON_SCRIPT_FILE` env var is removed.

Applied to all affected engine steps:
- `steps/engine/crud/k8s/execute.yml`
- `steps/engine/crud/k8s/collect.yml`
- `steps/engine/machine/k8s/execute.yml`
- `steps/engine/machine/k8s/collect.yml`

## Verification

Reproduced the shadowing and confirmed the fix locally:

```
# crud/ on sys.path[0] (file invocation)
import azure.core.exceptions  -> ModuleNotFoundError: No module named 'azure.core'

# modules/python on sys.path[0] (-m crud.main)
import azure.core.exceptions; import crud.azure  -> both import OK
```
