### PR TITLE
GPU CRUD: raise per-step timeout 600s -> 1800s

### DIFF
--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -50,7 +50,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 1800
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -82,7 +82,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 1800
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -117,7 +117,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 1800
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -149,7 +149,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 1800
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -183,7 +183,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 1800
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -217,7 +217,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 1800
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -248,7 +248,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 1800
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -280,7 +280,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 1800
               step_wait_time: 30
               count: 1
               replicas: 10


### PR DESCRIPTION
## Problem

The **GPU Cluster CRUD** pipeline (`pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml`, ADO defId 61) has been failing on the majority of its scheduled runs.

The dominant failure signature is node-pool scale/create steps hitting the per-step timeout while A100/H100 nodes are still coming up:

- ARM reports the scale operation **succeeded** (~1750s), but the Kubernetes readiness wait — driven by `step_time_out` (600s / 10 min via `operation_timeout_minutes`) — gives up first with `Only 0 nodes are ready, expected 1 nodes!`.
- On timeout the harness advances to the next CRUD step and collides with the **still-running ARM op**, producing `(OperationNotAllowed) ... in-progress scale node pool operation`, which cascades to a hard failure.

In other words, GPU nodes (ND96asr_v4 / NC40ads_H100_v5 / NV36ads_A10_v5) routinely take longer than 10 minutes to reach `Ready`, so the 600s per-step budget is simply too short.

## Fix

Raise `step_time_out` from **600s to 1800s** (30 min) for all GPU stages.

This matches the existing ARM long-running-operation poll ceiling (`TIMEOUT_SECONDS = 1800` in `utils/provisioning_instrumentation.py`), so the readiness wait no longer times out before the node joins — and no code change is required.

## Scope

- Config-only: 8 `step_time_out: 600 -> 1800` edits, one per GPU stage.
- No Python changes.