### PR TITLE
GPU CRUD: raise per-step timeout to 45m and align ARM poll ceiling

### DIFF
--- a/modules/python/clients/aks_client.py
+++ b/modules/python/clients/aks_client.py
@@ -34,6 +34,7 @@ from utils.azure_node_pool_cli import (
 )
 from utils.provisioning_instrumentation import (
     instrument_nodepool_provisioning,
+    TIMEOUT_SECONDS as DEFAULT_ARM_LRO_TIMEOUT_SECONDS,
 )
 from .kubernetes_client import KubernetesClient
 
@@ -148,6 +149,12 @@ class AKSClient:
             raise ValueError(error_msg)
         self.result_dir = result_dir or get_env_vars("RESULT_DIR")
         self.operation_timeout_minutes = operation_timeout_minutes
+        # Cap the ARM long-running-operation poll at the per-step timeout so it
+        # tracks the K8s readiness wait (both derive from --step-timeout). Floor
+        # it at the historical default so non-GPU callers keep today's behavior.
+        self.arm_operation_timeout_seconds = max(
+            int(operation_timeout_minutes * 60), DEFAULT_ARM_LRO_TIMEOUT_SECONDS
+        )
 
         # Initialize Kubernetes client if provided or if kubeconfig is available
         try:
@@ -451,6 +458,7 @@ class AKSClient:
                     node_count,
                     vm_size,
                     self.aks_client,
+                    timeout_seconds=self.arm_operation_timeout_seconds,
                 )
 
                 logger.info(
@@ -643,6 +651,7 @@ class AKSClient:
                     node_pool_name,
                     node_count,
                     self.aks_client,
+                    timeout_seconds=self.arm_operation_timeout_seconds,
                 )
 
                 logger.info(f"Scaling node pool {node_pool_name} to {node_count} nodes")
@@ -885,6 +894,7 @@ class AKSClient:
                         step,
                         self.aks_client,
                         label=f"step {step} ",
+                        timeout_seconds=self.arm_operation_timeout_seconds,
                     )
 
                     # Run ARM and K8s readiness concurrently to capture both timings

--- a/modules/python/tests/clients/test_aks_client.py
+++ b/modules/python/tests/clients/test_aks_client.py
@@ -94,6 +94,24 @@ class TestAKSClient(unittest.TestCase):  # pylint: disable=too-many-instance-att
                 resource_group="fake-resource-group",
             )
 
+    def test_arm_timeout_floored_at_default(self):
+        """Short step timeouts keep the historical ARM poll floor (1800s)."""
+        # setUp uses the default operation_timeout_minutes (10 -> 600s), so the
+        # floor wins.
+        self.assertEqual(self.aks_client.arm_operation_timeout_seconds, 1800)
+
+    def test_arm_timeout_tracks_large_step_timeout(self):
+        """A large per-step timeout raises the ARM poll ceiling to match it."""
+        client = AKSClient(
+            subscription_id="fake-subscription-id",
+            resource_group="fake-resource-group",
+            cluster_name="fake-cluster",
+            credential=self.mock_credential,
+            result_dir=self.test_result_dir,
+            operation_timeout_minutes=45,  # e.g. GPU step_time_out=2700s
+        )
+        self.assertEqual(client.arm_operation_timeout_seconds, 2700)
+
     def test_get_cluster_name_provided(self):
         """Test get_cluster_name when name is already provided"""
         self.assertEqual(self.aks_client.get_cluster_name(), "fake-cluster")

--- a/modules/python/tests/utils/test_azure_node_pool_cli.py
+++ b/modules/python/tests/utils/test_azure_node_pool_cli.py
@@ -206,6 +206,40 @@ class TestAzureNodePoolCLI(unittest.TestCase):
 
         self.assertTrue(callable(operation))
 
+    @mock.patch("utils.azure_node_pool_cli.begin_create_or_update_with_retry")
+    def test_prepare_scale_operation_forwards_timeout_seconds(self, mock_begin):
+        operation = prepare_scale_operation(
+            mock.MagicMock(),
+            "VirtualMachineScaleSets",
+            "test-rg",
+            "test-cluster",
+            "test-pool",
+            3,
+            mock.MagicMock(),
+            timeout_seconds=2700,
+        )
+        operation()
+
+        self.assertEqual(mock_begin.call_args.kwargs["timeout_seconds"], 2700)
+
+    @mock.patch("utils.azure_node_pool_cli.begin_create_or_update_with_retry")
+    def test_prepare_create_operation_forwards_timeout_seconds(self, mock_begin):
+        operation = prepare_create_operation(
+            {},
+            "VirtualMachineScaleSets",
+            False,
+            "test-rg",
+            "test-cluster",
+            "test-pool",
+            2,
+            "Standard_D2s_v3",
+            mock.MagicMock(),
+            timeout_seconds=2700,
+        )
+        operation()
+
+        self.assertEqual(mock_begin.call_args.kwargs["timeout_seconds"], 2700)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/modules/python/tests/utils/test_provisioning_instrumentation.py
+++ b/modules/python/tests/utils/test_provisioning_instrumentation.py
@@ -244,6 +244,28 @@ class TestBeginCreateOrUpdateWithRetry(unittest.TestCase):
             )
 
     @mock.patch("utils.provisioning_instrumentation.time")
+    def test_timeout_honors_explicit_timeout_seconds(self, mock_time):
+        """An explicit timeout_seconds overrides the module default TIMEOUT_SECONDS."""
+        mock_time.sleep = mock.MagicMock()
+
+        mock_poller = mock.MagicMock()
+        mock_poller.done.return_value = False
+        mock_poller.result.return_value = None
+
+        sdk_client = mock.MagicMock()
+        sdk_client.agent_pools.begin_create_or_update.return_value = mock_poller
+
+        with self.assertRaises(TimeoutError):
+            begin_create_or_update_with_retry(
+                aks_sdk_client=sdk_client,
+                resource_group="rg",
+                cluster_name="cluster1",
+                node_pool_name="pool1",
+                parameters={},
+                timeout_seconds=0,
+            )
+
+    @mock.patch("utils.provisioning_instrumentation.time")
     def test_post_accept_failure_attaches_request_started_at(self, mock_time):
         """An accepted op that then fails carries the accept time on the exception."""
         mock_time.time.return_value = 500

--- a/modules/python/utils/azure_node_pool_cli.py
+++ b/modules/python/utils/azure_node_pool_cli.py
@@ -145,6 +145,7 @@ def prepare_create_operation(
     vm_size,
     aks_sdk_client,
     label="",
+    timeout_seconds=None,
 ):
     """Return a node-pool create callable for the requested pool type."""
     if node_pool_type != AzureNodePoolTypeConstants.VIRTUAL_MACHINES:
@@ -161,6 +162,7 @@ def prepare_create_operation(
             node_pool_name,
             sdk_parameters,
             label=label,
+            timeout_seconds=timeout_seconds,
         )
     if gpu_node_pool:
         raise ValueError("GPU node pools with type VirtualMachines are not supported")
@@ -183,6 +185,7 @@ def prepare_scale_operation(
     node_count,
     aks_sdk_client,
     label="",
+    timeout_seconds=None,
 ):
     """Return a node-pool scale callable for the requested pool type."""
     if node_pool_type != AzureNodePoolTypeConstants.VIRTUAL_MACHINES:
@@ -195,6 +198,7 @@ def prepare_scale_operation(
             node_pool_name,
             node_pool,
             label=label,
+            timeout_seconds=timeout_seconds,
         )
     return partial(
         scale_virtual_machines_node_pool,

--- a/modules/python/utils/provisioning_instrumentation.py
+++ b/modules/python/utils/provisioning_instrumentation.py
@@ -112,11 +112,18 @@ def begin_create_or_update_with_retry(
     node_pool_name,
     parameters,
     label="",
+    timeout_seconds=None,
 ):
     """
     Call begin_create_or_update, retrying IN_PROGRESS_CODES (a *previous* op still
     in progress) up to MAX_RETRIES; poll until done, TimeoutError after
-    TIMEOUT_SECONDS.
+    timeout_seconds (defaults to TIMEOUT_SECONDS when not supplied).
+
+    timeout_seconds lets the caller align the ARM long-running-operation poll
+    ceiling with the per-step timeout. Large GPU SKUs (A100/H100) routinely take
+    longer than the default to finish scaling; capping the poll below the real
+    scale duration abandons a still-running ARM op, which then blocks the next
+    step with OperationNotAllowed.
 
     Returns (request_started_at, retry_occurred): request_started_at is when the
     accepted (2xx) attempt's PUT was issued, so callers count the accepted
@@ -124,6 +131,8 @@ def begin_create_or_update_with_retry(
     On failure it attaches request_started_at to the exception (see below) so the
     caller can still exclude the queue-wait.
     """
+    if timeout_seconds is None:
+        timeout_seconds = TIMEOUT_SECONDS
     retry_occurred = False
     for attempt in range(MAX_RETRIES):
         request_started_at = time.time()
@@ -153,9 +162,9 @@ def begin_create_or_update_with_retry(
             while not poller.done():
                 time.sleep(POLL_INTERVAL_SECONDS)
                 elapsed += POLL_INTERVAL_SECONDS
-                if elapsed >= TIMEOUT_SECONDS:
+                if elapsed >= timeout_seconds:
                     raise TimeoutError(
-                        f"Node pool {node_pool_name} {label}timed out after {TIMEOUT_SECONDS}s"
+                        f"Node pool {node_pool_name} {label}timed out after {timeout_seconds}s"
                     )
                 logger.info(
                     f"Waiting for node pool {node_pool_name} {label}to complete "

--- a/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
+++ b/pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml
@@ -50,7 +50,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 2700
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -82,7 +82,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 2700
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -117,7 +117,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 2700
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -149,7 +149,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 2700
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -183,7 +183,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 2700
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -217,7 +217,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 2700
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -248,7 +248,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 2700
               step_wait_time: 30
               count: 1
               replicas: 10
@@ -280,7 +280,7 @@ stages:
               create_node_count: 0
               scale_node_count: 2
               scale_step_size: 1
-              step_time_out: 600
+              step_time_out: 2700
               step_wait_time: 30
               count: 1
               replicas: 10


### PR DESCRIPTION
## Problem

The **GPU Cluster CRUD** pipeline (`pipelines/perf-eval/GPU Benchmark/k8s-gpu-cluster-crud.yml`, ADO defId 61) fails on most scheduled runs. Node-pool scale/create steps hit the per-step timeout while A100/H100 nodes are still coming up:

- ARM reports the scale **succeeded**, but the K8s readiness wait — driven by `step_time_out` (was 600s / 10 min via `operation_timeout_minutes`) — gives up first with `Only N nodes are ready`.
- On timeout the harness advances to the next CRUD step and collides with the **still-running ARM op** → `(OperationNotAllowed) ... in-progress scale node pool operation`, cascading to a hard failure.

A first attempt at `step_time_out: 1800` (30 min) **still failed** (build 79914): the `1→2` A100 scale-up needed **more than 30 min**, and — critically — `step_time_out` alone cannot exceed 30 min because the ARM long-running-operation poll was hardcoded to `TIMEOUT_SECONDS = 1800`.

## Fix

- **`step_time_out` 600 → 2700 (45 min)** for all GPU stages. This drives the K8s readiness wait (`operation_timeout_minutes = step_time_out / 60`).
- **Make the ARM poll timeout configurable.** `begin_create_or_update_with_retry` gains a `timeout_seconds` arg (defaults to `TIMEOUT_SECONDS`), threaded through `prepare_create_operation` / `prepare_scale_operation`.
- **`AKSClient` derives** `arm_operation_timeout_seconds = max(step_timeout_seconds, 1800)` so the ARM ceiling tracks the per-step timeout for GPU while non-GPU callers keep the historical 1800s floor.

Together these let a GPU step run the full 45 min on both the readiness and ARM sides, so the op is no longer abandoned mid-flight and the `OperationNotAllowed` cascade disappears. Well within the per-stage `timeout_in_minutes: 180` budget.

## Testing

- Unit tests added for the configurable timeout (`begin_create_or_update_with_retry`, `prepare_*` forwarding, `AKSClient.arm_operation_timeout_seconds` floor/track).
- Full `modules/python` suite: **824 passed, 1 skipped**.